### PR TITLE
Language Settings Feature discovery

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     implementation "com.crashlytics.sdk.android:crashlytics:${deps.crashlytics}"
 
     implementation "com.evernote:android-job:${deps.evernoteAndroidJob}"
+    implementation "com.getkeepsafe.taptargetview:taptargetview:1.11.0"
     implementation "com.google.guava:guava:${deps.guava}"
     implementation "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:${deps.advrecyclerview}"
     implementation "com.jakewharton:butterknife:${deps.butterknife}"

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.java
@@ -120,7 +120,7 @@ public abstract class BasePlatformActivity extends BaseDesignActivity
                 }
                 break;
             case R.id.action_switch_language:
-                LanguageSettingsActivity.start(this);
+                showLanguageSettings();
                 return true;
         }
         return super.onOptionsItemSelected(item);
@@ -287,6 +287,10 @@ public abstract class BasePlatformActivity extends BaseDesignActivity
         } catch (@NonNull final ActivityNotFoundException e) {
             WebUrlLauncher.openUrl(this, URI_SUPPORT);
         }
+    }
+
+    protected void showLanguageSettings() {
+        LanguageSettingsActivity.start(this);
     }
 
     class ChangeListener implements SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.java
@@ -54,7 +54,7 @@ public abstract class BasePlatformActivity extends BaseDesignActivity
     // Navigation Drawer
     @Nullable
     @BindView(R.id.drawer_layout)
-    DrawerLayout mDrawerLayout;
+    protected DrawerLayout mDrawerLayout;
     @Nullable
     @BindView(R.id.drawer_menu)
     NavigationView mDrawerMenu;

--- a/app/src/main/java/org/cru/godtools/activity/LanguageSettingsActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/LanguageSettingsActivity.java
@@ -13,6 +13,7 @@ import org.cru.godtools.R;
 import org.keynote.godtools.android.fragment.LanguageSettingsFragment;
 
 import static org.cru.godtools.analytics.AnalyticsService.SCREEN_LANGUAGE_SETTINGS;
