### PR TITLE
app crashes when leaving preview mode

### DIFF
--- a/src/org/keynote/godtools/android/PreviewModeMainPW.java
+++ b/src/org/keynote/godtools/android/PreviewModeMainPW.java
@@ -194,7 +194,7 @@ public class PreviewModeMainPW extends BaseActionBarActivity implements
 
                     if (Type.DISABLE_TRANSLATOR.equals(type))
                     {
-                        pdLoading.hide();
+                        if (pdLoading != null) pdLoading.hide();
 
                         Toast.makeText(PreviewModeMainPW.this, getString(R.string.translator_disabled),
                                 Toast.LENGTH_LONG).show();
@@ -209,7 +209,7 @@ public class PreviewModeMainPW extends BaseActionBarActivity implements
 
                 if (BroadcastUtil.ACTION_FAIL.equals(intent.getAction()))
                 {
-                    pdLoading.hide();
+                    if (pdLoading != null) pdLoading.hide();
                 }
             }
         };
@@ -343,7 +343,7 @@ public class PreviewModeMainPW extends BaseActionBarActivity implements
         
         // only return draft packages with translator mode
         List<GTPackage> packageByLanguage = GTPackage.getDraftPackages(PreviewModeMainPW.this, languagePrimary);
-        if("en".equals(languagePrimary))
+        if ("en".equals(languagePrimary))
         {
             removeEveryStudent(packageByLanguage);
         }


### PR DESCRIPTION
 pdLoading is sometimes null. App will crash when leaving Preview mode if pdLoading is null. @ryancarlson 
