### PR TITLE
Improvements

### DIFF
--- a/src/org/keynote/godtools/android/MainPW.java
+++ b/src/org/keynote/godtools/android/MainPW.java
@@ -470,6 +470,7 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
         {
             languagePrimary = gtLanguage.getLanguageCode();
             packageList = getPackageList();
+            alterLayoutToAccommodateLongerLists(packageList);
             packageFrag.refreshList(languagePrimary, isTranslatorModeEnabled(), packageList);
 
             SharedPreferences.Editor editor = settings.edit();
@@ -590,8 +591,6 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
             hideLoading();
 
         }
-
-//        alterLayoutToAccommodateLongerLists(packageList);
 
         createTheHomeScreen();
     }

--- a/src/org/keynote/godtools/android/MainPW.java
+++ b/src/org/keynote/godtools/android/MainPW.java
@@ -17,6 +17,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
@@ -25,6 +26,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -51,6 +53,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static android.widget.RelativeLayout.*;
 
 
 public class MainPW extends BaseActionBarActivity implements LanguageDialogFragment.OnLanguageChangedListener,
@@ -112,6 +116,8 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
         languagePrimary = settings.getString(GTLanguage.KEY_PRIMARY, "en");
 
         packageList = getPackageList(); // get the packages for the primary language
+
+        alterLayoutToAccommodateLongerLists(packageList);
 
         FragmentManager fm = getSupportFragmentManager();
         packageFrag = (PackageListFragment) fm.findFragmentByTag(TAG_LIST);
@@ -265,7 +271,7 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
 
                 if(listHasNoLivePackage(packageList))
                 {
-                    handleLiseWithNoLivePackages();
+                    handleListWithNoLivePackages();
                     primaryCode = settings.getString(GTLanguage.KEY_PRIMARY, "en");
                     packageFrag.refreshList(primaryCode, isTranslatorModeEnabled(), packageList);
                 }
@@ -288,6 +294,25 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
         createTheHomeScreen();
     }
 
+    private void alterLayoutToAccommodateLongerLists(List<GTPackage> packageList)
+    {
+        if(packageList == null) return;
+
+        if(packageList.size() > 6)
+        {
+            LayoutInflater mInflater = LayoutInflater.from(this);
+            View contentView = mInflater.inflate(R.layout.main_pw, null);
+            ImageView imageView = (ImageView) contentView.findViewById(R.id.logo);
+
+            RelativeLayout.MarginLayoutParams marginParams = new RelativeLayout.MarginLayoutParams(imageView.getLayoutParams());
+            marginParams.setMargins(marginParams.leftMargin, 15, marginParams.rightMargin, 5);
+            RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(marginParams);
+            layoutParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+            imageView.setLayoutParams(layoutParams);
+            setContentView(contentView);
+        }
+    }
+
     private boolean listHasNoLivePackage(List<GTPackage> packageList)
     {
         if(packageList == null || packageList.isEmpty()) return true;
@@ -300,7 +325,7 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
         return true;
     }
 
-    private void handleLiseWithNoLivePackages()
+    private void handleListWithNoLivePackages()
     {
         SharedPreferences settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
@@ -516,7 +541,6 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
                 packageFrag.refreshList(langCode, isTranslatorModeEnabled(), packageList);
                 hideLoading();
             }
-
         }
         else if (tag.equalsIgnoreCase("parallel"))
         {
@@ -567,8 +591,9 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
 
         }
 
-        createTheHomeScreen();
+//        alterLayoutToAccommodateLongerLists(packageList);
 
+        createTheHomeScreen();
     }
 
     private List<GTPackage> getPackageList()

--- a/src/org/keynote/godtools/android/MainPW.java
+++ b/src/org/keynote/godtools/android/MainPW.java
@@ -263,6 +263,13 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
                 // refresh the list
                 String primaryCode = settings.getString(GTLanguage.KEY_PRIMARY, "en");
 
+                if(listHasNoLivePackage(packageList))
+                {
+                    handleLiseWithNoLivePackages();
+                    primaryCode = settings.getString(GTLanguage.KEY_PRIMARY, "en");
+                    packageFrag.refreshList(primaryCode, isTranslatorModeEnabled(), packageList);
+                }
+
                 if (!languagePrimary.equalsIgnoreCase(primaryCode))
                 {
                     SnuffyApplication app = (SnuffyApplication) getApplication();
@@ -281,6 +288,25 @@ public class MainPW extends BaseActionBarActivity implements LanguageDialogFragm
         createTheHomeScreen();
     }
 
+    private boolean listHasNoLivePackage(List<GTPackage> packageList)
+    {
+        if(packageList == null || packageList.isEmpty()) return true;
+
+        for(GTPackage gtPackage : packageList)
+        {
+            if("Live".equalsIgnoreCase(gtPackage.getStatus())) return false;
+        }
+
+        return true;
+    }
+
+    private void handleLiseWithNoLivePackages()
+    {
+        SharedPreferences settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putString(GTLanguage.KEY_PRIMARY, "en");
+        editor.commit();
+    }
 
     @Override
     public void onStart()

--- a/src/org/keynote/godtools/android/SettingsPW.java
+++ b/src/org/keynote/godtools/android/SettingsPW.java
@@ -209,10 +209,12 @@ public class SettingsPW extends BaseActionBarActivity implements
     }
 
 