+import static org.cru.godtools.base.Settings.FEATURE_LANGUAGE_SETTINGS;
 
 public class LanguageSettingsActivity extends BasePlatformActivity {
     private static final String TAG_MAIN_FRAGMENT = "mainFragment";
@@ -38,6 +39,7 @@ public class LanguageSettingsActivity extends BasePlatformActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        prefs().setFeatureDiscovered(FEATURE_LANGUAGE_SETTINGS);
         mAnalytics.onTrackScreen(SCREEN_LANGUAGE_SETTINGS);
     }
 

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
@@ -336,6 +336,10 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
             case FEATURE_LANGUAGE_SETTINGS:
                 assert mToolbar != null : "canShowFeatureDiscovery() verifies mToolbar is not null";
                 if (mToolbar.findViewById(R.id.action_switch_language) != null) {
+                    // purge any pending feature discovery triggers since we are showing feature discovery now
+                    purgeQueuedFeatureDiscovery(FEATURE_LANGUAGE_SETTINGS);
+
+                    // show language settings feature discovery
                     final TapTarget target = TapTarget.forToolbarMenuItem(
                             mToolbar, R.id.action_switch_language,
                             getString(R.string.feature_discovery_title_language_settings),
@@ -356,17 +360,16 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
     }
 
     private void dispatchDelayedFeatureDiscovery(@NonNull final String feature, final boolean force, final long delay) {
-        // remove all previously queued feature discovery tasks for this feature if we are forcing it now
-        if (force) {
-            mTaskHandler.removeMessages(TASK_FEATURE_DISCOVERY, feature);
-        }
-
         final Message msg = mTaskHandler.obtainMessage(TASK_FEATURE_DISCOVERY, feature);
         final Bundle data = new Bundle();
         data.putString(EXTRA_FEATURE, feature);
         data.putBoolean(EXTRA_FORCE, force);
         msg.setData(data);
         mTaskHandler.sendMessageDelayed(msg, delay);
+    }
+
+    private void purgeQueuedFeatureDiscovery(@NonNull final String feature) {
+        mTaskHandler.removeMessages(TASK_FEATURE_DISCOVERY, feature);
     }
 
     private class LanguageSettingsFeatureDiscoveryListener extends TapTargetView.Listener {

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
@@ -298,9 +298,10 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
 
         if (mToolbar != null) {
             if (mToolbar.findViewById(R.id.action_switch_language) != null) {
-                final TapTarget target = TapTarget.forToolbarMenuItem(mToolbar, R.id.action_switch_language,
-                                                                      getString(R.string.title_tour_language),
-                                                                      getString(R.string.desc_tour_language));
+                final TapTarget target = TapTarget.forToolbarMenuItem(
+                        mToolbar, R.id.action_switch_language,
+                        getString(R.string.feature_discovery_title_language_settings),
+                        getString(R.string.feature_discovery_desc_language_settings));
                 mFeatureDiscovery = TapTargetView.showFor(this, target, new LanguageSettingsFeatureDiscoveryListener());
                 mFeatureDiscoveryActive = FEATURE_LANGUAGE_SETTINGS;
             } else {

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
@@ -326,8 +326,8 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
                     // TODO: the menu item just hasn't been drawn yet.
 
                     // the toolbar action isn't available yet.
-                    // re-attempt this feature discovery on the next iteration of the main Looper.
-                    mToolbar.post(() -> showFeatureDiscovery(feature, force));
+                    // re-attempt this feature discovery on the next frame iteration.
+                    mToolbar.postDelayed(() -> showFeatureDiscovery(feature, force), 17);
                 }
                 break;
         }

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
@@ -344,12 +344,12 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
                             TapTargetView.showFor(this, target, new LanguageSettingsFeatureDiscoveryListener());
                     mFeatureDiscoveryActive = feature;
                 } else {
-                    final MenuItem item = mToolbar.getMenu().findItem(R.id.action_switch_language);
-                    if (item != null && item.isVisible()) {
-                        // the toolbar action isn't available yet.
-                        // re-attempt this feature discovery on the next frame iteration.
-                        dispatchDelayedFeatureDiscovery(feature, force, 17);
-                    }
+                    // TODO: we currently don't (can't?) distinguish between when the menu item doesn't exist and when
+                    // TODO: the menu item just hasn't been drawn yet.
+
+                    // the toolbar action isn't available yet.
+                    // re-attempt this feature discovery on the next frame iteration.
+                    dispatchDelayedFeatureDiscovery(feature, force, 17);
                 }
                 break;
         }

--- a/app/src/main/res/layout/fragment_tour_languages.xml
+++ b/app/src/main/res/layout/fragment_tour_languages.xml
@@ -29,7 +29,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:gravity="center_horizontal"
-            android:text="@string/title_tour_language" />
+            android:text="@string/feature_discovery_title_language_settings" />
 
         <View style="@style/Widget.GodTools2.Tour.Spacer" />
 

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -18,7 +18,7 @@
     <string name="share_story_subject">Hoor hoe God beweeg!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Voeg nuwe hulpmiddels by</string>
-    <string name="title_tour_language">Stel jou Tale in</string>
+    <string name="feature_discovery_title_language_settings">Stel jou Tale in</string>
     <string name="action_tour_ok">Okei</string>
     <string name="action_tour_now">Nou</string>
     <string name="action_tour_later">Later</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">استمع لكيفية تحرك الرب!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">إضافة أدوات جديدة</string>
-    <string name="title_tour_language">حدد لغاتك</string>
+    <string name="feature_discovery_title_language_settings">حدد لغاتك</string>
     <string name="action_tour_ok">حسناً</string>
     <string name="action_tour_now">الآن</string>
     <string name="action_tour_later">لاحقاً</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Чуйте как се движи Бог</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Добавете нови инструменти</string>
-    <string name="title_tour_language">Настройте Вашите езици</string>
+    <string name="feature_discovery_title_language_settings">Настройте Вашите езици</string>
     <string name="action_tour_ok">ОК</string>
     <string name="action_tour_now">Сега</string>
     <string name="action_tour_later">По-късно</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -15,7 +15,7 @@
     <!-- Share a story -->
     <!-- Tour UI -->
     <string name="title_tour_tools">নতুন সরঞ্জাম যোগ করুন</string>
