### PR TITLE
Pop back to previous activity after downloading language

### DIFF
--- a/app/src/main/java/org/cru/godtools/adapter/LanguagesAdapter.java
+++ b/app/src/main/java/org/cru/godtools/adapter/LanguagesAdapter.java
@@ -197,7 +197,11 @@ public class LanguagesAdapter extends RecyclerView.Adapter<LanguageViewHolder> {
         @UiThread
         @OnClick(R.id.action_add)
         void onAddLanguage() {
-            mTools.addLanguage(mLocale);
+            if (mCallbacks != null) {
+                mCallbacks.onLanguageSelected(mLocale);
+            } else {
+                mTools.addLanguage(mLocale);
+            }
         }
 
         @Optional

--- a/app/src/main/java/org/cru/godtools/adapter/LanguagesAdapter.java
+++ b/app/src/main/java/org/cru/godtools/adapter/LanguagesAdapter.java
@@ -194,17 +194,6 @@ public class LanguagesAdapter extends RecyclerView.Adapter<LanguageViewHolder> {
         }
 
         @Optional
-        @UiThread
-        @OnClick(R.id.action_add)
-        void onAddLanguage() {
-            if (mCallbacks != null) {
-                mCallbacks.onLanguageSelected(mLocale);
-            } else {
-                mTools.addLanguage(mLocale);
-            }
-        }
-
-        @Optional
         @OnClick(R.id.action_remove)
         void onRemoveLanguage() {
             if (!mProtected.contains(mLocale)) {


### PR DESCRIPTION
Use the `else` as a fallback in case mCallbacks is null for some reason. At least the language will be downloaded, but the activity just won't pop.

(maybe the null check isn't needed, but it's done elsewhere, so I did it here)