### PR TITLE
fix androidTest issue on older versions of android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.start
                 targetSdkVersion targetSdk
 
                 testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+                multiDexKeepProguard rootProject.file('multidex-keep.pro')
             }
 
             compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 org.gradle.jvmargs=-Xmx2048M
 android.databinding.enableV2=true
 
-# workaround for https://issuetracker.google.com/u/0/issues/78108767
-android.enableD8MainDexList=false
-
 # maven POM attributes
 POM_SCM_CONNECTION = git@github.com:CruGlobal/godtools-android.git
 

--- a/multidex-keep.pro
+++ b/multidex-keep.pro
@@ -1,0 +1,5 @@
+# Keep unit tests in the main dex file
+# see: https://issuetracker.google.com/u/0/issues/78108767
+-keepclasseswithmembers class * {
+    @org.junit.* *;
+}


### PR DESCRIPTION
This is accomplished by including any class containing junit test related annotations in the main dex file