-    <string name="title_tour_language">আপনার ভাষা সেট করুন</string>
+    <string name="feature_discovery_title_language_settings">আপনার ভাষা সেট করুন</string>
     <string name="action_tour_ok">ঠিক আছে</string>
     <string name="action_tour_now">ekhon</string>
     <string name="action_tour_later">পরে</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Poslechněte si, jak Bůh hýbe světem!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Přidat nové nástroje</string>
-    <string name="title_tour_language">Nastavení jazyků</string>
+    <string name="feature_discovery_title_language_settings">Nastavení jazyků</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Nyní</string>
     <string name="action_tour_later">Později</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Hør, hvordan Gud bevæger!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Tilføj nye værktøjer</string>
-    <string name="title_tour_language">Angiv dine sprog</string>
+    <string name="feature_discovery_title_language_settings">Angiv dine sprog</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Nu</string>
     <string name="action_tour_later">Senere</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Hören Sie, wie Gott bewegt!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Neue Tools hinzufügen</string>
-    <string name="title_tour_language">Wählen Sie Ihre Sprache</string>
+    <string name="feature_discovery_title_language_settings">Wählen Sie Ihre Sprache</string>
     <string name="action_tour_ok">Okay</string>
     <string name="action_tour_now">Jetzt</string>
     <string name="action_tour_later">Später</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Ακούστε πώς κινείται ο Θεός!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Προσθήκη Νέων Εργαλείων</string>
-    <string name="title_tour_language">Ορίστε τις γλώσσες σας</string>
+    <string name="feature_discovery_title_language_settings">Ορίστε τις γλώσσες σας</string>
     <string name="action_tour_ok">Εντάξει</string>
     <string name="action_tour_now">Τώρα</string>
     <string name="action_tour_later">Αργότερα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">¡Escucha cómo se mueve Dios!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Agrega nuevas herramientas</string>
-    <string name="title_tour_language">Establece tus idiomas</string>
+    <string name="feature_discovery_title_language_settings">Establece tus idiomas</string>
     <string name="action_tour_ok">Ok</string>
     <string name="action_tour_now">Ahora</string>
     <string name="action_tour_later">Más tarde</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Kuula, kuidas Jumal tegutseb!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Lisa uusi tööriistu</string>
-    <string name="title_tour_language">Seadista oma keeled</string>
+    <string name="feature_discovery_title_language_settings">Seadista oma keeled</string>
     <string name="action_tour_ok">Nõus</string>
     <string name="action_tour_now">Kohe</string>
     <string name="action_tour_later">Hiljem</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">صدای حرکت خداوند را بشنوید!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">افزودن ابزار جدید</string>
-    <string name="title_tour_language">زبان خود را تنظیم کنید</string>
+    <string name="feature_discovery_title_language_settings">زبان خود را تنظیم کنید</string>
     <string name="action_tour_ok">تأیید</string>
     <string name="action_tour_now">اکنون</string>
     <string name="action_tour_later">بعداً</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Pakinggan kung paano nakakabagabag ng puso ang Diyos!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Magdagdag ng Mga Bagong Tool</string>
-    <string name="title_tour_language">I-set ang Iyong Mga Wika</string>
+    <string name="feature_discovery_title_language_settings">I-set ang Iyong Mga Wika</string>
     <string name="action_tour_ok">Okay</string>
     <string name="action_tour_now">Ngayon</string>
     <string name="action_tour_later">Sa Ibang Pagkakataon</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Découvrez comment Dieu agit!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Ajouter de nouveaux outils</string>
-    <string name="title_tour_language">Réglez vos languages</string>
+    <string name="feature_discovery_title_language_settings">Réglez vos languages</string>
     <string name="action_tour_ok">D\'accord</string>
     <string name="action_tour_now">Maintenant</string>
     <string name="action_tour_later">Plus tard</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Découvrez comment Dieu agit !</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Ajouter de nouveaux outils</string>
