### PR TITLE
Checkstyle updates

### DIFF
--- a/analysis/checkstyle/checkstyle.xml
+++ b/analysis/checkstyle/checkstyle.xml
@@ -86,6 +86,11 @@
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->
         <module name="GenericWhitespace"/>
         <module name="EmptyForIteratorPad"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true" />
+            <property name="allowMultipleEmptyLines" value="false" />
+            <property name="allowMultipleEmptyLinesInsideClassMembers" value="false" />
+        </module>
         <module name="MethodParamPad"/>
         <module name="NoWhitespaceAfter"/>
         <module name="NoWhitespaceBefore"/>

--- a/app/src/main/java/org/cru/godtools/adapter/ToolsAdapter.java
+++ b/app/src/main/java/org/cru/godtools/adapter/ToolsAdapter.java
@@ -55,6 +55,7 @@ public class ToolsAdapter extends CursorAdapter<ToolsAdapter.ToolViewHolder>
     public static final String COL_PRIMARY_LANGUAGE = "primary_language";
     public static final String COL_PARALLEL_LANGUAGE = "parallel_language";
     public static final String COL_DEFAULT_LANGUAGE = "default_language";
+
     public interface Callbacks {
         void onToolInfo(@Nullable String code);
 

--- a/library/analytics/src/debug/java/org/cru/godtools/analytics/TimberAnalyticsService.java
+++ b/library/analytics/src/debug/java/org/cru/godtools/analytics/TimberAnalyticsService.java
@@ -21,6 +21,7 @@ public class TimberAnalyticsService implements AnalyticsService {
 
     @Nullable
     private static TimberAnalyticsService sInstance;
+
     @NonNull
     public static synchronized TimberAnalyticsService getInstance() {
         if (sInstance == null) {

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/AdobeAnalyticsService.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/AdobeAnalyticsService.java
@@ -1,5 +1,6 @@
 package org.cru.godtools.analytics;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -74,7 +75,9 @@ public final class AdobeAnalyticsService implements AnalyticsService {
     }
 
     @Nullable
+    @SuppressLint("StaticFieldLeak")
     private static AdobeAnalyticsService sInstance;
+
     @NonNull
     public static synchronized AdobeAnalyticsService getInstance(@NonNull final Context context) {
         if (sInstance == null) {

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/AnalyticsDispatcher.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/AnalyticsDispatcher.java
@@ -27,6 +27,7 @@ public final class AnalyticsDispatcher implements InvocationHandler {
 
     @Nullable
     private static AnalyticsDispatcher sInstance;
+
     @NonNull
     public static synchronized AnalyticsDispatcher getInstance(@NonNull final Context context) {
         if (sInstance == null) {

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/GoogleAnalyticsService.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/GoogleAnalyticsService.java
@@ -42,6 +42,7 @@ class GoogleAnalyticsService implements AnalyticsService {
 
     @Nullable
     private static GoogleAnalyticsService sInstance;
+
     @NonNull
     static synchronized GoogleAnalyticsService getInstance(@NonNull final Context context) {
         if (sInstance == null) {

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/SnowplowAnalyticsService.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/SnowplowAnalyticsService.java
@@ -79,6 +79,7 @@ public class SnowplowAnalyticsService {
 
     @Nullable
     private static SnowplowAnalyticsService sInstance;
+
     @NonNull
     @AnyThread
     public static synchronized SnowplowAnalyticsService getInstance(@NonNull final Context context) {

--- a/library/api/src/main/java/org/cru/godtools/api/GodToolsApi.java
+++ b/library/api/src/main/java/org/cru/godtools/api/GodToolsApi.java
@@ -74,6 +74,7 @@ public class GodToolsApi {
     @Nullable
     @SuppressLint("StaticFieldLeak")
     private static GodToolsApi sInstance;
+
     public static synchronized void configure(@NonNull final Context context, @NonNull final String apiUri) {
         if (sInstance != null) {
             throw new IllegalStateException("Attempted to configure GodToolsApi multiple times");
@@ -81,7 +82,6 @@ public class GodToolsApi {
 
         sInstance = new GodToolsApi(context.getApplicationContext(), apiUri);
     }
-
 
     @NonNull
     public static synchronized GodToolsApi getInstance(@NonNull final Context context) {

--- a/library/base/src/main/java/org/cru/godtools/base/Settings.java
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.java
@@ -32,6 +32,7 @@ public final class Settings {
 
     @Nullable
     private static Settings sInstance;
+
     @NonNull
     public static Settings getInstance(@NonNull final Context context) {
         synchronized (Settings.class) {

--- a/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.java
+++ b/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.java
@@ -58,6 +58,7 @@ public class GodToolsDao extends AbstractAsyncDao implements StreamDao {
 
     @Nullable
     private static GodToolsDao sInstance;
+
     @NonNull
     public static GodToolsDao getInstance(@NonNull final Context context) {
         synchronized (GodToolsDao.class) {

--- a/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDatabase.java
+++ b/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDatabase.java
@@ -86,6 +86,7 @@ public final class GodToolsDatabase extends WalSQLiteOpenHelper {
 
     @SuppressLint("StaticFieldLeak")
     private static GodToolsDatabase sInstance;
+
     @NonNull
     public static GodToolsDatabase getInstance(@NonNull final Context context) {
         synchronized (GodToolsDatabase.class) {

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.java
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.java
@@ -134,6 +134,7 @@ public final class GodToolsDownloadManager {
     @Nullable
     @SuppressLint("StaticFieldLeak")
     private static GodToolsDownloadManager sInstance;
+
     @NonNull
     @MainThread
     public static GodToolsDownloadManager getInstance(@NonNull final Context context) {

--- a/library/xml-model/src/androidTest/java/org/cru/godtools/xml/model/UtilsIT.java
+++ b/library/xml-model/src/androidTest/java/org/cru/godtools/xml/model/UtilsIT.java
@@ -4,12 +4,8 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.support.test.runner.AndroidJUnit4;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Map;
 
 import static org.cru.godtools.xml.model.Utils.parseColor;
 import static org.cru.godtools.xml.model.Utils.parseUrl;
@@ -30,15 +26,10 @@ public final class UtilsIT {
         assertThat(parseColor("akjsdf", Color.RED), is(Color.RED));
     }
 
-    private static final Map<String, Uri> TEST_URLS = ImmutableMap.<String, Uri>builder()
-            .put("https://www.example.com/path", Uri.parse("https://www.example.com/path"))
-            .put("www.example.com/path", Uri.parse("http://www.example.com/path"))
-            .put("mailto:someone@example.com", Uri.parse("mailto:someone@example.com"))
-            .build();
     @Test
     public void verifyParseUrl() throws Exception {
-        for (final Map.Entry<String, Uri> url : TEST_URLS.entrySet()) {
-            assertThat(parseUrl(url.getKey(), null), is(url.getValue()));
-        }
+        assertThat(parseUrl("https://www.example.com/path", null), is(Uri.parse("https://www.example.com/path")));
+        assertThat(parseUrl("www.example.com/path", null), is(Uri.parse("http://www.example.com/path")));
+        assertThat(parseUrl("mailto:someone@example.com", null), is(Uri.parse("mailto:someone@example.com")));
     }
 }

--- a/library/xml-model/src/main/java/org/cru/godtools/xml/service/ManifestManager.java
+++ b/library/xml-model/src/main/java/org/cru/godtools/xml/service/ManifestManager.java
@@ -58,6 +58,7 @@ public class ManifestManager {
     @Nullable
     @SuppressLint("StaticFieldLeak")
     private static ManifestManager sInstance;
+
     @NonNull
     public static synchronized ManifestManager getInstance(@NonNull final Context context) {
         if (sInstance == null) {

--- a/ui/articles-aem-renderer/src/androidTest/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabaseTest.java
+++ b/ui/articles-aem-renderer/src/androidTest/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabaseTest.java
@@ -44,7 +44,6 @@ public class ArticleRoomDatabaseTest {
         mAttachmentDao = db.attachmentDao();
         mAssociationDao = db.manifestAssociationDao();
 
-
         for (int i = 0; i < 12; i++) {
             Article article = new Article();
 
@@ -63,7 +62,6 @@ public class ArticleRoomDatabaseTest {
             date.getTimezoneOffset();
             article.mTitle = " The title = " + i;
             mArticleDao.insertArticle(article);
-
         }
 
         mSavedArticles = mArticleDao.getTestableAllArticles();
@@ -82,7 +80,6 @@ public class ArticleRoomDatabaseTest {
 
             mAttachmentDao.insertAttachment(attachment);
         }
-
     }
 
     @After
@@ -95,7 +92,6 @@ public class ArticleRoomDatabaseTest {
         assertTrue("No article was saved.", mSavedArticles.size() > 0);
     }
 
-
     @Test
     public void verifyArticleHasAttachment() {
         for (Article article : mSavedArticles) {
@@ -103,7 +99,6 @@ public class ArticleRoomDatabaseTest {
                        mAttachmentDao.getTestableAttachmentsByArticle(article.mId).size() > 0);
         }
     }
-
 
     @Test
     public void verifyManifestHasArticles() {

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.java
@@ -8,7 +8,6 @@ import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 import android.support.annotation.VisibleForTesting;
 
-
 import org.cru.godtools.articles.aem.model.Article;
 
 import java.util.List;
@@ -48,7 +47,7 @@ interface ArticleDao {
     LiveData<List<Article>> getAllArticles();
 
     //region Testable (Non Live Data)
-    @VisibleForTesting()
+    @VisibleForTesting
     @Query("SELECT * FROM article_table")
     List<Article> getTestableAllArticles();
     //endregion

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.java
@@ -4,7 +4,6 @@ import android.arch.lifecycle.LiveData;
 import android.content.Context;
 import android.os.AsyncTask;
 
-
 import org.cru.godtools.articles.aem.model.Article;
 
 import java.util.List;
@@ -54,7 +53,4 @@ public class ArticleRepository {
         /* This is called in AsyncTask to insure it doesn't run on UI thread */
         AsyncTask.execute(() -> mArticleDao.deleteArticles(articles));
     }
-
-
-
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
@@ -1,4 +1,4 @@
-package org.cru.godtools.articles.aem.db;;
+package org.cru.godtools.articles.aem.db;
 
 import android.arch.persistence.room.Database;
 import android.arch.persistence.room.Room;
@@ -9,7 +9,6 @@ import org.cru.godtools.articles.aem.model.Article;
 import org.cru.godtools.articles.aem.model.Attachment;
 import org.cru.godtools.articles.aem.model.ManifestAssociation;
 
-
 /**
  * This class is used to create the database table.
  *
@@ -17,13 +16,6 @@ import org.cru.godtools.articles.aem.model.ManifestAssociation;
  */
 @Database(entities = { Article.class, ManifestAssociation.class, Attachment.class }, version = 1)
 public abstract class ArticleRoomDatabase extends RoomDatabase {
-
-    public abstract ArticleDao articleDao();
-
-    public abstract ManifestAssociationDao manifestAssociationDao();
-
-    public abstract AttachmentDao attachmentDao();
-
     private static ArticleRoomDatabase instance;
 
     /**
@@ -45,4 +37,9 @@ public abstract class ArticleRoomDatabase extends RoomDatabase {
         return instance;
     }
 
+    public abstract ArticleDao articleDao();
+
+    public abstract ManifestAssociationDao manifestAssociationDao();
+
+    public abstract AttachmentDao attachmentDao();
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AttachmentRepository.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AttachmentRepository.java
@@ -4,7 +4,6 @@ import android.arch.lifecycle.LiveData;
 import android.content.Context;
 import android.os.AsyncTask;
 
-
 import org.cru.godtools.articles.aem.model.Attachment;
 
 import java.util.List;
@@ -15,7 +14,6 @@ import java.util.List;
  * @author Gyasi Story
  */
 public class AttachmentRepository {
-
     private final AttachmentDao mAttachmentDao;
 
     public AttachmentRepository(Context context) {

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ManifestAssociationDao.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ManifestAssociationDao.java
@@ -8,7 +8,6 @@ import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
 import android.support.annotation.VisibleForTesting;
 
-
 import org.cru.godtools.articles.aem.model.Article;
 import org.cru.godtools.articles.aem.model.ManifestAssociation;
 

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/view_model/ArticleViewModel.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/view_model/ArticleViewModel.java
@@ -5,7 +5,6 @@ import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
 import android.support.annotation.NonNull;
 
-
 import org.cru.godtools.articles.aem.db.ArticleRepository;
 import org.cru.godtools.articles.aem.db.AttachmentRepository;
 import org.cru.godtools.articles.aem.db.ManifestAssociationRepository;
@@ -15,7 +14,6 @@ import org.cru.godtools.articles.aem.model.Attachment;
 import java.util.List;
 
 public class ArticleViewModel extends AndroidViewModel {
-
     private final ArticleRepository mArticleRepository;
     private final AttachmentRepository mAttchReposistory;
     private final ManifestAssociationRepository mManifestRepository;
@@ -32,7 +30,6 @@ public class ArticleViewModel extends AndroidViewModel {
         mArticleRepository.insertArticle(article);
     }
 
-
     public void deleteArticles(Article... articles) {
         mArticleRepository.deleteArticles(articles);
     }
@@ -40,7 +37,6 @@ public class ArticleViewModel extends AndroidViewModel {
     public LiveData<List<Article>> getArticles() {
         return mArticleRepository.getAllArticles();
     }
-
 
     public LiveData<List<Article>> getArticlesByManifest(String manifestID) {
         return mManifestRepository.getArticlesByManifestID(manifestID);

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.java
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.java
@@ -14,6 +14,7 @@ import uk.co.chrisjenx.calligraphy.CalligraphyUtils;
 import uk.co.chrisjenx.calligraphy.TypefaceUtils;
 
 public final class LocaleTypefaceUtils {
+    @SuppressWarnings("checkstyle:EmptyLineSeparator")
     private static final Map<Locale, String> TYPEFACES;
     static {
         final ImmutableMap.Builder<Locale, String> typefaceBuilder = ImmutableMap.builder();

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.java
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.java
@@ -104,6 +104,7 @@ public final class GodToolsShortcutManager implements SharedPreferences.OnShared
     @Nullable
     @SuppressLint("StaticFieldLeak")
     private static GodToolsShortcutManager sInstance;
+
     @NonNull
     @MainThread
     public static GodToolsShortcutManager getInstance(@NonNull final Context context) {
@@ -116,7 +117,7 @@ public final class GodToolsShortcutManager implements SharedPreferences.OnShared
         return sInstance;
     }
 
-    /* BEGIN lifecycle */
+    // region Lifecycle Events
 
     /**
      * Called when the device locale was updated.
@@ -181,9 +182,9 @@ public final class GodToolsShortcutManager implements SharedPreferences.OnShared
         }
     }
 
-    /* END lifecycle */
+    // endregion Lifecycle Events
 
-    /* BEGIN Pending shortcut */
+    // region Pending shortcut
 
     @AnyThread
     public boolean canPinToolShortcut(@Nullable final Tool tool) {
@@ -285,7 +286,7 @@ public final class GodToolsShortcutManager implements SharedPreferences.OnShared
         }
     }
 
-    /* END Pending shortcut */
+    // endregion Pending shortcut
 
     @AnyThread
     private void enqueueUpdateShortcuts(final boolean immediate) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/service/FollowupService.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/service/FollowupService.java
@@ -41,6 +41,7 @@ public final class FollowupService {
     @Nullable
     @SuppressLint("StaticFieldLeak")
     private static FollowupService sInstance;
+
     @NonNull
     @MainThread
     public static FollowupService start(@NonNull final Context context) {


### PR DESCRIPTION
This updates the checkstyle rules to enforce an `EmptyLineSeparator` policy.

The rationale behind the rule is to make whitespace more consistent across our code base. Extra whitespace lines may provide benefit while you are working on a feature to keep your modified code separate from existing code, but once you merge that code I feel it reduces readability and utilizing regions is a better mechanism for grouping related functionality together.

In addition, constant thrashing in number of empty lines between logic messes with git history, which has an impact on merging diverging branches back together.