### PR TITLE
Analytics events in content xml

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.java
@@ -1,0 +1,29 @@
+package org.cru.godtools.analytics.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.Map;
+
+public class AnalyticsActionEvent extends AnalyticsBaseEvent {
+    @NonNull
+    private final String mAction;
+
+    protected AnalyticsActionEvent() {
+        mAction = "";
+    }
+
+    public AnalyticsActionEvent(@NonNull final String action) {
+        mAction = action;
+    }
+
+    @NonNull
+    public String getAction() {
+        return mAction;
+    }
+
+    @Nullable
+    public Map<String, ?> getAttributes() {
+        return null;
+    }
+}

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsBaseEvent.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsBaseEvent.java
@@ -1,0 +1,14 @@
+package org.cru.godtools.analytics.model;
+
+import android.support.annotation.NonNull;
+
+import org.cru.godtools.analytics.AnalyticsService;
+
+public abstract class AnalyticsBaseEvent {
+    /**
+     * Return whether or not this Analytics event should be tracked in the specified service
+     */
+    public boolean trackInService(@NonNull final AnalyticsService service) {
+        return true;
+    }
+}

--- a/library/base-app/src/main/java/org/cru/godtools/base/app/BaseGodToolsApplication.java
+++ b/library/base-app/src/main/java/org/cru/godtools/base/app/BaseGodToolsApplication.java
@@ -10,6 +10,8 @@ import com.newrelic.agent.android.NewRelic;
 
 import org.ccci.gto.android.common.compat.util.LocaleCompat;
 import org.ccci.gto.android.common.crashlytics.timber.CrashlyticsTree;
+import org.cru.godtools.analytics.AdobeAnalyticsService;
+import org.cru.godtools.analytics.AnalyticsDispatcher;
 import org.cru.godtools.analytics.AnalyticsEventBusIndex;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.EventBusBuilder;
