### PR TITLE
Don't try to hide dialog if it wasn't showing in the first place.

### DIFF
--- a/src/org/keynote/godtools/android/SnuffyPWActivity.java
+++ b/src/org/keynote/godtools/android/SnuffyPWActivity.java
@@ -800,7 +800,11 @@ public class SnuffyPWActivity extends Activity
         @Override
         protected void onPostExecute(Integer result)
         {
-            dismissDialog(DIALOG_PROCESS_PACKAGE_PROGRESS);
+            if(mProgressDialog != null &&
+                    mProgressDialog.isShowing())
+            {
+                dismissDialog(DIALOG_PROCESS_PACKAGE_PROGRESS);
+            }
             completeSetup(result != 0);
         }
     }


### PR DESCRIPTION
Fixes this bug which causes an app crash:

https://fabric.io/cru/android/apps/org.keynote.godtools.android/issues/560cb053f5d3a7f76b75cf02