-    <string name="title_tour_language">Définissez vos langues</string>
+    <string name="feature_discovery_title_language_settings">Définissez vos langues</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Maintenant</string>
     <string name="action_tour_later">Plus tard</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">הקשיבו איך האל זז!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">הוסיפו כלים חדשים</string>
-    <string name="title_tour_language">הגדירו את השפה שלכם</string>
+    <string name="feature_discovery_title_language_settings">הגדירו את השפה שלכם</string>
     <string name="action_tour_ok">בסדר</string>
     <string name="action_tour_now">עכשיו</string>
     <string name="action_tour_later">אחר כך</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">गॉड का चलना सुनें!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">नए टूल जोड़ें</string>
-    <string name="title_tour_language">अपनी भाषा निर्धारित करें</string>
+    <string name="feature_discovery_title_language_settings">अपनी भाषा निर्धारित करें</string>
     <string name="action_tour_ok">ठीक</string>
     <string name="action_tour_now">अभी</string>
     <string name="action_tour_later">बाद में</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Poslušajte kako nas Bog nadahnjuje!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Dodaj nove alate</string>
-    <string name="title_tour_language">Odredite svoje jezike</string>
+    <string name="feature_discovery_title_language_settings">Odredite svoje jezike</string>
     <string name="action_tour_ok">U redu</string>
     <string name="action_tour_now">Odmah</string>
     <string name="action_tour_later">Kasnije</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Halld Isten cselekedeteit!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Új eszközök hozzáadása</string>
-    <string name="title_tour_language">A nyelvek beállítása</string>
+    <string name="feature_discovery_title_language_settings">A nyelvek beállítása</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Most</string>
     <string name="action_tour_later">Később</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Dengarkan bagaimana Tuhan bergerak!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Tambah Alat Baru</string>
-    <string name="title_tour_language">Tetapkan Bahasa Anda</string>
+    <string name="feature_discovery_title_language_settings">Tetapkan Bahasa Anda</string>
     <string name="action_tour_ok">Oke</string>
     <string name="action_tour_now">Sekarang</string>
     <string name="action_tour_later">Nanti</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Dengarkan bagaimana Tuhan bergerak!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Tambah Alat Baru</string>
-    <string name="title_tour_language">Tetapkan Bahasa Anda</string>
+    <string name="feature_discovery_title_language_settings">Tetapkan Bahasa Anda</string>
     <string name="action_tour_ok">Oke</string>
     <string name="action_tour_now">Sekarang</string>
     <string name="action_tour_later">Nanti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Senti la presenza di Dio!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Aggiungi nuovi strumenti</string>
-    <string name="title_tour_language">Imposta le lingue</string>
+    <string name="feature_discovery_title_language_settings">Imposta le lingue</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Adesso</string>
     <string name="action_tour_later">Più tardi</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">神とのストーリーを聞いてみましょう。</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">新しいツールを追加</string>
-    <string name="title_tour_language">言語を設定</string>
+    <string name="feature_discovery_title_language_settings">言語を設定</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">今すぐ</string>
     <string name="action_tour_later">後で</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">신이 어떻게 움직이는지 들어보세요!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">새 도구 추가</string>
-    <string name="title_tour_language">언어 설정</string>
+    <string name="feature_discovery_title_language_settings">언어 설정</string>
     <string name="action_tour_ok">확인</string>
     <string name="action_tour_now">지금</string>
     <string name="action_tour_later">나중에</string>

--- a/app/src/main/res/values-mg/strings.xml
+++ b/app/src/main/res/values-mg/strings.xml
@@ -17,7 +17,7 @@
     <!-- Share a story -->
     <!-- Tour UI -->
     <string name="title_tour_tools">Hanampy Fitaovana Hafa</string>
-    <string name="title_tour_language">Safidio ny Fiteninao</string>
+    <string name="feature_discovery_title_language_settings">Safidio ny Fiteninao</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Ankehitriny</string>
     <string name="action_tour_later">Aoriana</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Dengar cara God berfungsi!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Tambah Alat Baharu</string>
