### PR TITLE
Revert "upgrade to latest plugin version"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-alpha6'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha5'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         //noinspection GradleDependency
         classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'


### PR DESCRIPTION
This reverts commit 2bb52f8087ba3ddd475d6d39e0d3942b19926f39.

alpha 6 of the android build plugin introduced a crash on ICS.