### PR TITLE
Fix Snowplow URIs

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.java
@@ -61,7 +61,7 @@ public class AnalyticsActionEvent extends AnalyticsBaseEvent {
     @Override
     public Uri.Builder getSnowPlowContentScoringUri() {
         return super.getSnowPlowContentScoringUri()
-                .appendPath(SNOWPLOW_CONTENT_SCORING_URI_PATH_ACTION)
+                .authority(SNOWPLOW_CONTENT_SCORING_URI_PATH_ACTION)
                 .appendPath(getCategory())
                 .appendPath(getAction());
     }

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsScreenEvent.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsScreenEvent.java
@@ -45,7 +45,7 @@ public class AnalyticsScreenEvent extends AnalyticsBaseEvent {
     @Override
     public Uri.Builder getSnowPlowContentScoringUri() {
         return super.getSnowPlowContentScoringUri()
-                .appendPath(SNOWPLOW_CONTENT_SCORING_URI_PATH_SCREEN)
+                .authority(SNOWPLOW_CONTENT_SCORING_URI_PATH_SCREEN)
                 .appendPath(getScreen());
     }
 }


### PR DESCRIPTION
This PR fixes an issue where we were sending URIs like `godtools:/screenview/...` to snowplow instead of `godtools://screenview/...`.