### PR TITLE
Prune orphaned records

### DIFF
--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportDao.kt
@@ -35,6 +35,12 @@ interface AemImportDao {
     fun removeOldArticles(aemImportUri: Uri, currentArticleUris: List<@JvmSuppressWildcards Uri>)
 
     @WorkerThread
+    @Query("""
+        DELETE FROM aemImports
+        WHERE uri NOT IN (SELECT aemImportUri FROM translationAemImports)""")
+    fun removeOrphanedAemImports()
+
+    @WorkerThread
     @Query("SELECT * FROM aemImports WHERE uri = :uri")
     fun find(uri: Uri?): AemImport?
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
@@ -32,6 +32,9 @@ abstract class AemImportRepository internal constructor(private val db: ArticleR
             // update the last processed time
             updateLastProcessed(aemImport.uri, Date())
         }
+
+        // remove any orphaned articles
+        db.articleRepository().removeOrphanedArticles()
     }
 
     @Transaction

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
@@ -38,6 +38,6 @@ abstract class AemImportRepository internal constructor(private val db: ArticleR
     @WorkerThread
     open fun removeOrphanedAemImports() {
         db.aemImportDao().removeOrphanedAemImports()
-        db.articleDao().removeOrphanedArticles()
+        db.articleRepository().removeOrphanedArticles()
     }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
@@ -33,4 +33,11 @@ abstract class AemImportRepository internal constructor(private val db: ArticleR
             updateLastProcessed(aemImport.uri, Date())
         }
     }
