### PR TITLE
Fix Snowplow Screen View URIs

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsScreenEvent.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsScreenEvent.java
@@ -7,7 +7,7 @@ import android.support.annotation.Nullable;
 import java.util.Locale;
 
 public class AnalyticsScreenEvent extends AnalyticsBaseEvent {
-    private static final String SNOWPLOW_CONTENT_SCORING_URI_PATH_SCREEN = "screen_view";
+    private static final String SNOWPLOW_CONTENT_SCORING_URI_PATH_SCREEN = "screenview";
 
     /* Screen event names */
     public static final String SCREEN_HOME = "Home";


### PR DESCRIPTION
The `screen_view` portion of the URI was being used as the `host`, in which underscore is an invalid character. This led to the data not getting through to Redshift. This should fix any data we are sending going forward. The other data will need to be fixed using SQL.