-    <string name="title_tour_language">Tetapkan Bahasa Anda</string>
+    <string name="feature_discovery_title_language_settings">Tetapkan Bahasa Anda</string>
     <string name="action_tour_ok">Okey</string>
     <string name="action_tour_now">Sekarang</string>
     <string name="action_tour_later">Kemudian</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Hør hvordan Gud rører!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Legg til nye verktøy</string>
-    <string name="title_tour_language">Angi språk</string>
+    <string name="feature_discovery_title_language_settings">Angi språk</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Nå</string>
     <string name="action_tour_later">Senere</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Posłuchaj o tym jak porusza się Bóg we świecie!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Dodaj Nowe Narzędzia</string>
-    <string name="title_tour_language">Ustaw języki</string>
+    <string name="feature_discovery_title_language_settings">Ustaw języki</string>
     <string name="action_tour_ok">Okej</string>
     <string name="action_tour_now">Teraz</string>
     <string name="action_tour_later">Później</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Ouve como Deus está a comover!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Adicionar novas ferramentas</string>
-    <string name="title_tour_language">Definir os idiomas</string>
+    <string name="feature_discovery_title_language_settings">Definir os idiomas</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Agora</string>
     <string name="action_tour_later">Mais tarde</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Ouça como Deus está a comover!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Adicionar novas ferramentas</string>
-    <string name="title_tour_language">Definir os idiomas</string>
+    <string name="feature_discovery_title_language_settings">Definir os idiomas</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Agora</string>
     <string name="action_tour_later">Mais tarde</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Află cum lucrează Dumnezeu!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Adaugă instrumente noi</string>
-    <string name="title_tour_language">Setează limbile</string>
+    <string name="feature_discovery_title_language_settings">Setează limbile</string>
     <string name="action_tour_ok">Ok</string>
     <string name="action_tour_now">Acum</string>
     <string name="action_tour_later">Mai târziu</string>

--- a/app/src/main/res/values-ru-rMD/strings.xml
+++ b/app/src/main/res/values-ru-rMD/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Услышьте поступь божью!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Добавить новые инструменты</string>
-    <string name="title_tour_language">Установите свои языки</string>
+    <string name="feature_discovery_title_language_settings">Установите свои языки</string>
     <string name="action_tour_ok">Ок</string>
     <string name="action_tour_now">Сейчас</string>
     <string name="action_tour_later">Позже</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Услышьте поступь божью!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Добавить новые инструменты</string>
-    <string name="title_tour_language">Установите свои языки</string>
+    <string name="feature_discovery_title_language_settings">Установите свои языки</string>
     <string name="action_tour_ok">Ок</string>
     <string name="action_tour_now">Сейчас</string>
     <string name="action_tour_later">Позже</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Vypočujte si, aký je boh pôsobivý!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Pridať nové nástroje</string>
-    <string name="title_tour_language">Nastavte si jazyky</string>
+    <string name="feature_discovery_title_language_settings">Nastavte si jazyky</string>
     <string name="action_tour_ok">OK</string>
     <string name="action_tour_now">Teraz</string>
     <string name="action_tour_later">Neskôr</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Poslušaj, kako deluje Bog!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Dodaj nova orodja</string>
-    <string name="title_tour_language">Izberi jezike</string>
+    <string name="feature_discovery_title_language_settings">Izberi jezike</string>
     <string name="action_tour_ok">V redu</string>
     <string name="action_tour_now">Zdaj</string>
     <string name="action_tour_later">Kasneje</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Dëgjo se si Perëndia po punon.</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Shto mjete të reja</string>
-    <string name="title_tour_language">Vendos gjuhët e tua</string>
+    <string name="feature_discovery_title_language_settings">Vendos gjuhët e tua</string>
     <string name="action_tour_ok">Në rregull</string>
     <string name="action_tour_now">Tani</string>
     <string name="action_tour_later">Më vonë</string>

