### PR TITLE
don't restrict Modal orientation to prevent crash on 8.0.0

### DIFF
--- a/library/tract-renderer/src/main/AndroidManifest.xml
+++ b/library/tract-renderer/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
 
         <activity
             android:name=".activity.ModalActivity"
-            android:screenOrientation="userPortrait"
+            android:screenOrientation="user"
             android:theme="@style/Theme.GodTools.Tract.Activity.Modal" />
     </application>
 </manifest>


### PR DESCRIPTION
https://fabric.io/cru/android/apps/org.keynote.godtools.android/issues/5af9be3a11e9fa0aa58b13fa