### PR TITLE
Fix <content:image> rendering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-rc2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         //noinspection GradleDependency
         classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext.deps = [
         eventbusAnnotations  : '3.0.1',
         evernoteAndroidJob   : '1.1.11',
         facebookStetho       : '1.5.0',
-        gtoSupport           : '1.1.2',
+        gtoSupport           : '1.1.3-SNAPSHOT',
         guava                : '22.0-android',
         hamcrest             : '1.3',
         junit                : '4.12',

--- a/library/tract-renderer/src/main/res/layout/tract_content_image.xml
+++ b/library/tract-renderer/src/main/res/layout/tract_content_image.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.cru.godtools.tract.widget.TractPicassoImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<org.ccci.gto.android.common.picasso.view.SimplePicassoImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:scaleType="centerCrop"
     android:adjustViewBounds="true"
     android:cropToPadding="false"
-    android:saveEnabled="false"
-    app:scaleType="fill_x" />
+    android:saveEnabled="false" />


### PR DESCRIPTION
Depends on https://github.com/CruGlobal/android-gto-support/pull/167

we have no need of the `TractPicassoImageView` specific behavior, but we do need the underlying `SimplePicassoImageView` behavior.