### PR TITLE
always call `onBind()`

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/model/Base.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/model/Base.java
@@ -225,11 +225,8 @@ abstract class Base {
             if (model == null) {
                 markHidden();
             }
-            final T old = mModel;
             mModel = model;
-            if (old != mModel) {
-                onBind();
-            }
+            onBind();
         }
 
         public final void markVisible() {


### PR DESCRIPTION
we can't assume that onBind() will evaluate the same way because the base object didn't change. Also, this fixes an initialization bug where we bind `null` to the view holder before anything else is bound.