### PR TITLE
Account for action bar in layouts

### DIFF
--- a/src/org/keynote/godtools/android/SnuffyPWActivity.java
+++ b/src/org/keynote/godtools/android/SnuffyPWActivity.java
@@ -15,7 +15,6 @@ import android.os.Parcelable;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
-import android.support.v4.view.WindowCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -121,7 +120,7 @@ public class SnuffyPWActivity extends AppCompatActivity
         mConfigFileName = getIntent().getStringExtra("ConfigFileName");
         mPackageStatus = getIntent().getStringExtra("Status"); // live = draft
         mPageLeft = getIntent().getIntExtra("PageLeft", 0);
-        mPageTop = actionBarHeight();
+        mPageTop = actionBarHeightWithFallback();
         mPageWidth = getIntent().getIntExtra("PageWidth", 320);         // set defaults but they will not be used
         mPageHeight = getIntent().getIntExtra("PageHeight", 480);       // caller will always determine these and pass them in
         Log.i("ScreenSize", "Left = " + mPageLeft + ", Top = " + mPageTop + ", Width = " + mPageWidth + ", Height = " + mPageHeight);
@@ -187,14 +186,17 @@ public class SnuffyPWActivity extends AppCompatActivity
         }
     }
 
-    private int actionBarHeight()
+    /*
+     * Falls back to the height passed in through the intent extra if no action bar is found.
+     */
+    private int actionBarHeightWithFallback()
     {
         final TypedArray styledAttributes = getApplicationContext().getTheme().obtainStyledAttributes(
                 new int[] { android.R.attr.actionBarSize });
         final int actionBarSize = (int) styledAttributes.getDimension(0, 0);
 
         styledAttributes.recycle();
-        return actionBarSize;
+        return actionBarSize != 0 ? actionBarSize : getIntent().getIntExtra("PageTop", 0);
     }
 
     private void handleLanguagesWithAlternateFonts()


### PR DESCRIPTION
- This will make the action bar overflow button more obvious w/o overwriting content or pushing it off the bottom of the view