-    private void showExitTranslatorModeDialog() {
+    private void showExitTranslatorModeDialog()
+    {
         FragmentManager fm = getSupportFragmentManager();
         DialogFragment frag = (DialogFragment) fm.findFragmentByTag("confirm_dialog");
-        if (frag == null) {
+        if (frag == null)
+        {
             frag = ExitTranslatorModeConfirmDialogFragment.newInstance(
                     getString(R.string.dialog_translator_mode_title),
                     getString(R.string.dialog_translator_mode_body),
@@ -225,17 +227,19 @@ public class SettingsPW extends BaseActionBarActivity implements
     }
 
     @Override
-    public void onConfirmClick(boolean positive, String tag) {
-
-        if (tag.equalsIgnoreCase("ExitTranslatorMode")) {
-
-            if (positive) {
+    public void onConfirmClick(boolean positive, String tag)
+    {
+        if (tag.equalsIgnoreCase("ExitTranslatorMode"))
+        {
+            if (positive)
+            {
                 // disable translator mode
                 setResult(RESULT_PREVIEW_MODE_DISABLED);
                 setTranslatorMode(false);
                 finish();
-
-            } else {
+            }
+            else
+            {
                 cbTranslatorMode.setChecked(true);
             }
 
@@ -287,7 +291,8 @@ public class SettingsPW extends BaseActionBarActivity implements
         cbTranslatorMode.setEnabled(true);
     }
 
-    private void setTranslatorMode(boolean isEnabled) {
+    private void setTranslatorMode(boolean isEnabled)
+    {
         SharedPreferences settings = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         SharedPreferences.Editor editor = settings.edit();
         editor.putBoolean("TranslatorMode", isEnabled);

--- a/src/org/keynote/godtools/android/SettingsPW.java
+++ b/src/org/keynote/godtools/android/SettingsPW.java
@@ -20,7 +20,7 @@ import com.google.android.gms.analytics.Tracker;
 
 import org.keynote.godtools.android.business.GTLanguage;
 import org.keynote.godtools.android.fragments.AccessCodeDialogFragment;
-import org.keynote.godtools.android.fragments.ConfirmDialogFragment;
+import org.keynote.godtools.android.fragments.ExitTranslatorModeConfirmDialogFragment;
 import org.keynote.godtools.android.http.AuthTask;
 import org.keynote.godtools.android.http.GodToolsApiClient;
 import org.keynote.godtools.android.snuffy.SnuffyAlternateTypefaceTextView;
@@ -33,7 +33,7 @@ import java.util.Locale;
 
 public class SettingsPW extends BaseActionBarActivity implements
         View.OnClickListener,
-        ConfirmDialogFragment.OnConfirmClickListener,
+        ExitTranslatorModeConfirmDialogFragment.OnConfirmClickListener,
         AccessCodeDialogFragment.AccessCodeDialogListener,
         AuthTask.AuthTaskHandler {
 
@@ -213,7 +213,7 @@ public class SettingsPW extends BaseActionBarActivity implements
         FragmentManager fm = getSupportFragmentManager();
         DialogFragment frag = (DialogFragment) fm.findFragmentByTag("confirm_dialog");
         if (frag == null) {
-            frag = ConfirmDialogFragment.newInstance(
+            frag = ExitTranslatorModeConfirmDialogFragment.newInstance(
                     getString(R.string.dialog_translator_mode_title),
                     getString(R.string.dialog_translator_mode_body),
                     getString(R.string.yes),

--- a/src/org/keynote/godtools/android/fragments/ExitTranslatorModeConfirmDialogFragment.java
+++ b/src/org/keynote/godtools/android/fragments/ExitTranslatorModeConfirmDialogFragment.java
@@ -7,7 +7,7 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 
-public class ConfirmDialogFragment extends DialogFragment {
+public class ExitTranslatorModeConfirmDialogFragment extends DialogFragment {
 
     private static final String ARGS_TAG = "tag";
     private static final String ARGS_TITLE = "title";
@@ -22,7 +22,7 @@ public class ConfirmDialogFragment extends DialogFragment {
     private OnConfirmClickListener mListener;
 
     public static DialogFragment newInstance(String title, String message, String positive, String negative, String tag) {
-        DialogFragment frag = new ConfirmDialogFragment();
+        DialogFragment frag = new ExitTranslatorModeConfirmDialogFragment();
         Bundle args = new Bundle();
         args.putString(ARGS_TAG, tag);
         args.putString(ARGS_TITLE, title);

--- a/src/org/keynote/godtools/android/fragments/ExitTranslatorModeConfirmDialogFragment.java
+++ b/src/org/keynote/godtools/android/fragments/ExitTranslatorModeConfirmDialogFragment.java
@@ -21,7 +21,11 @@ public class ExitTranslatorModeConfirmDialogFragment extends DialogFragment {
 
     private OnConfirmClickListener mListener;
 
-    public static DialogFragment newInstance(String title, String message, String positive, String negative, String tag) {
+    public static DialogFragment newInstance(String title,
+                                             String message,
+                                             String positive,
+                                             String negative, String tag)
+    {
         DialogFragment frag = new ExitTranslatorModeConfirmDialogFragment();
         Bundle args = new Bundle();
         args.putString(ARGS_TAG, tag);
@@ -36,7 +40,8 @@ public class ExitTranslatorModeConfirmDialogFragment extends DialogFragment {
     }
 
     @Override
-    public void onAttach(Activity activity) {
+    public void onAttach(Activity activity)
+    {
         super.onAttach(activity);
         mListener = (OnConfirmClickListener) activity;
     }


### PR DESCRIPTION
Minor but important improvements to the Android app I've noticed while in beta
 - while in a language with only drafts and no live packages, the home page would render an empty frame when switching out of translator mode.  the fix is to switch back to english in this case
 - while in english and translator mode, the home page layout scrunches the buttons at the bottom of the page. alter the layout to have a smaller margin at the top to accommodate 7 packages.