### PR TITLE
show dialogs again

### DIFF
--- a/src/org/keynote/godtools/android/MainPW.java
+++ b/src/org/keynote/godtools/android/MainPW.java
@@ -1,10 +1,13 @@
 package org.keynote.godtools.android;
 
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.ActionBar;
 import android.util.Log;
 import android.view.Menu;
@@ -18,6 +21,8 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.keynote.godtools.android.broadcast.BroadcastUtil;
+import org.keynote.godtools.android.broadcast.Type;
 import org.keynote.godtools.android.business.GTLanguage;
 import org.keynote.godtools.android.business.GTPackage;
 import org.keynote.godtools.android.dao.DBAdapter;
@@ -66,6 +71,9 @@ public class MainPW extends BaseActionBarActivity implements PackageListFragment
 
     private List<HomescreenLayout> layouts;
 
+    private LocalBroadcastManager broadcastManager;
+    private BroadcastReceiver broadcastReceiver;
+
     SharedPreferences settings;
 
     /**
@@ -93,6 +101,8 @@ public class MainPW extends BaseActionBarActivity implements PackageListFragment
         actionBar.setCustomView(R.layout.titlebar_centered_title);
         TextView titleBar = (TextView) actionBar.getCustomView().findViewById(R.id.titlebar_title);
         titleBar.setText(R.string.app_title);
+
+        setupBroadcastReceiver();
 
         setupLayout();
 
@@ -202,6 +212,56 @@ public class MainPW extends BaseActionBarActivity implements PackageListFragment
         }
     }
 
+    @Override
+    protected void onDestroy()
+    {
+        super.onDestroy();
+        removeBroadcastReceiver();
+    }
+
+    private void setupBroadcastReceiver()
+    {
+        broadcastManager = LocalBroadcastManager.getInstance(getApplicationContext());
+
+        broadcastReceiver = new BroadcastReceiver()
+        {
+            @Override
+            public void onReceive(Context context, Intent intent)
+            {
+                 if (BroadcastUtil.ACTION_STOP.equals(intent.getAction()))
+                {
+                    Type type = (Type) intent.getSerializableExtra(BroadcastUtil.ACTION_TYPE);
+
+                    if (Type.ENABLE_TRANSLATOR.equals(type))
+                    {
+                        // refresh the list
+                        String primaryCode = settings.getString(GTLanguage.KEY_PRIMARY, "en");
+
+                        refreshPackageList(true);
+
+                        if (!languagePrimary.equalsIgnoreCase(primaryCode))
+                        {
+                            SnuffyApplication app = (SnuffyApplication) getApplication();
+                            app.setAppLocale(primaryCode);
+                        }
+
+                        Toast.makeText(MainPW.this, "Translator preview mode is enabled", Toast.LENGTH_LONG).show();
+
+                        finish();
+                    }
+                }
+            }
+        };
+
+        broadcastManager.registerReceiver(broadcastReceiver, BroadcastUtil.stopFilter());
+    }
+
+    private void removeBroadcastReceiver()
+    {
+        broadcastManager.unregisterReceiver(broadcastReceiver);
+        broadcastReceiver = null;
+    }
+
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu)
@@ -247,26 +307,6 @@ public class MainPW extends BaseActionBarActivity implements PackageListFragment
 
                 refreshPackageList(false);
                 createTheHomeScreen();
-
-                break;
-            }
-            case RESULT_PREVIEW_MODE_DISABLED:
-            {
-                // refresh the list
-                String primaryCode = settings.getString(GTLanguage.KEY_PRIMARY, "en");
-
-                refreshPackageList(true);
-
-                if (!languagePrimary.equalsIgnoreCase(primaryCode))
-                {
-                    SnuffyApplication app = (SnuffyApplication) getApplication();
-                    app.setAppLocale(primaryCode);
-                }
-
-                Toast.makeText(MainPW.this, "Translator preview mode is disabled", Toast.LENGTH_LONG).show();
-
-                finish();
-                startActivity(getIntent());
 
                 break;
             }

--- a/src/org/keynote/godtools/android/broadcast/BroadcastUtil.java
+++ b/src/org/keynote/godtools/android/broadcast/BroadcastUtil.java
@@ -10,9 +10,8 @@ import static org.keynote.godtools.android.utils.Constants.STATUS_CODE;
  */
 public final class BroadcastUtil
 {
-    private final String TAG = getClass().getSimpleName();
-
     public static final String ACTION_START = BroadcastUtil.class.getName() + ".ACTION_START";
+    public static final String ACTION_DRAFT_START = BroadcastUtil.class.getName() + ".DRAFT_START";
     public static final String ACTION_STOP = BroadcastUtil.class.getName() + ".ACTION_STOP";
     public static final String ACTION_TYPE = BroadcastUtil.class.getName() + ".ACTION_TYPE";
     public static final String ACTION_FAIL = BroadcastUtil.class.getName() + ".ACTION_FAIL";
@@ -20,6 +19,11 @@ public final class BroadcastUtil
     public static Intent startBroadcast()
     {
         return new Intent(ACTION_START);
+    }
+
+    public static Intent draftBroadcast()
+    {
+        return new Intent(ACTION_DRAFT_START);
     }
     
     public static Intent stopBroadcast(Type type)
@@ -45,6 +49,11 @@ public final class BroadcastUtil
     public static IntentFilter startFilter()
     {
         return new IntentFilter(ACTION_START);
+    }
+
+    public static IntentFilter startDraftFilter()
+    {
+        return new IntentFilter(ACTION_DRAFT_START);
     }
 
     public static IntentFilter stopFilter()

--- a/src/org/keynote/godtools/android/expandableList/ExpandableListAdapter.java
+++ b/src/org/keynote/godtools/android/expandableList/ExpandableListAdapter.java
@@ -29,7 +29,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.keynote.godtools.android.broadcast.BroadcastUtil.startBroadcast;
+import static org.keynote.godtools.android.broadcast.BroadcastUtil.draftBroadcast;
+import static org.keynote.godtools.android.broadcast.BroadcastUtil.failBroadcast;
 import static org.keynote.godtools.android.broadcast.BroadcastUtil.stopBroadcast;
 import static org.keynote.godtools.android.utils.Constants.AUTH_DRAFT;
 import static org.keynote.godtools.android.utils.Constants.FOUR_LAWS;
@@ -51,6 +52,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
     private List<GTPackage> packages;
     private GTPackage currentPackage;
     private String languagePrimary;
+    private LocalBroadcastManager broadcastManager;
 
     int lastExpandedPosition = -1;
     
@@ -64,6 +66,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
 
         listDataHeader = new ArrayList<String>();
         listDataChild = new HashMap<String, List<String>>();
+        broadcastManager = LocalBroadcastManager.getInstance(context);
 
         // child list needs one item to show expandable menu
         List<String> childList = new ArrayList<String>(1);
@@ -249,7 +252,9 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                         switch (which)
                         {
                             case DialogInterface.BUTTON_POSITIVE:
-
+                                
+                                broadcastManager.sendBroadcast(draftBroadcast());
+                                
                                 GodToolsApiClient.publishDraft(settings.getString(AUTH_DRAFT, ""),
                                         currentPackage.getLanguage(),
                                         currentPackage.getCode(),
@@ -258,6 +263,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                                             @Override
                                             public void draftTaskComplete()
                                             {
+                                                broadcastManager.sendBroadcast(stopBroadcast(Type.DRAFT_PUBLISH_TASK));
                                                 Toast.makeText(context, "Draft has been published", Toast.LENGTH_SHORT).show();
                                                 ((PreviewModeMainPW)context).refreshDrafts();
                                             }
@@ -265,6 +271,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                                             @Override
                                             public void draftTaskFailure(int statusCode)
                                             {
+                                                broadcastManager.sendBroadcast(failBroadcast(Type.DRAFT_PUBLISH_TASK));
                                                 Toast.makeText(context, "Failed to publish draft", Toast.LENGTH_SHORT).show();
                                             }
                                         });
@@ -293,6 +300,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                         {
                             case DialogInterface.BUTTON_POSITIVE:
                                 
+                                broadcastManager.sendBroadcast(draftBroadcast());
                                 Log.i(TAG, "Creating Draft");
                                 
                                 GodToolsApiClient.createDraft(settings.getString(AUTH_DRAFT, ""),
@@ -303,6 +311,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                                             @Override
                                             public void draftTaskComplete()
                                             {
+                                                broadcastManager.sendBroadcast(stopBroadcast(Type.DRAFT_CREATION_TASK));
                                                 Toast.makeText(context.getApplicationContext(), "Draft has been created", Toast.LENGTH_SHORT).show();
                                                 ((PreviewModeMainPW)context).refreshDrafts();
                                             }
@@ -310,6 +319,7 @@ public class ExpandableListAdapter extends BaseExpandableListAdapter implements 
                                             @Override
                                             public void draftTaskFailure(int code)
                                             {
+                                                broadcastManager.sendBroadcast(failBroadcast(Type.DRAFT_CREATION_TASK));
                                                 Toast.makeText(context.getApplicationContext(), "Failed to create a new draft", Toast.LENGTH_SHORT).show();
                                             }
                                         });


### PR DESCRIPTION
- Broadcast manager has to be re-added in the two UI classes for a couple of reasons.
- First it is used to notify preview mode to show the loading dialog when an API call is made from the expanded list
- Also, it needs to be used to finish a current activity when switching to or from preview mode. The old way, which is a response from activity code doesn't work because when switching, the previous activity is not returned to
