### PR TITLE
Add Kazakh and Polish strings files

### DIFF
--- a/res/values-kk/strings.xml
+++ b/res/values-kk/strings.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Қызмет құралдары</string>
+    <string name="menu_item_kgp">Құдайды жеке танып білу</string>
+    <string name="menu_item_satisfied">Қанағаттанасыз ба?</string>
+    <string name="menu_item_4laws">Төрт Рухани Ақиқат</string>
+    <string name="menu_item_share">Бөлісу</string>
+    <string name="menu_item_contents">Мазмұны</string>
+    <string name="menu_item_help">Көмек</string>
+    <string name="menu_switch_language">Тілді ауыстыру</string>
+    <string name="menu_update_page">Парақшаны жаңарту (жоба)</string>
+    <string name="menu_flip">Шерту</string>
+    <string name="app_name_everystudent">Құдай туралы сұрақтар?</string>
+    <string name="quit_dialog_message">Қызмет құралдарынан шыққыңыз келе ме?</string>
+    <string name="quit_dialog_confirm">Шығу</string>
+    <string name="quit_dialog_cancel">Жою</string>
+    <string name="search_label">EveryStudent.com</string>
+    <string name="search_hint">Іздеу EveryStudent.com</string>
+    <string name="search_no_results">{{search_term}} үшін нәтиже табылмады</string>
+    <string name="settings_description">Құдай және өмір жайында сұрақтарды зерттеңіз</string>
+    <string name="menu_search">Іздеу</string>
+    <string name="menu_about">туралы</string>
+    <string name="snuffy_help">Келесі бетке өту үшін, сол жаққа жүргізіңіз. Бастапқы бетке өту үшін оң жаққа жүргізіңіз. Мәзірді көрсету үшін парақшаның кез келген жерін іске қосуға болады. Тек батырмаға баспаңыз.</string>
+    <string name="snuffy_help_title" formatted="false">{{package_name}} Көмек</string>
+    <string name="choose_your_email_provider">Электрондық поштаңыздың қызмет жеткізушісін таңдаңыз</string>
+    <string name="unable_to_send_the_email">Хатты жіберу іске аспады</string>
+    <string name="email">Электрондық пошта</string>
+    <string name="copy">Көшірме</string>
+    <string name="all_websites">Барлық сайттар</string>
+    <!-- Renderer Activity -->
+    <string name="processing_package">Парақшаны жүктеу...</string>
+    <string name="processing_failed">Пакетті өңдеу іске аспады</string>
+    <string name="select_share">Қалай бөліскіңіз келетінін таңдаңыз</string>
+    <string name="update_page">Парақшаны жаңарту</string>
+    <string name="page_error">Парақшаны өңдеу кезінде туындаған қателік</string>
+    <!-- Splash Activity -->
+    <string name="check_update">Жаңартуларды тексеру</string>
+    <!-- Settings Activity -->
+    <string name="settings_title">Баптаулар</string>
+    <string name="settings_main_language">Негізгі тіл:</string>
+    <string name="settings_parallel_language">Қатарлас тіл:</string>
+    <string name="settings_parallel_info">Көрсетілім кезінде басқа тілге ауысу үшін, экранда \"басқа тілге ауысу\" батырмасын басыңыз.</string>
+    <string name="settings_select">Таңдау</string>
+    <string name="settings_translator_mode">Алдын ала қарап шығу тәртібі (аударма)</string>
+    <string name="settings_notification">Хабарламаға рұқсат</string>
+    <string name="wrong_passcode">Өтініш тағы бір рет байқап көріңіз</string>
+    <string name="expired_passcode">Алдын ала қарап шығу сеансының мезгілі өтті</string>
+    <string name="authenticate_code">Кодқа кіруді сәйкестендіру</string>
+    <!-- Main Activity-->
+    <string name="share_prompt">Қалай бөліскіңіз келетінін таңдаңыз</string>
+    <!-- Language List -->
+    <string name="download">Жүктеу</string>
+    <string name="downloading">Жүктеу</string>
+    <string name="delete">Өшіру</string>
+    <string name="retry">Қайталаңыз</string>
+    <!-- Translator Mode Dialog -->
+    <string name="dialog_translator_mode_title">Алдын ала қарап шығу режимінен шығу</string>
+    <string name="dialog_translator_mode_body">Жобалар экранға шығарылмайды</string>
+    <string name="translator_enabled">Аударманы алдын ала қарап шығу режимі қосулы</string>
+    <string name="translator_disabled">Аударманы алдын ала қарап шығу режимі өшірулі</string>
+    <string name="draft_published">Жоба жарияланды</string>
+    <string name="draft_publish_fail">Жобаны жариялау мүмкін емес</string>
+    <string name="draft_publish_message">Сіз осы жобаны жариялағыңыз келеді ме?</string>
+    <string name="draft_publish_confirm">Иә, дайын!</string>
+    <string name="draft_publish_negative">Жоқ, мен шешімімді өзгерттім.</string>
+    <string name="draft_created">Жоба құрылды</string>
+    <string name="draft_create_failed">Жаңа жоба құру мүмкін болмады</string>
+    <string name="draft_start_message">Жаңа жоба құру?</string>
+    <!-- Access Code Dialog -->
+    <string name="dialog_access_code_title">Кодқа кіруді енгізу</string>
+    <string name="invalid_code">Дұрыс емес код</string>
+    <!-- Preview Mode -->
+    <string name="pull_down_info">жобаны жаңарту үшін тартыңыз</string>
+    <string name="preview_mode_title">Қарап шығу режимі</string>
+    <string name="package_not_created">Пакет әлі құрылмаған</string>
+    <string name="connecting">Серверге қосылу</string>
+    <!-- Package Reader -->
+    <string name="open">Ашу</string>
+    <string name="cannot_launch_browser">Браузерді іске қоса алмады</string>
+    <string name="multi_website_assist">- сізге көмек бере алатын сайттар</string>
+    <string name="single_website_assist">- сізге көмектесетін сайт</string>
+    <string name="cannot_dial">Теру дискін іске қоса алмады</string>
+    <string name="cannot_email">электрондық пошта құралын қосу мүмкін емес</string>
+    <!-- Every Student-->
+    <string name="could_not_load_content">Мазмұнды жүктеу іске аспады</string>
+    <!-- Shared Strings -->
+    <string name="ok">Жақсы</string>
+    <string name="cancel">күшін жою</string>
+    <string name="yes">Иә</string>
+    <string name="no">Жоқ</string>
+    <string name="none">ешбірі</string>
+    <string name="send">жіберу</string>
+    <string name="drafts_updated">Жобалар жаңартылды</string>
+    <string name="failed_update_draft">Жобаларды жаңарту іске аспады</string>
+    <string name="failed_download_draft">"Жобаларды жүктеу іске аспады "</string>
+    <string name="failed_download_resources">Қоларды жүктеу іске аспады</string>
+    <string name="success">Сәтті!</string>
+    <string name="internet_needed">Интернет байланысы осы сұранысты аяқтау үшін қажет</string>
+    <string name="alternate_language">Қатарлас Тілдер</string>
+    <string name="alternate_language_message">Таңдалған қатарлас тіл осы құралы үшін қол жетімді емес.</string>
+    <!-- Sharing -->
+    <string name="app_email_subject">"Бүгінгі сұхбатымыз  {{package_name}} туралы "</string>
+    <string name="share_general_subject">{{app_name}}</string>
+    <string name="share_general_message">Мұнда бүгін қарайтын бағдарламаны жүктеу үшін сілтеме: http://godtoolsapp.com
+Мұнда бағдарламаның {{share_link}} веб нұсқасына сілтеме
+Көбірек әңгімелесейік!</string>
+    <string name="app_share_link_base_link" formatted="false">http://www.knowgod.com</string>
+    <string name="share_from_page_subject">{{app_name}}</string>
+    <string name="share_from_page_message" formatted="false">Бүгінгі таңда біз көретін буклет осы. Бұл сілтеме сіздермен соңғы рет көрген беттің веб-нұсқасы:
+{{share_link}}
+Қане, көбірек сөйлесейік!</string>
+    <string name="satisfied_share" formatted="false">Өмірімізде Киелі Рухтың күшін көріп жатқанымызды айтудың өзі керемет. Жақын арада осы жайында көбірек айтатын боламыз деп үміттенемін. Сондай-ақ, бүгін таңда біз {{share_link}} қарағанымызды тексере аласыз.</string>
+    <string name="everystudent_share">Бүгінгі таңда сіздердің рухани сұрақтарыңыз жайлы сөйлескеніміз өте жақсы. Жақын арада осы жайында көбірек сөйлесеміз деп үміттенемін. Сондай-ақ {{share_link}} - те қарағандарымызды тексере аласыз</string>
+    <!-- iOS -->
+    <string name="translator_mode">[Аудармашы режимі]</string>
+    <string name="intro_share_instructions">Бөлісу</string>
+    <string name="intro_tool_instructions">Құралды таңдаңыз</string>
+    <string name="intro_language_instructions">Тілді таңдаңыз</string>
+    <string name="settings_language_none_selected">Бірде біреуі таңдалған жоқ</string>
+    <string name="settings_parallel_info_tap">Көрсетілім кезінде мәзірді қарау үшін экранды басыңыз.</string>
+    <string name="settings_parallel_info_switch_button">Екі тілді ауыстырып қосады</string>
+    <string name="settings_parallel_info_toggle_explaination">Егер кітапша қатарлас тілде берілмеген болса, ауыстыру батырмасы мәзірде көрсетілмейді</string>
+    <string name="menu_item_languages">Тіл</string>
+    <string name="access_code_placeholder">Құпиясөз</string>
+    <string name="status_updating_resources">Қорларды жаңарту</string>
+    <string name="status_updating_drafts">Жобаларды жаңарту</string>
+    <string name="status_creating_drafts">Жобаны құру</string>
+    <string name="status_publishing_drafts">Жобаның басылымы</string>
+    <string name="status_updating_menu">Мәзірді жаңарту</string>
+    <string name="status_checking_for_updates">Жаңартуларды тексеру</string>
+    <string name="status_initial_setup">Бастапқы орнату</string>
+    <string name="status_downloading_resources">Қорларды жүктеу</string>
+    <string name="language_alert_title">Тілдік баптаулар</string>
+    <string name="language_alert_body">Тілді үнсіз келісім бойынша қосқыңыз келеді ме? {{language_name}}</string>
+    <string name="draft_refresh_message">Жаңарған проект</string>
+    <string name="draft_refresh_error">Істен шыққанды жаңарту</string>
+    <string name="everystudent_title">Тақырыптар</string>
+    <string name="error_title">Қате</string>
+    <string name="menu_download_bad_xml">"Серверде мәзір жайлы ақпарат жоқ "</string>
+    <string name="packages_download_error">Пакеттерді жүктеу кезінде қателік жіберілді.</string>
+    <string name="page_download_error">Парақшаны жүктеу кезінде қателік жіберілді</string>
+    <string name="server_error">Серверде әдетте кездесетін мәселелер болды</string>
+    <string name="initial_setup_error_message">Өкінішке орай қорларды жүктей алмадық. Өтініш құралды жауып, қайта ашыңыз. Егер мәселе шешілмей жатса, мына мекен-жайға байланысқа шығыңыз support@godtoolsapp.com</string>
+</resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">God Tools</string>
+    <string name="menu_item_kgp">Przyjaźń z Bogiem</string>
+    <string name="menu_item_satisfied">Zadowolony?</string>
+    <string name="menu_item_4laws">Cztery prawa duchowego życia</string>
+    <string name="menu_item_share">Podziel się</string>
+    <string name="menu_item_contents">Treść</string>
+    <string name="menu_item_help">Pomoc</string>
+    <string name="menu_switch_language">Zamień język</string>
+    <string name="menu_update_page">Aktualizuj stronę (wersja robocza)</string>
+    <string name="menu_flip">Obróć</string>
+    <string name="app_name_everystudent">Pytania na temat Boga?</string>
+    <string name="quit_dialog_message">Na pewno chcesz zamknąć God Tools?</string>
+    <string name="quit_dialog_confirm">Wyjście</string>
+    <string name="quit_dialog_cancel">Anuluj</string>
+    <string name="search_label">kazdystudent.pl</string>
+    <string name="search_hint">Przeszukaj stronę kazdystudent.pl</string>
+    <string name="search_no_results">Nie znaleziono \"{{search_term}}\"</string>
+    <string name="settings_description">Pytania na temat życia i Boga</string>
+    <string name="menu_search">Szukaj</string>
+    <string name="menu_about">O aplikacji</string>
+    <string name="snuffy_help">Aby przejść do następnej strony przesuń palcem w lewą stronę. Aby wrócić do poprzedniej strony przesuń palcem w prawo. Aby zobaczyć menu dotknij dowolnego miejsca na ekranie (innego niż aktywny link/przycisk)</string>
+    <string name="snuffy_help_title" formatted="false">Pomoc na temat: {{package_name}}</string>
+    <string name="choose_your_email_provider">Wybierz dostawcę poczty elektronicznej</string>
+    <string name="unable_to_send_the_email">Nie można wysłać emaila</string>
+    <string name="email">Email</string>
+    <string name="copy">Kopiuj</string>
+    <string name="all_websites">Wszystkie strony WWW</string>
+    <!-- Renderer Activity -->
+    <string name="processing_package">Trwa ładowanie...</string>
+    <string name="processing_failed">Błąd pakietu</string>
+    <string name="select_share">Wybierz sposób podzielenia się</string>
+    <string name="update_page">Trwa aktualizowanie...</string>
+    <string name="page_error">Błąd odświeżenia strony</string>
+    <!-- Splash Activity -->
+    <string name="check_update">Trwa sprawdzanie aktualizacji...</string>
+    <!-- Settings Activity -->
+    <string name="settings_title">Ustawienia</string>
+    <string name="settings_main_language">Język główny</string>
+    <string name="settings_parallel_language">Język równoległy:</string>
+    <string name="settings_parallel_info">"Dotknij ekranu i wybierz komendę \"Zamień język\" aby zobaczyć treść prezentacji w innym języku. Ta opcja nie działa jeśli tłumaczenie danej prezentacji nie jest dostępne.  "</string>
+    <string name="settings_select">Wybierz</string>
+    <string name="settings_translator_mode">Tryb podglądu (dla tłumaczy)</string>
+    <string name="settings_notification">Pozwól na zawiadomienia</string>
+    <string name="wrong_passcode">Proszę spróbować ponownie</string>
+    <string name="expired_passcode">Sesja trybu podglądu wersji roboczej wygasła</string>
+    <string name="authenticate_code">Sprawdzanie kodu dostępu</string>
+    <!-- Main Activity-->
+    <string name="share_prompt">Wybierz sposób podzielenia się</string>
+    <!-- Language List -->
+    <string name="download">Pobierz</string>
+    <string name="downloading">Pobieranie</string>
+    <string name="delete">Usuń</string>
+    <string name="retry">Powtórz</string>
+    <!-- Translator Mode Dialog -->
+    <string name="dialog_translator_mode_title">Zakończyć tryb podglądu wersji roboczej?</string>
+    <string name="dialog_translator_mode_body">Wersja robocza nie może być wyświetlona</string>
+    <string name="translator_enabled">Tryb podglądu dla tłumacza jest włączony</string>
+    <string name="translator_disabled">Tryb podglądu dla tłumacza jest wyłączony</string>
+    <string name="draft_published">Wersja robocza uzyskała status oficjalnej publikacji</string>
+    <string name="draft_publish_fail">Błąd publikacji wersji roboczej</string>
+    <string name="draft_publish_message">Czy opublikować wersję roboczą jako oficjalne tłumaczenie?</string>
+    <string name="draft_publish_confirm">Tak, wszystko gotowe!</string>
+    <string name="draft_publish_negative">Jednak na razie nie.</string>
+    <string name="draft_created">Wersja robocza została utworzona</string>
+    <string name="draft_create_failed">Błąd utworzenia nowej wersji roboczej</string>
+    <string name="draft_start_message">Stworzyć nową wersję roboczą tłumaczenia?</string>
+    <!-- Access Code Dialog -->
+    <string name="dialog_access_code_title">Wprowadź kod dostępu:</string>
+    <string name="invalid_code">Niewłaściwy kod dostępu</string>
+    <!-- Preview Mode -->
+    <string name="pull_down_info">Przesuń, aby zaktualizować wersje robocze tłumaczenia</string>
+    <string name="preview_mode_title">Tryb podglądu</string>
+    <string name="package_not_created">Pakiet nie jest jeszcze utworzony</string>
+    <string name="connecting">Trwa łączenie sie z serwerem</string>
+    <!-- Package Reader -->
+    <string name="open">Otwórz</string>
+    <string name="cannot_launch_browser">Błąd uruchomienia przeglądarki</string>
+    <string name="multi_website_assist">- pomocne strony WWW</string>
+    <string name="single_website_assist">- pomocna strona WWW</string>
+    <string name="cannot_dial">Błąd uruchomienia diallera</string>
+    <string name="cannot_email">Błąd uruchomienia aplikacji poczty elektronicznej</string>
+    <!-- Every Student-->
+    <string name="could_not_load_content">Nie można załadować zawartości</string>
+    <!-- Shared Strings -->
+    <string name="ok">OK</string>
+    <string name="cancel">Anuluj</string>
+    <string name="yes">Tak</string>
+    <string name="no">Nie</string>
+    <string name="none">Żaden</string>
+    <string name="send">Wyślij</string>
+    <string name="drafts_updated">Wersje robocze tłumaczeń zostały zaktualizowane</string>
+    <string name="failed_update_draft">Błąd aktualizacji wersji roboczych tłumaczeń</string>
+    <string name="failed_download_draft">Błąd pobrania wersji roboczych tłumaczeń</string>
+    <string name="failed_download_resources">Błąd pobrania źródła</string>
+    <string name="success">Sukces!</string>
+    <string name="internet_needed">Do wykonania polecenia niezbędne jest połączenie z internetem</string>
+    <string name="alternate_language">Język równoległy</string>
+    <string name="alternate_language_message">Tłumaczenie w wybrany języku nie jest jeszcze dostępne.</string>
+    <!-- Sharing -->
+    <string name="app_email_subject">Nasza dzisiejsza rozmowa o prezentacji \"{{package_name}}\"</string>
+    <string name="share_general_subject">{{app_name}}</string>
+    <string name="share_general_message">Tutaj jest link do ściągnięcia aplikacja o której dzisiaj rozmawialiśmy:
+http://godtoolsapp.com
+A tutaj możesz zobaczyć te treści na stronie internetowej {{share_link}}
+Bądźmy w kontakcie!</string>
+    <string name="app_share_link_base_link" formatted="false">http://www.knowgod.com</string>
+    <string name="share_from_page_subject">{{app_name}}</string>
+    <string name="share_from_page_message" formatted="false">Przesyłam link do prezentacji, o której rozmawialiśmy dzisiaj. Ten link kieruje do ostatniej strony prezentacji, którą razem omawialiśmy: {{share_link}}
+Bądźmy w kontakcie!</string>
+    <string name="satisfied_share" formatted="false">Bardzo się cieszę, że mogliśmy porozmawiać dzisiaj jak możemy doświadczać mocy Ducha Świętego w naszym życiu. Mam nadzięję, że będziemy mogli o tym jeszcze wkrótce porozmawiać. A póki co przesyłam link do prezentacji, którą omawialiśmy:  {{share_link}}</string>
+    <string name="everystudent_share">Bardzo się cieszę, że mogliśmy porozmawiać dzisiaj o ważnych duchowych kwestiach. Mam nadzięję, że będziemy mogli o tym jeszcze wkrótce porozmawiać. A póki co przesyłam link do prezentacji, którą omawialiśmy:  {{share_link}}</string>
+    <!-- iOS -->
+    <string name="translator_mode">[ Tryb dla tłumaczy ]</string>
+    <string name="intro_share_instructions">Podziel się</string>
+    <string name="intro_tool_instructions">Wybierz prezentację</string>
+    <string name="intro_language_instructions">Wybierz język</string>
+    <string name="settings_language_none_selected">Żaden nie jest wybrany</string>
+    <string name="settings_parallel_info_tap">Dotknij ekranu, aby zobaczyć menu.</string>
+    <string name="settings_parallel_info_switch_button">Możliwość zamiany  dotyczy 2 języków</string>
+    <string name="settings_parallel_info_toggle_explaination">Przycisk zamiany języka nie ukaże się, jeśli prezentacja nie jest dostępna w równoległym języku</string>
+    <string name="menu_item_languages">Język</string>
+    <string name="access_code_placeholder">Kod dostęu</string>
+    <string name="status_updating_resources">Trwa aktualizowanie danych...</string>
+    <string name="status_updating_drafts">Trwa aktualizowanie wersji roboczych tłumaczeń...</string>
+    <string name="status_creating_drafts">Trwa tworzenie wersji roboczej tłumaczenia...</string>
+    <string name="status_publishing_drafts">Trwa proces publikowania wersji roboczej do statusu oficjalnego tłumaczenia....</string>
+    <string name="status_updating_menu">Aktualizacje menu...</string>
+    <string name="status_checking_for_updates">Trwa sprawdzanie aktualizacji...</string>
+    <string name="status_initial_setup">Ustawienia początkowe...</string>
+    <string name="status_downloading_resources">Trwa pobieranie danych...</string>
+    <string name="language_alert_title">Ustawienia języka</string>
+    <string name="language_alert_body">Czy {{language_name}} ma być domyślnym językiem?</string>
+    <string name="draft_refresh_message">Trwa odświeżanie wersji roboczej tłumaczenia...</string>
+    <string name="draft_refresh_error">Błąd odświeżenia wersji roboczej</string>
+    <string name="everystudent_title">Tematy</string>
+    <string name="error_title">Błąd</string>
+    <string name="menu_download_bad_xml">Brak danych na serwerze.</string>
+    <string name="packages_download_error">Nastąpił błąd podczas pobierania pakietów</string>
+    <string name="page_download_error">Nastąpił błąd podczas pobierania strony</string>
+    <string name="server_error">Wystąpiły problemy z serwerem</string>
+    <string name="initial_setup_error_message">Niestety nie można załadować danych. Zamknij aplikację i uruchom ją ponownie. Jeśli problem będzie się powtarzał skontaktuj sie z nami: support@godtoolsapp.com</string>
+</resources>


### PR DESCRIPTION
- all strings were translated, prior to the one I added in the previous PR indicating that users cannot delete the current primary language.
- Polish was tested on Nexus 5 running Lollipop.
- Kazakh locale not yet tested b/c I can't figure out how to do that on the Nexus (yet)