@@ -33,6 +35,9 @@ public class BaseGodToolsApplication extends Application {
 
         // configure eventbus
         configureEventBus(EventBus.builder()).installDefaultEventBus();
+
+        // configure analytics
+        configureAnalyticsServices();
     }
 
     private void initializeCrashlytics() {
@@ -45,6 +50,11 @@ public class BaseGodToolsApplication extends Application {
         Crashlytics.setString("SystemLanguage", LocaleCompat.toLanguageTag(Locale.getDefault()));
 
         Timber.plant(new CrashlyticsTree());
+    }
+
+    protected void configureAnalyticsServices() {
+        AdobeAnalyticsService.getInstance(this);
+        AnalyticsDispatcher.getInstance(this);
     }
 
     @NonNull

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/Constants.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/Constants.java
@@ -3,6 +3,7 @@ package org.cru.godtools.tract;
 public final class Constants {
     // XML namespaces
     public static final String XMLNS_MANIFEST = "https://mobile-content-api.cru.org/xmlns/manifest";
+    public static final String XMLNS_ANALYTICS = "https://mobile-content-api.cru.org/xmlns/analytics";
     public static final String XMLNS_TRACT = "https://mobile-content-api.cru.org/xmlns/tract";
     public static final String XMLNS_CONTENT = "https://mobile-content-api.cru.org/xmlns/content";
 

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ContentAnalyticsActionEvent.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ContentAnalyticsActionEvent.java
@@ -1,0 +1,42 @@
+package org.cru.godtools.tract.analytics.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.common.base.Strings;
+
+import org.cru.godtools.analytics.AdobeAnalyticsService;
+import org.cru.godtools.analytics.AnalyticsService;
+import org.cru.godtools.analytics.model.AnalyticsActionEvent;
+import org.cru.godtools.tract.model.AnalyticsEvent;
+
+import java.util.Map;
+
+public class ContentAnalyticsActionEvent extends AnalyticsActionEvent {
+    @NonNull
+    private final AnalyticsEvent mAnalyticsEvent;
+
+    public ContentAnalyticsActionEvent(@NonNull final AnalyticsEvent event) {
+        mAnalyticsEvent = event;
+    }
+
+    @Override
+    public boolean trackInService(@NonNull final AnalyticsService service) {
+        if (service instanceof AdobeAnalyticsService) {
+            return mAnalyticsEvent.isForSystem(AnalyticsEvent.System.ADOBE);
+        }
+        return false;
+    }
+
+    @NonNull
+    @Override
+    public String getAction() {
+        return Strings.nullToEmpty(mAnalyticsEvent.getAction());
+    }
+
+    @Nullable
+    @Override
+    public Map<String, ?> getAttributes() {
+        return mAnalyticsEvent.getAttributes();
+    }
+}

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/AnalyticsEvent.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/AnalyticsEvent.java
@@ -39,7 +39,7 @@ public class AnalyticsEvent {
     private static final String XML_ATTRIBUTE_KEY = "key";
     private static final String XML_ATTRIBUTE_VALUE = "value";
 
-    private enum System {
+    public enum System {
         ADOBE, UNKNOWN;
 
         @NonNull
@@ -92,6 +92,28 @@ public class AnalyticsEvent {
     private Trigger mTrigger = Trigger.DEFAULT;
     @NonNull
     private Map<String, String> mAttributes = ImmutableMap.of();
+
+    public String getAction() {
+        return mAction;
+    }
+
+    @NonNull
+    public Map<String, String> getAttributes() {
+        return mAttributes;
+    }
+
+    public boolean isTriggerType(final Trigger... types) {
+        for (final Trigger type : types) {
+            if (mTrigger == type) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isForSystem(@NonNull final System system) {
+        return mSystems.contains(system);
+    }
 
     @NonNull
     @WorkerThread

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/AnalyticsEvent.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/AnalyticsEvent.java
@@ -1,0 +1,173 @@
+package org.cru.godtools.tract.model;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
+import android.text.TextUtils;
+
+import com.annimon.stream.Stream;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import org.ccci.gto.android.common.util.NumberUtils;
+import org.ccci.gto.android.common.util.XmlPullParserUtils;
+import org.jetbrains.annotations.Contract;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.cru.godtools.tract.Constants.XMLNS_ANALYTICS;
+
+public class AnalyticsEvent {
+    public static final String XML_EVENTS = "events";
+    private static final String XML_EVENT = "event";
+    private static final String XML_ACTION = "action";
+    private static final String XML_DELAY = "delay";
+    private static final String XML_SYSTEM = "system";
+    private static final String XML_SYSTEM_ADOBE = "adobe";
+    private static final String XML_TRIGGER = "trigger";
+    private static final String XML_TRIGGER_SELECTED = "selected";
+    private static final String XML_TRIGGER_VISIBLE = "visible";
+    private static final String XML_TRIGGER_HIDDEN = "hidden";
+    private static final String XML_ATTRIBUTE = "attribute";
+    private static final String XML_ATTRIBUTE_KEY = "key";
+    private static final String XML_ATTRIBUTE_VALUE = "value";
+
+    private enum System {
+        ADOBE, UNKNOWN;
+
+        @NonNull
+        static Collection<System> parseMultiple(@Nullable final String systems) {
+            return Sets.immutableEnumSet(
+                    Stream.of(TextUtils.split(systems, "\\s"))
+                            .map(system -> {
+                                switch (Strings.nullToEmpty(system)) {
+                                    case XML_SYSTEM_ADOBE:
+                                        return ADOBE;
+                                    default:
+                                        return UNKNOWN;
+                                }
+                            })
+                            .filterNot(UNKNOWN::equals)
+                            .distinct()
+                            .toList()
+            );
+        }
+    }
+
+    public enum Trigger {
+        SELECTED, VISIBLE, HIDDEN, DEFAULT, UNKNOWN;
+
+        @Nullable
+        @Contract("_,!null -> !null")
+        static Trigger parse(@Nullable final String trigger, @Nullable final Trigger defValue) {
+            if (trigger != null) {
+                switch (trigger) {
+                    case XML_TRIGGER_SELECTED:
+                        return SELECTED;
+                    case XML_TRIGGER_VISIBLE:
+                        return VISIBLE;
+                    case XML_TRIGGER_HIDDEN:
+                        return HIDDEN;
+                    default:
+                        return UNKNOWN;
+                }
+            }
+
+            return defValue;
+        }
+    }
+
+    private String mAction;
+    private int mDelay = 0;
+    @NonNull
+    private Collection<System> mSystems = ImmutableSet.of();
+    @NonNull
+    private Trigger mTrigger = Trigger.DEFAULT;
+    @NonNull
+    private Map<String, String> mAttributes = ImmutableMap.of();
+
+    @NonNull
+    @WorkerThread
+    public static Collection<AnalyticsEvent> fromEventsXml(@NonNull final XmlPullParser parser)
+            throws XmlPullParserException, IOException {
+        parser.require(XmlPullParser.START_TAG, XMLNS_ANALYTICS, XML_EVENTS);
+
+        // process any child elements
+        final ImmutableList.Builder<AnalyticsEvent> events = ImmutableList.builder();
+        while (parser.next() != XmlPullParser.END_TAG) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+
+            // process recognized nodes
+            switch (parser.getNamespace()) {
+                case XMLNS_ANALYTICS:
+                    switch (parser.getName()) {
+                        case XML_EVENT:
+                            events.add(AnalyticsEvent.fromXml(parser));
+                            continue;
+                    }
+                    break;
+            }
+
+            // skip unrecognized nodes
+            XmlPullParserUtils.skipTag(parser);
+        }
+
+        // return any events we parsed
+        return events.build();
+    }
+
+    @NonNull
+    @WorkerThread
+    public static AnalyticsEvent fromXml(@NonNull final XmlPullParser parser)
+            throws XmlPullParserException, IOException {
+        return new AnalyticsEvent().parse(parser);
+    }
+
+    @NonNull
+    @WorkerThread
+    private AnalyticsEvent parse(@NonNull final XmlPullParser parser) throws IOException, XmlPullParserException {
+        parser.require(XmlPullParser.START_TAG, XMLNS_ANALYTICS, XML_EVENT);
+
+        mAction = parser.getAttributeValue(null, XML_ACTION);
+        mDelay = NumberUtils.toInteger(parser.getAttributeValue(null, XML_DELAY), mDelay);
+        mSystems = System.parseMultiple(parser.getAttributeValue(null, XML_SYSTEM));
+        mTrigger = Trigger.parse(parser.getAttributeValue(null, XML_TRIGGER), mTrigger);
+
+        // process any child elements
+        final ImmutableMap.Builder<String, String> attributes = ImmutableMap.builder();
+        while (parser.next() != XmlPullParser.END_TAG) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+
+            // process recognized nodes
+            switch (parser.getNamespace()) {
+                case XMLNS_ANALYTICS:
+                    switch (parser.getName()) {
+                        case XML_ATTRIBUTE:
+                            final String key = parser.getAttributeValue(null, XML_ATTRIBUTE_KEY);
+                            final String value = parser.getAttributeValue(null, XML_ATTRIBUTE_VALUE);
+                            attributes.put(key, Strings.nullToEmpty(value));
+                            XmlPullParserUtils.skipTag(parser);
+                            continue;
+                    }
+                    break;
+            }
+
+            // skip unrecognized nodes
+            XmlPullParserUtils.skipTag(parser);
+        }
+        mAttributes = attributes.build();
+
+        return this;
+    }
+}

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Base.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Base.java
@@ -15,10 +15,12 @@ import com.annimon.stream.Stream;
 
 import org.cru.godtools.base.model.Event;
 import org.cru.godtools.tract.R;
+import org.cru.godtools.tract.analytics.model.ContentAnalyticsActionEvent;
 import org.cru.godtools.tract.model.Text.Align;
 import org.greenrobot.eventbus.EventBus;
 import org.xmlpull.v1.XmlPullParser;
 
+import java.util.Collection;
 import java.util.Set;
 
 import butterknife.ButterKnife;
@@ -227,6 +229,17 @@ abstract class Base {
                     .map(builder::id)
                     .map(Event.Builder::build)
                     .forEach(EventBus.getDefault()::post);
+        }
+
+        final void triggerAnalyticsEvents(final Collection<AnalyticsEvent> events,
+                                          final AnalyticsEvent.Trigger... types) {
+            Stream.of(events)
+                    .filter(e -> e.isTriggerType(types))
+                    .forEach(this::sendAnalyticsEvent);
+        }
+
+        private void sendAnalyticsEvent(@NonNull final AnalyticsEvent event) {
+            EventBus.getDefault().post(new ContentAnalyticsActionEvent(event));
         }
 
         /**

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Button.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Button.java
@@ -21,17 +21,20 @@ import org.cru.godtools.analytics.AnalyticsService;
 import org.cru.godtools.base.model.Event;
 import org.cru.godtools.tract.R;
 import org.cru.godtools.tract.R2;
+import org.cru.godtools.tract.model.AnalyticsEvent.Trigger;
 import org.cru.godtools.tract.model.Text.Align;
 import org.jetbrains.annotations.Contract;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.OnClick;
 
+import static org.cru.godtools.tract.Constants.XMLNS_ANALYTICS;
 import static org.cru.godtools.tract.Constants.XMLNS_CONTENT;
 import static org.cru.godtools.tract.model.Text.XML_TEXT;
 
@@ -67,6 +70,9 @@ public final class Button extends Content implements Styles {
     @Nullable
     @ColorInt
     private Integer mColor;
+
+    @NonNull
+    Collection<AnalyticsEvent> mAnalyticsEvents = ImmutableSet.of();
 
     @NonNull
     Type mType = Type.DEFAULT;
@@ -125,6 +131,13 @@ public final class Button extends Content implements Styles {
 
             // process recognized nodes
             switch (parser.getNamespace()) {
+                case XMLNS_ANALYTICS:
+                    switch (parser.getName()) {
+                        case AnalyticsEvent.XML_EVENTS:
+                            mAnalyticsEvents = AnalyticsEvent.fromEventsXml(parser);
+                            continue;
+                    }
+                    break;
                 case XMLNS_CONTENT:
                     switch (parser.getName()) {
                         case XML_TEXT:
@@ -171,6 +184,8 @@ public final class Button extends Content implements Styles {
         @OnClick(R2.id.button)
         void click() {
             if (mModel != null) {
+                triggerAnalyticsEvents(mModel.mAnalyticsEvents, Trigger.SELECTED, Trigger.DEFAULT);
+
                 switch (mModel.mType) {
                     case URL:
                         if (mModel.mUrl != null) {

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Link.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Link.java
@@ -13,20 +13,26 @@ import org.ccci.gto.android.common.util.XmlPullParserUtils;
 import org.cru.godtools.base.model.Event;
 import org.cru.godtools.tract.R;
 import org.cru.godtools.tract.R2;
+import org.cru.godtools.tract.model.AnalyticsEvent.Trigger;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.OnClick;
 
+import static org.cru.godtools.tract.Constants.XMLNS_ANALYTICS;
 import static org.cru.godtools.tract.Constants.XMLNS_CONTENT;
 import static org.cru.godtools.tract.model.Text.XML_TEXT;
 
 public final class Link extends Content {
     static final String XML_LINK = "link";
+
+    @NonNull
+    Collection<AnalyticsEvent> mAnalyticsEvents = ImmutableSet.of();
 
     @NonNull
     Set<Event.Id> mEvents = ImmutableSet.of();
@@ -58,6 +64,13 @@ public final class Link extends Content {
 
             // process recognized nodes
             switch (parser.getNamespace()) {
+                case XMLNS_ANALYTICS:
+                    switch (parser.getName()) {
+                        case AnalyticsEvent.XML_EVENTS:
+                            mAnalyticsEvents = AnalyticsEvent.fromEventsXml(parser);
+                            continue;
+                    }
+                    break;
                 case XMLNS_CONTENT:
                     switch (parser.getName()) {
                         case XML_TEXT:
@@ -108,6 +121,7 @@ public final class Link extends Content {
         void click() {
             if (mModel != null) {
                 sendEvents(mModel.mEvents);
+                triggerAnalyticsEvents(mModel.mAnalyticsEvents, Trigger.SELECTED, Trigger.DEFAULT);
             }
         }
     }

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Tab.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Tab.java
@@ -6,16 +6,20 @@ import android.support.annotation.UiThread;
 import android.view.ViewGroup;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.ccci.gto.android.common.util.XmlPullParserUtils;
 import org.cru.godtools.tract.R;
+import org.cru.godtools.tract.model.AnalyticsEvent.Trigger;
 import org.cru.godtools.tract.model.Tabs.TabsViewHolder;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
+import static org.cru.godtools.tract.Constants.XMLNS_ANALYTICS;
 import static org.cru.godtools.tract.Constants.XMLNS_CONTENT;
 
 public final class Tab extends Base implements Parent {
@@ -23,6 +27,9 @@ public final class Tab extends Base implements Parent {
     private static final String XML_LABEL = "label";
 
     private final int mPosition;
+
+    @NonNull
+    Collection<AnalyticsEvent> mAnalyticsEvents = ImmutableSet.of();
 
     @Nullable
     private Text mLabel;
@@ -70,6 +77,13 @@ public final class Tab extends Base implements Parent {
 
             // process recognized nodes
             switch (parser.getNamespace()) {
+                case XMLNS_ANALYTICS:
+                    switch (parser.getName()) {
+                        case AnalyticsEvent.XML_EVENTS:
+                            mAnalyticsEvents = AnalyticsEvent.fromEventsXml(parser);
+                            continue;
+                    }
+                    break;
                 case XMLNS_CONTENT:
                     switch (parser.getName()) {
                         case XML_LABEL:
@@ -104,6 +118,12 @@ public final class Tab extends Base implements Parent {
     public static final class TabViewHolder extends ParentViewHolder<Tab> {
         TabViewHolder(@NonNull final ViewGroup parent, @Nullable final TabsViewHolder parentViewHolder) {
             super(Tab.class, parent, R.layout.tract_content_paragraph, parentViewHolder);
+        }
+
+        public void trackSelectedAnalyticsEvents() {
+            if (mModel != null) {
+                triggerAnalyticsEvents(mModel.mAnalyticsEvents, Trigger.SELECTED, Trigger.DEFAULT);
+            }
         }
     }
 }

--- a/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Tabs.java
+++ b/library/tract-renderer/src/main/java/org/cru/godtools/tract/model/Tabs.java
@@ -92,6 +92,8 @@ final class Tabs extends Content {
         @BindView(R2.id.tab)
         FrameLayout mTabContent;
 
+        boolean mBinding = false;
+
         @NonNull
         private TabViewHolder[] mTabContentViewHolders = EMPTY_TAB_VIEW_HOLDERS;
         private final Pools.Pool<TabViewHolder> mRecycledTabViewHolders = new Pools.SimplePool<>(5);
@@ -103,6 +105,7 @@ final class Tabs extends Content {
 
         /* BEGIN lifecycle */
 
+        @UiThread
         @Override
         void onBind() {
             super.onBind();
@@ -111,7 +114,10 @@ final class Tabs extends Content {
 
         @Override
         public void onTabSelected(@NonNull final TabLayout.Tab tab) {
-            showTabContent(tab.getPosition());
+            final TabViewHolder holder = showTabContent(tab.getPosition());
+            if (!mBinding) {
+                holder.trackSelectedAnalyticsEvents();
+            }
         }
 
         @Override
@@ -128,6 +134,8 @@ final class Tabs extends Content {
         }
 
         private void bindTabs() {
+            mBinding = true;
+
             // remove all the old tabs
             mTabs.removeAllTabs();
             Stream.of(mTabContentViewHolders)
@@ -163,6 +171,8 @@ final class Tabs extends Content {
                     mTabs.addTab(tab2);
                 }
             }
+
+            mBinding = false;
         }
 
         @NonNull
@@ -175,12 +185,13 @@ final class Tabs extends Content {
             return holder;
         }
 
-        private void showTabContent(final int position) {
+        private TabViewHolder showTabContent(final int position) {
             final TabViewHolder holder = mTabContentViewHolders[position];
             if (holder.mRoot.getParent() != mTabContent) {
                 mTabContent.removeAllViews();
                 mTabContent.addView(holder.mRoot);
             }
+            return holder;
         }
     }
 }


### PR DESCRIPTION
Adds support for parsing and triggering the analytics events XML for tracts. This PR only implements analytics events triggered by "selection" behavior for tabs, buttons, and links. It does not support card visibility triggered events yet.

Events fired on card visibility triggers are going to take more thorough changes due to the need to monitor state and cancel delayed events if the visibility state changes. I'm going to do this in a separate PR once I figure out the best path to implement it.