### PR TITLE
Don't require location hardware

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
         android:name="${applicationId}.permission.C2D_MESSAGE"
         android:maxSdkVersion="22" />
 
+    <uses-feature
+        android:name="android.hardware.location"
+        android:required="false" />
 
     <application
         android:name=".GodToolsApplication"


### PR DESCRIPTION
The legacy location permission we are maintaining adds a location hardware requirement that we don't want to actually enforce