--- a/app/src/main/res/values-sr-rRS/strings.xml
+++ b/app/src/main/res/values-sr-rRS/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Чујте како се Бог креће!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Додај нове алате</string>
-    <string name="title_tour_language">Подесите своје језике</string>
+    <string name="feature_discovery_title_language_settings">Подесите своје језике</string>
     <string name="action_tour_ok">У реду</string>
     <string name="action_tour_now">Сад</string>
     <string name="action_tour_later">Касније</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Sikiliza namna Mungu anavyotembea!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Ongeza Vifaa Vipya</string>
-    <string name="title_tour_language">Weka Lugha Zako</string>
+    <string name="feature_discovery_title_language_settings">Weka Lugha Zako</string>
     <string name="action_tour_ok">Sawa</string>
     <string name="action_tour_now">Sasa</string>
     <string name="action_tour_later">Baadaye</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">దేవుడు ఎలా కదులుతున్నాడో వినండి!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">కొత్త సాధనాలను జోడించండి</string>
-    <string name="title_tour_language">మీ భాషలను సెట్ చేయండి</string>
+    <string name="feature_discovery_title_language_settings">మీ భాషలను సెట్ చేయండి</string>
     <string name="action_tour_ok">సరే</string>
     <string name="action_tour_now">ఇప్పుడు</string>
     <string name="action_tour_later">తరువాత</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">มาฟังกันว่าพระผู้เป็นเจ้าทรงนำเราได้อย่างไร!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">เพิ่มเครื่องมือใหม่</string>
-    <string name="title_tour_language">ตั้งค่าภาษา</string>
+    <string name="feature_discovery_title_language_settings">ตั้งค่าภาษา</string>
     <string name="action_tour_ok">โอเค</string>
     <string name="action_tour_now">ตอนนี้</string>
     <string name="action_tour_later">ภายหลัง</string>

--- a/app/src/main/res/values-tl/strings.xml
+++ b/app/src/main/res/values-tl/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Pakinggan kung paano nakakabagabag ng puso ang Diyos!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Magdagdag ng Mga Bagong Tool</string>
-    <string name="title_tour_language">I-set ang Iyong Mga Wika</string>
+    <string name="feature_discovery_title_language_settings">I-set ang Iyong Mga Wika</string>
     <string name="action_tour_ok">Okay</string>
     <string name="action_tour_now">Ngayon</string>
     <string name="action_tour_later">Sa Ibang Pagkakataon</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Tanrı\'nın nasıl hareket ettiğini duyun!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Yeni Araçlar Ekle</string>
-    <string name="title_tour_language">Dillerinizi Ayarlayın</string>
+    <string name="feature_discovery_title_language_settings">Dillerinizi Ayarlayın</string>
     <string name="action_tour_ok">Tamam</string>
     <string name="action_tour_now">Şimdi</string>
     <string name="action_tour_later">Daha Sonra</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Почуйте, як Бог пробуджує сердце!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Додати інструменти</string>
-    <string name="title_tour_language">Встановіть мови</string>
+    <string name="feature_discovery_title_language_settings">Встановіть мови</string>
     <string name="action_tour_ok">Добре</string>
     <string name="action_tour_now">Зараз</string>
     <string name="action_tour_later">Потім</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">Nghe xem Chúa di chuyển như thế nào!</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">Thêm các Công cụ Mới</string>
-    <string name="title_tour_language">Thiết lập Ngôn ngữ của Bạn</string>
+    <string name="feature_discovery_title_language_settings">Thiết lập Ngôn ngữ của Bạn</string>
     <string name="action_tour_ok">Ok</string>
     <string name="action_tour_now">Ngay bây giờ</string>
     <string name="action_tour_later">Để sau</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">聆听神是如何作工的！</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">添加新工具</string>
-    <string name="title_tour_language">设置您的语言</string>
+    <string name="feature_discovery_title_language_settings">设置您的语言</string>
     <string name="action_tour_ok">确定</string>
     <string name="action_tour_now">现在</string>
     <string name="action_tour_later">稍后</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,7 +19,7 @@
     <string name="share_story_subject">聆聽上帝的故事！</string>
     <!-- Tour UI -->
     <string name="title_tour_tools">添加新工具</string>
