### PR TITLE
Remove "now" & "later" buttons in favor of one "Okay" button during onboarding tour

### DIFF
--- a/app/src/main/java/org/keynote/godtools/android/activity/TourActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/TourActivity.java
@@ -157,16 +157,6 @@ public class TourActivity extends AppCompatActivity {
         }
 
         @Optional
-        @OnClick(R.id.action_switch_language)
-        void showLanguageSettings() {
-            final TourActivity activity = FragmentUtils.getListener(this, TourActivity.class);
-            if (activity != null) {
-                LanguageSettingsActivity.start(activity);
-                activity.finish();
-            }
-        }
-
-        @Optional
         @OnClick(R.id.action_tour_close)
         void closeTour() {
             final TourActivity activity = FragmentUtils.getListener(this, TourActivity.class);

--- a/app/src/main/res/layout/fragment_tour_languages.xml
+++ b/app/src/main/res/layout/fragment_tour_languages.xml
@@ -38,12 +38,6 @@
             android:layout_height="wrap_content">
 
             <Button
-                android:id="@+id/action_switch_language"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_tour_now" />
-
-            <Button
                 android:id="@+id/action_tour_close"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -51,7 +45,7 @@
                 android:layout_marginStart="8dp"
                 android:layout_toEndOf="@id/action_switch_language"
                 android:layout_toRightOf="@id/action_switch_language"
-                android:text="@string/action_tour_later" />
+                android:text="@string/action_tour_ok" />
         </RelativeLayout>
 
         <View style="@style/Widget.GodTools2.Tour.Spacer" />

--- a/app/src/main/res/layout/fragment_tour_languages.xml
+++ b/app/src/main/res/layout/fragment_tour_languages.xml
@@ -33,20 +33,11 @@
 
         <View style="@style/Widget.GodTools2.Tour.Spacer" />
 
-        <RelativeLayout
+        <Button
+            android:id="@+id/action_tour_close"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
-
-            <Button
-                android:id="@+id/action_tour_close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="8dp"
-                android:layout_marginStart="8dp"
-                android:layout_toEndOf="@id/action_switch_language"
-                android:layout_toRightOf="@id/action_switch_language"
-                android:text="@string/action_tour_ok" />
-        </RelativeLayout>
+            android:layout_height="wrap_content"
+            android:text="@string/action_tour_ok" />
 
         <View style="@style/Widget.GodTools2.Tour.Spacer" />
 


### PR DESCRIPTION


The "Now" button which took the user to the pick languages activity proved frustrating/distracting for users. Now just one "Okay" button.