### PR TITLE
Multidex debug builds only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,14 @@ configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.start
             lintOptions {
                 lintConfig rootProject.file("analysis/lint/lint.xml")
             }
+
+            buildTypes {
+                debug {
+                    // HACK: Unfortunately we cannot target androidTest builds with multidex only, so we have to target
+                    // HACK: all debug builds so that androidTest works when multidex is required.
+                    multiDexEnabled true
+                }
+            }
         }
 
         dependencies {

--- a/ui/articles-aem-renderer/build.gradle
+++ b/ui/articles-aem-renderer/build.gradle
@@ -1,9 +1,3 @@
-android {
-    defaultConfig {
-        multiDexEnabled true
-    }
-}
-
 dependencies {
 
     implementation "android.arch.lifecycle:extensions:${deps.androidLifecycle}"


### PR DESCRIPTION
This PR configures multidex for debug builds only.

We were already utilizing Multi-Dex with debug app builds, and androidTest runs against debug builds only. So, we leverage these facts to enable multidex for all library androidTest builds and not enable multidex for release builds