### PR TITLE
disable www.knowgod.com deep links to fix app link behavior

### DIFF
--- a/library/tract-renderer/src/main/AndroidManifest.xml
+++ b/library/tract-renderer/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-                <data android:host="@string/tract_deeplink_host_1" />
+                <!--<data android:host="@string/tract_deeplink_host_1" />-->
                 <data android:host="@string/tract_deeplink_host_2" />
                 <data android:pathPattern="/.*/kgp.*" />
                 <!--<data android:pathPattern="/.*/kgp-us.*" />-->


### PR DESCRIPTION
https://www.knowgod.com/.well-known/assetlinks.json issues a 301 redirect. This is invalid according to the verification file requirements listed here: https://developer.android.com/training/app-links/verify-site-associations.html#publish-json