-    <string name="title_tour_language">設定語言</string>
+    <string name="feature_discovery_title_language_settings">設定語言</string>
     <string name="action_tour_ok">好</string>
     <string name="action_tour_now">現在</string>
     <string name="action_tour_later">待會</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,8 +26,6 @@
     <!-- Tour UI -->
     <eat-comment />
     <string name="title_tour_tools">Add New Tools</string>
-    <string name="title_tour_language">60+ Languages</string>
-    <string name="desc_tour_language">Share GodTools with someone in their native language.</string>
     <string name="action_tour_ok">Okay</string>
     <string name="action_tour_now">Now</string>
     <string name="action_tour_later">Later</string>
@@ -53,6 +51,8 @@
 
     <!-- Language Selection UI -->
     <eat-comment />
+    <string name="feature_discovery_title_language_settings">60+ Languages</string>
+    <string name="feature_discovery_desc_language_settings">Share GodTools with someone in their native language.</string>
     <string name="menu_language_settings">Language Settings</string>
     <string name="title_language_settings">Language Settings</string>
     <string name="title_language_primary">Primary Language</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,8 @@
     <!-- Tour UI -->
     <eat-comment />
     <string name="title_tour_tools">Add New Tools</string>
-    <string name="title_tour_language">Set Your Languages</string>
+    <string name="title_tour_language">60+ Languages</string>
+    <string name="desc_tour_language">Share GodTools with someone in their native language.</string>
     <string name="action_tour_ok">Okay</string>
     <string name="action_tour_now">Now</string>
     <string name="action_tour_later">Later</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <!-- Language Selection UI -->
     <eat-comment />
     <string name="feature_discovery_title_language_settings">60+ Languages</string>
-    <string name="feature_discovery_desc_language_settings">Share GodTools with someone in their native language.</string>
+    <string name="feature_discovery_desc_language_settings" translatable="false">@string/text_language_parallel_description</string>
     <string name="menu_language_settings">Language Settings</string>
     <string name="title_language_settings">Language Settings</string>
     <string name="title_language_primary">Primary Language</string>

--- a/library/base/src/main/java/org/cru/godtools/base/Settings.java
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.java
@@ -18,6 +18,10 @@ public final class Settings {
     private static final String PREF_PRIMARY_LANGUAGE = "languagePrimary";
     private static final String PREF_PARALLEL_LANGUAGE = "languageParallel";
     private static final String PREF_TOUR_COMPLETED = "tour_completed";
+    private static final String PREF_FEATURE_DISCOVERED = "feature_discovered.";
+
+    // feature discovery
+    public static final String FEATURE_LANGUAGE_SETTINGS = "languageSettings";
 
     @NonNull
     private final SharedPreferences mPrefs;
@@ -45,6 +49,25 @@ public final class Settings {
     public void setTourCompleted() {
         mPrefs.edit()
                 .putBoolean(PREF_TOUR_COMPLETED, true)
+                .apply();
+    }
+
+    public boolean isFeatureDiscovered(@NonNull final String feature) {
+        // handle pre-conditions that would indicate a feature was already discovered
+        switch (feature) {
+            case FEATURE_LANGUAGE_SETTINGS:
+                if (getParallelLanguage() != null) {
+                    setFeatureDiscovered(FEATURE_LANGUAGE_SETTINGS);
+                }
+                break;
+        }
+
+        return mPrefs.getBoolean(PREF_FEATURE_DISCOVERED + feature, false);
+    }
+
+    public void setFeatureDiscovered(@NonNull final String feature) {
+        mPrefs.edit()
+                .putBoolean(PREF_FEATURE_DISCOVERED + feature, true)
                 .apply();
     }
 


### PR DESCRIPTION
The Language Settings feature discovery triggers after 10 seconds on the home screen if it hasn't triggered before and if the user hasn't already visited Language Settings or set a Parallel Language.

Feature Discovery is setup in a manner that will allow us to provide more context sensitive prompts in the future as we want to highlight feature usage for a user.