### PR TITLE
Deep Link updates for JF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext.deps = [
         hamcrest             : '1.3',
         junit                : '4.12',
         leakcanary           : '1.5.1',
-        lightweightStream    : '1.1.8',
+        lightweightStream    : '1.2.0',
         multidex             : '1.0.3',
         newrelic             : '5.14.0',
         playServices         : '10.2.6',

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,11 @@ ext.deps = [
         junit                : '4.12',
         leakcanary           : '1.5.1',
         lightweightStream    : '1.2.0',
+        mockito              : '2.17.0',
         multidex             : '1.0.3',
         newrelic             : '5.14.0',
         playServices         : '10.2.6',
+        powermock            : '2.0.0-beta.9',
         retrofit2            : '2.3.0',
         snowplow             : '0.6.2',
         timber               : '4.7.0'
@@ -71,6 +73,8 @@ subprojects {
         }
         maven { url 'https://maven.fabric.io/public' }
         maven { url 'http://maven.snplow.com/releases' }
+        // XXX: temporary to use beta version of powermock
+        maven { url 'https://dl.bintray.com/powermock/maven' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ ext.deps = [
         hamcrest             : '1.3',
         junit                : '4.12',
         leakcanary           : '1.5.1',
-        lightweightStream    : '1.2.0',
+        lightweightStream    : '1.1.9',
         mockito              : '2.17.0',
         multidex             : '1.0.3',
         newrelic             : '5.14.0',

--- a/library/tract-renderer/build.gradle
+++ b/library/tract-renderer/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     androidTestImplementation "org.hamcrest:hamcrest-library:${deps.hamcrest}"
 
     testImplementation "junit:junit:${deps.junit}"
+    testImplementation "org.mockito:mockito-core:${deps.mockito}"
+    testImplementation "org.powermock:powermock-classloading-xstream:${deps.powermock}"
+    testImplementation "org.powermock:powermock-module-junit4-rule:${deps.powermock}"
+    testImplementation "org.ccci.gto.android:gto-support-testing:${deps.gtoSupport}"
 
     annotationProcessor "android.arch.lifecycle:compiler:${deps.androidLifecycle}"
     annotationProcessor "com.jakewharton:butterknife-compiler:${deps.butterknife}"

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/Constants.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/Constants.java
@@ -6,6 +6,9 @@ public final class Constants {
     public static final String XMLNS_TRACT = "https://mobile-content-api.cru.org/xmlns/tract";
     public static final String XMLNS_CONTENT = "https://mobile-content-api.cru.org/xmlns/content";
 
+    // deep link uri params
+    public static final String PARAM_PRIMARY_LANGUAGE = "primaryLanguage";
+
     // common extras
     public static final String EXTRA_MANIFEST_FILE_NAME = "manifest_file";
     public static final String EXTRA_PAGE = "page";

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
@@ -12,7 +12,9 @@ import android.os.Bundle;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 import android.support.annotation.UiThread;
+import android.support.annotation.VisibleForTesting;
 import android.support.design.widget.TabLayout;
 import android.support.design.widget.TabLayoutUtils;
 import android.support.v4.app.LoaderManager;
@@ -134,15 +136,17 @@ public class TractActivity extends ImmersiveActivity
     @Nullable
     private GodToolsDownloadManager mDownloadManager;
     @NonNull
-    private SettableFuture[] mDownloadTasks = new SettableFuture[0];
+    @VisibleForTesting
+    SettableFuture[] mDownloadTasks = new SettableFuture[0];
     @NonNull
     private DownloadProgress mDownloadProgress = DownloadProgress.INDETERMINATE;
 
-    private final SparseArray<Translation> mTranslations = new SparseArray<>();
-    private final SparseArray<Manifest> mManifests = new SparseArray<>();
+    private final SparseArray<Translation> mTranslations;
+    private final SparseArray<Manifest> mManifests;
     @NonNull
     boolean[] mHiddenLanguages = new boolean[0];
-    private int mActiveLanguage = 0;
+    @VisibleForTesting
+    int mActiveLanguage = 0;
 
     protected static void populateExtras(@NonNull final Bundle extras, @NonNull final String toolCode,
                                          @NonNull final Locale... languages) {
@@ -155,6 +159,18 @@ public class TractActivity extends ImmersiveActivity
         final Bundle extras = new Bundle();
         populateExtras(extras, toolCode, languages);
         context.startActivity(new Intent(context, TractActivity.class).putExtras(extras));
+    }
+
+    public TractActivity() {
+        mTranslations = new SparseArray<>();
+        mManifests = new SparseArray<>();
+    }
+
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    TractActivity(@NonNull final SparseArray<Translation> translations,
+                  @NonNull final SparseArray<Manifest> manifests) {
+        mTranslations = translations;
+        mManifests = manifests;
     }
 
     /* BEGIN lifecycle */
@@ -386,6 +402,7 @@ public class TractActivity extends ImmersiveActivity
      * via a deep link.
      */
     @UiThread
+    @VisibleForTesting
     void updateHiddenLanguages() {
         int primaryLanguage = -1;
         for (int i = 0; i < mLanguages.length; i++) {

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
@@ -410,8 +410,13 @@ public class TractActivity extends ImmersiveActivity
             final int state = determineLanguageState(i);
             mHiddenLanguages[i] = state == STATE_NOT_FOUND;
 
+            // short-circuit loop if this language was not found
+            if (state == STATE_NOT_FOUND) {
+                continue;
+            }
+
             // primary language specific logic
-            if (i < mPrimaryLanguages && state != STATE_NOT_FOUND) {
+            if (i < mPrimaryLanguages) {
                 if (mActiveLanguage == i || (state == STATE_LOADED && primaryLanguage == -1)) {
                     // don't hide the primary language
                     mHiddenLanguages[i] = false;

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
@@ -423,7 +423,7 @@ public class TractActivity extends ImmersiveActivity
 
                     // track our current primary language
                     primaryLanguage = i;
-                } else if (i < mPrimaryLanguages) {
+                } else {
                     // hide any other potential primary language
                     mHiddenLanguages[i] = true;
                 }

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.java
@@ -243,14 +243,9 @@ public class TractActivity extends ImmersiveActivity
     @Override
     public void onTabSelected(final TabLayout.Tab tab) {
         final Locale locale = (Locale) tab.getTag();
-        for (int i = 0; i < mLanguages.length; i++) {
-            if (mLanguages[i].equals(locale)) {
-                mActiveLanguage = i;
-                restartDownloadProgressListener();
-                updateActiveManifest();
-                mAnalytics.onTrackToggleLanguage(locale);
-                return;
-            }
+        if (locale != null) {
+            updateActiveLanguage(locale);
+            mAnalytics.onTrackToggleLanguage(locale);
         }
     }
 
@@ -428,6 +423,19 @@ public class TractActivity extends ImmersiveActivity
                 }
                 updateLanguageToggle();
                 break;
+            }
+        }
+    }
+
+    private void updateActiveLanguage(@NonNull final Locale locale) {
+        for (int i = 0; i < mLanguages.length; i++) {
+            if (mLanguages[i].equals(locale)) {
+                if (i != mActiveLanguage) {
+                    mActiveLanguage = i;
+                    restartDownloadProgressListener();
+                    updateActiveManifest();
+                }
+                return;
             }
         }
     }

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Manifest.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Manifest.java
@@ -7,6 +7,7 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.DimenRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
 import android.support.v4.util.SimpleArrayMap;
@@ -89,8 +90,14 @@ public final class Manifest extends Base implements Styles {
     @VisibleForTesting
     final SimpleArrayMap<String, Resource> mResources = new SimpleArrayMap<>();
 
-    @VisibleForTesting
-    Manifest(@NonNull final String manifestName, @NonNull final String toolCode, @NonNull final Locale locale) {
+    @RestrictTo(RestrictTo.Scope.TESTS)
+    public Manifest() {
+        mManifestName = "";
+        mCode = "";
+        mLocale = Locale.ENGLISH;
+    }
+
+    private Manifest(@NonNull final String manifestName, @NonNull final String toolCode, @NonNull final Locale locale) {
         super();
         mManifestName = manifestName;
         mCode = toolCode;

--- a/library/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityUpdateHiddenLanguagesTest.java
+++ b/library/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityUpdateHiddenLanguagesTest.java
@@ -1,0 +1,135 @@
+package org.cru.godtools.tract.activity;
+
+import android.graphics.Color;
+import android.util.SparseArray;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import org.ccci.gto.android.common.testing.CommonMocks;
+import org.cru.godtools.model.Translation;
+import org.cru.godtools.tract.model.Manifest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.OngoingStubbing;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@PrepareForTest({Color.class})
+public class TractActivityUpdateHiddenLanguagesTest {
+    @Rule
+    public final PowerMockRule mPowerMockRule = new PowerMockRule();
+
+    private TractActivity mActivity;
+    @Mock
+    private SparseArray<Translation> mTranslations;
+    @Mock
+    private SparseArray<Manifest> mManifests;
+    private Manifest mManifest;
+
+    @Before
+    public void setup() {
+        CommonMocks.mockColor();
+        MockitoAnnotations.initMocks(this);
+
+        mActivity = new TractActivity(mTranslations, mManifests);
+        mManifest = new Manifest();
+    }
+
+    private void setLanguages(final Locale... locales) {
+        mActivity.mLanguages = locales;
+        mActivity.mDownloadTasks = new SettableFuture[mActivity.mLanguages.length];
+        mActivity.mHiddenLanguages = new boolean[mActivity.mLanguages.length];
+    }
+
+    @Test
+    public void verifyPrimaryFirstDownloaded() {
+        // setup test
+        setLanguages(Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN);
+        mActivity.mActiveLanguage = 0;
+        mActivity.mPrimaryLanguages = 2;
+        whenGetTranslation(0).thenReturn(new Translation());
+        whenGetManifest(0).thenReturn(mManifest);
+
+        // run logic and verify results
+        mActivity.updateHiddenLanguages();
+        assertFalse("first language shouldn't be hidden because it is downloaded", mActivity.mHiddenLanguages[0]);
+        assertTrue("second is hidden because first is already downloaded", mActivity.mHiddenLanguages[1]);
+        assertFalse(mActivity.mHiddenLanguages[2]);
+    }
+
+    @Test
+    public void verifyPrimaryFirstLoadingSecondDownloaded() {
+        // setup test
+        setLanguages(Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN);
+        mActivity.mActiveLanguage = 0;
+        mActivity.mPrimaryLanguages = 2;
+        whenGetTranslation(0).thenReturn(new Translation());
+        whenGetTranslation(1).thenReturn(new Translation());
+        whenGetManifest(1).thenReturn(mManifest);
+
+        // run logic and verify results
+        mActivity.updateHiddenLanguages();
+        assertFalse("first language shouldn't be hidden because it is currently active and potentially available",
+                    mActivity.mHiddenLanguages[0]);
+        assertTrue("second language should be hidden because first language might be available to use as primary",
+                   mActivity.mHiddenLanguages[1]);
+        assertFalse(mActivity.mHiddenLanguages[2]);
+    }
+
+    @Test
+    public void verifyPrimaryFirstMissingSecondLoading() {
+        // setup test
+        setLanguages(Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN);
+        mActivity.mActiveLanguage = 2;
+        mActivity.mPrimaryLanguages = 2;
+        translationMissing(0);
+        whenGetTranslation(1).thenReturn(new Translation());
+
+        // run logic and verify results
+        mActivity.updateHiddenLanguages();
+        assertTrue("first language should be hidden because it is not available", mActivity.mHiddenLanguages[0]);
+        assertTrue("second language should be hidden because it is still loading", mActivity.mHiddenLanguages[1]);
+        assertFalse(mActivity.mHiddenLanguages[2]);
+    }
+
+    @Test
+    public void verifyPrimaryFirstDownloadedSecondActive() {
+        // setup test
+        setLanguages(Locale.FRENCH, Locale.GERMAN, Locale.ITALIAN);
+        mActivity.mActiveLanguage = 1;
+        mActivity.mPrimaryLanguages = 2;
+        whenGetTranslation(0).thenReturn(new Translation());
+        whenGetTranslation(1).thenReturn(new Translation());
+        whenGetManifest(0).thenReturn(mManifest);
+
+        // run logic and verify results
+        mActivity.updateHiddenLanguages();
+        assertTrue("first language should be hidden because second language is primary and active",
+                   mActivity.mHiddenLanguages[0]);
+        assertFalse("second language shouldn't be hidden because it is currently active",
+                    mActivity.mHiddenLanguages[1]);
+        assertFalse(mActivity.mHiddenLanguages[2]);
+    }
+
+    private OngoingStubbing<Translation> whenGetTranslation(final int index) {
+        when(mTranslations.indexOfKey(index)).thenReturn(0);
+        return when(mTranslations.get(index));
+    }
+
+    private void translationMissing(final int index) {
+        when(mTranslations.indexOfKey(index)).thenReturn(-1);
+    }
+
+    private OngoingStubbing<Manifest> whenGetManifest(final int index) {
+        return when(mManifests.get(index));
+    }
+}


### PR DESCRIPTION
Within the Android TractActivity we already store an array of languages we are attempting to show. This PR leverages this arbitrary list of languages to display to implement the primary language fallback functionality.

1. We parse a list of primary language candidates (with fallbacks) from the deep link
2. We trigger a background download for all of these potential languages
3. We pick which of the primary language options we actually make visible in the UI via `updateHiddenLanguages()`
   - If one of the potential primary languages is currently active we use that as the primary language. (This prevents unexpected state changes in the UI for the end user)
   - Otherwise the first potential primary language that we haven't determined to be missing is used.
   - This state is refreshed every time we refresh the language toggle UI.
     - This automatically happens whenever some new data is made available to the TractActivity
- We also update which language is the active language if the current active language is not found