+
+    @Transaction
+    @WorkerThread
+    open fun removeOrphanedAemImports() {
+        db.aemImportDao().removeOrphanedAemImports()
+        db.articleDao().removeOrphanedArticles()
+    }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
@@ -57,6 +57,11 @@ interface ArticleDao {
         WHERE articleUri = :articleUri AND resourceUri NOT IN (:currentResourceUris)""")
     fun removeOldResources(articleUri: Uri, currentResourceUris: List<@JvmSuppressWildcards Uri>)
 
+    @Query("""
+        DELETE FROM articles
+        WHERE uri NOT IN (SELECT articleUri FROM aemImportArticles)""")
+    fun removeOrphanedArticles()
+
     @WorkerThread
     @Query("SELECT * FROM articles WHERE uri = :uri")
     fun find(uri: Uri): Article?

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.kt
@@ -15,7 +15,7 @@ abstract class ArticleRepository internal constructor(private val db: ArticleRoo
 
     @Transaction
     @WorkerThread
-    fun removeOrphanedArticles() {
+    open fun removeOrphanedArticles() {
         db.articleDao().removeOrphanedArticles()
         db.resourceDao().removeOrphanedResources()
     }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRepository.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.articles.aem.db
 
 import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Transaction
+import android.support.annotation.WorkerThread
 import org.cru.godtools.articles.aem.model.Article
 
 @Dao
@@ -10,5 +11,12 @@ abstract class ArticleRepository internal constructor(private val db: ArticleRoo
     open fun updateContent(article: Article) {
         db.articleDao().updateContent(article.uri, article.contentUuid, article.content)
         db.resourceRepository().storeResources(article, article.mResources)
+    }
+
+    @Transaction
+    @WorkerThread
+    fun removeOrphanedArticles() {
+        db.articleDao().removeOrphanedArticles()
+        db.resourceDao().removeOrphanedResources()
     }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ResourceDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ResourceDao.kt
@@ -24,12 +24,20 @@ interface ResourceDao {
     fun updateLocalFile(uri: Uri, contentType: MediaType?, fileName: String?, downloadDate: Date?)
 
     @WorkerThread
+    @Query("""
+        DELETE FROM resources
+        WHERE uri NOT IN (SELECT uri FROM articleResources)""")
+    fun removeOrphanedResources()
+
+    @WorkerThread
     @Query("SELECT * FROM resources WHERE uri = :uri")
     fun find(uri: Uri): Resource?
 
+    @WorkerThread
     @Query("SELECT * FROM resources")
     fun getAll(): List<Resource>
 
+    @WorkerThread
     @Query("""
         SELECT r.*
         FROM resources AS r JOIN articleResources AS a ON a.resourceUri = r.uri

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/TranslationRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/TranslationRepository.kt
@@ -54,6 +54,6 @@ abstract class TranslationRepository internal constructor(private val db: Articl
         db.translationDao().all
                 .filterNot { valid.contains(it.key) }
                 .apply { db.translationDao().remove(this) }
-        db.aemImportDao().removeOrphanedAemImports()
+        db.aemImportRepository().removeOrphanedAemImports()
     }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/TranslationRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/TranslationRepository.kt
@@ -54,5 +54,6 @@ abstract class TranslationRepository internal constructor(private val db: Articl
         db.translationDao().all
                 .filterNot { valid.contains(it.key) }
                 .apply { db.translationDao().remove(this) }
+        db.aemImportDao().removeOrphanedAemImports()
     }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/fragment/AemArticleFragment.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/fragment/AemArticleFragment.java
@@ -27,6 +27,7 @@ import org.cru.godtools.articles.aem.service.AEMDownloadManger;
 import org.cru.godtools.base.tool.fragment.BaseToolFragment;
 import org.cru.godtools.base.ui.util.WebUrlLauncher;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -41,6 +42,8 @@ import timber.log.Timber;
 import static org.cru.godtools.articles.aem.Constants.EXTRA_ARTICLE;
 
 public class AemArticleFragment extends BaseToolFragment {
+    private static final String TAG = "AemArticleFragment";
+
     @BindView(R2.id.aem_article_web_view)
     WebView mWebView;
     private final ArticleWebViewClient mWebViewClient = new ArticleWebViewClient();
@@ -214,8 +217,14 @@ public class AemArticleFragment extends BaseToolFragment {
             InputStream data = null;
             try {
                 data = resource.getInputStream(requireContext());
+            } catch (final FileNotFoundException e) {
+                // the file wasn't found in the local cache directory. log the error and clear the local file state so
+                // it is downloaded again.
+                Timber.tag(TAG)
+                        .e(e, "Missing cached version of: %s", resource.getUri());
+                resourceDao.updateLocalFile(resource.getUri(), null, null, null);
             } catch (final IOException e) {
-                Timber.tag("AEMArticleFragment")
+                Timber.tag(TAG)
                         .d(e, "Error opening local file");
             }
             if (data == null) {

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Constants.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Constants.kt
@@ -1,0 +1,4 @@
+@file:JvmName("Constants")
+package org.cru.godtools.articles.aem.model
+
+const val TABLE_NAME_RESOURCE = "resources"

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Resource.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Resource.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.util.Date
 
-@Entity(tableName = "resources")
+@Entity(tableName = TABLE_NAME_RESOURCE)
 class Resource(@field:PrimaryKey val uri: Uri) {
     var contentType: MediaType? = null
     var localFileName: String? = null

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/service/AEMDownloadManger.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/service/AEMDownloadManger.java
@@ -510,17 +510,10 @@ public class AEMDownloadManger {
     private static final int PRIORITY_SYNC_AEM_IMPORT = -30;
     private static final int PRIORITY_DOWNLOAD_ARTICLE = -20;
 
-    abstract class UniqueUriBasedTask implements PriorityRunnable {
-        @NonNull
-        final Uri mUri;
-        volatile boolean mStarted = false;
+    abstract class UniqueTask implements PriorityRunnable {
         volatile boolean mForce = false;
-
+        volatile boolean mStarted = false;
         final SettableFuture<Boolean> mResult = SettableFuture.create();
-
-        UniqueUriBasedTask(@NonNull final Uri uri) {
-            mUri = uri;
-        }
 
         /**
          * Update the force flag for this task, but only before it has started. We never go from forcing the sync to not
@@ -551,6 +544,15 @@ public class AEMDownloadManger {
         abstract Object getLock();
 
         abstract boolean runTask();
+    }
+
+    abstract class UniqueUriBasedTask extends UniqueTask {
+        @NonNull
+        final Uri mUri;
+
+        UniqueUriBasedTask(@NonNull final Uri uri) {
+            mUri = uri;
+        }
     }
 
     class SyncAemImportTask extends UniqueUriBasedTask {


### PR DESCRIPTION
- Prunes any orphaned database objects that are no longer referenced (aem imports, articles, resources)
- has a low priority cleaner process that remove any cached files that are not referenced in the resources table