### PR TITLE
fix a number format for the Albanian translation

### DIFF
--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -31,7 +31,7 @@
     <string name="label_tools_about">Rreth</string>
     <plurals name="label_tools_languages">
         <item quantity="one">%1$,d gjuhë</item>
-        <item quantity="other">%1,d e gjuhëve</item>
+        <item quantity="other">%1$,d e gjuhëve</item>
     </plurals>
     <!-- Language Selection UI -->
     <string name="feature_discovery_title_language_settings">60+ gjuhët</string>


### PR DESCRIPTION
Fixes https://fabric.io/cru/android/apps/org.keynote.godtools.android/issues/5b5db3046007d59fcd220c28?time=last-ninety-days