### PR TITLE
AEM tags support

### DIFF
--- a/library/xml-model/src/main/java/org/cru/godtools/xml/model/Category.java
+++ b/library/xml-model/src/main/java/org/cru/godtools/xml/model/Category.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.ccci.gto.android.common.util.XmlPullParserUtils;
 import org.xmlpull.v1.XmlPullParser;
@@ -13,6 +13,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.cru.godtools.xml.Constants.XMLNS_ARTICLE;
 import static org.cru.godtools.xml.Constants.XMLNS_MANIFEST;
@@ -32,7 +33,7 @@ public class Category extends Base {
     private String mBanner;
 
     @NonNull
-    private List<String> mAemTags = ImmutableList.of();
+    private Set<String> mAemTags = ImmutableSet.of();
 
     @NonNull
     @WorkerThread
@@ -61,7 +62,7 @@ public class Category extends Base {
     }
 
     @NonNull
-    public List<String> getAemTags() {
+    public Set<String> getAemTags() {
         return mAemTags;
     }
 
@@ -95,7 +96,7 @@ public class Category extends Base {
                     }
                     break;
             }
-            mAemTags = ImmutableList.copyOf(aemTags);
+            mAemTags = ImmutableSet.copyOf(aemTags);
 
             // skip unrecognized nodes
             XmlPullParserUtils.skipTag(parser);

--- a/library/xml-model/src/main/java/org/cru/godtools/xml/model/Category.java
+++ b/library/xml-model/src/main/java/org/cru/godtools/xml/model/Category.java
@@ -4,16 +4,22 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
+import com.google.common.collect.ImmutableList;
+
 import org.ccci.gto.android.common.util.XmlPullParserUtils;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.cru.godtools.xml.Constants.XMLNS_ARTICLE;
 import static org.cru.godtools.xml.Constants.XMLNS_MANIFEST;
 
 public class Category extends Base {
     static final String XML_CATEGORY = "category";
+    private static final String XML_AEM_TAG = "aem-tag";
     private static final String XML_ID = "id";
     private static final String XML_LABEL = "label";
     private static final String XML_BANNER = "banner";
@@ -24,6 +30,9 @@ public class Category extends Base {
     private Text mLabel;
     @Nullable
     private String mBanner;
+
+    @NonNull
+    private List<String> mAemTags = ImmutableList.of();
 
     @NonNull
     @WorkerThread
@@ -51,6 +60,11 @@ public class Category extends Base {
         return getResource(mBanner);
     }
 
+    @NonNull
+    public List<String> getAemTags() {
+        return mAemTags;
+    }
+
     @WorkerThread
     private Category parse(@NonNull final XmlPullParser parser) throws IOException, XmlPullParserException {
         parser.require(XmlPullParser.START_TAG, XMLNS_MANIFEST, XML_CATEGORY);
@@ -58,6 +72,7 @@ public class Category extends Base {
         mId = parser.getAttributeValue(null, XML_ID);
         mBanner = parser.getAttributeValue(null, XML_BANNER);
 
+        final List<String> aemTags = new ArrayList<>();
         while (parser.next() != XmlPullParser.END_TAG) {
             if (parser.getEventType() != XmlPullParser.START_TAG) {
                 continue;
@@ -72,7 +87,15 @@ public class Category extends Base {
                             continue;
                     }
                     break;
+                case XMLNS_ARTICLE:
+                    switch (parser.getName()) {
+                        case XML_AEM_TAG:
+                            aemTags.add(parser.getAttributeValue(null, XML_ID));
+                            break;
+                    }
+                    break;
             }
+            mAemTags = ImmutableList.copyOf(aemTags);
 
             // skip unrecognized nodes
             XmlPullParserUtils.skipTag(parser);

--- a/ui/article-renderer/build.gradle
+++ b/ui/article-renderer/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-picasso:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-recyclerview:${deps.gtoSupport}"
 
+    implementation "com.google.guava:guava:${deps.guava}"
     implementation "com.jakewharton:butterknife:${deps.butterknife}"
 
     annotationProcessor "com.jakewharton:butterknife-compiler:${deps.butterknife}"

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/fragment/ArticlesFragment.java
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/fragment/ArticlesFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 
 import com.annimon.stream.Optional;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.ccci.gto.android.common.support.v4.util.FragmentUtils;
@@ -235,7 +236,7 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
                 mTool = tool;
                 mLocale = locale;
                 mTags = tags;
-                mArticles = mAemDb.articleDao().getArticles(tool, locale, tags);
+                mArticles = mAemDb.articleDao().getArticles(tool, locale, ImmutableList.copyOf(tags));
             }
 
             return mArticles;

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/fragment/ArticlesFragment.java
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/fragment/ArticlesFragment.java
@@ -1,7 +1,8 @@
 package org.cru.godtools.article.fragment;
 
+import android.app.Application;
+import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -12,17 +13,22 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.annimon.stream.Optional;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+
 import org.ccci.gto.android.common.support.v4.util.FragmentUtils;
 import org.cru.godtools.article.R;
 import org.cru.godtools.article.R2;
 import org.cru.godtools.article.adapter.ArticlesAdapter;
-import org.cru.godtools.articles.aem.db.ArticleDao;
 import org.cru.godtools.articles.aem.db.ArticleRoomDatabase;
 import org.cru.godtools.articles.aem.model.Article;
 import org.cru.godtools.base.tool.fragment.BaseToolFragment;
+import org.cru.godtools.xml.model.Category;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import butterknife.BindView;
 
@@ -44,6 +50,9 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
     private /*final*/ String mCategory;
     @NonNull
     private /*final*/ ArticleListViewModel mViewModel;
+
+    @Nullable
+    private LiveData<List<Article>> mArticles;
 
     public static ArticlesFragment newInstance(@NonNull final String code, @NonNull final Locale locale,
                                                @Nullable final String category) {
@@ -90,6 +99,7 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
     protected void onManifestUpdated() {
         super.onManifestUpdated();
         updateArticlesViewManifest();
+        updateArticlesLiveData();
     }
 
     /**
@@ -114,15 +124,37 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
 
     // endregion LifeCycle Events
 
+    // region ViewModel methods
+
     private void setupViewModel() {
         mViewModel = ViewModelProviders.of(this).get(ArticleListViewModel.class);
+        updateArticlesLiveData();
+    }
 
-        if (mViewModel.articles == null) {
-            final ArticleDao articleDao = ArticleRoomDatabase.getInstance(requireContext()).articleDao();
-            mViewModel.articles = mCategory != null ? articleDao.getArticles(mTool, mLocale, mCategory) :
-                    articleDao.getArticles(mTool, mLocale);
+    private void updateArticlesLiveData() {
+        final LiveData<List<Article>> articles;
+        if (mCategory != null) {
+            // lookup AEM tags from the manifest category
+            final Set<String> tags = Optional.ofNullable(mManifest)
+                    .flatMap(m -> m.findCategory(mCategory))
+                    .map(Category::getAemTags)
+                    .orElseGet(ImmutableSet::of);
+            articles = mViewModel.getArticlesForTags(mTool, mLocale, tags);
+        } else {
+            // no category, so show all articles for this tool
+            articles = mViewModel.getArticles(mTool, mLocale);
+        }
+
+        if (articles != mArticles) {
+            if (mArticles != null) {
+                mArticles.removeObservers(this);
+            }
+            mArticles = articles;
+            updateArticlesViewArticles();
         }
     }
+
+    // endregion ViewModel methods
 
     // region ArticlesView
 
@@ -136,10 +168,10 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
 
             mArticlesAdapter = new ArticlesAdapter();
             mArticlesAdapter.setCallbacks(this);
-            mViewModel.articles.observe(this, mArticlesAdapter);
             mArticlesView.setAdapter(mArticlesAdapter);
 
             updateArticlesViewManifest();
+            updateArticlesViewArticles();
         }
     }
 
@@ -149,17 +181,72 @@ public class ArticlesFragment extends BaseToolFragment implements ArticlesAdapte
         }
     }
 
+    private void updateArticlesViewArticles() {
+        if (mArticlesAdapter != null && mArticles != null) {
+            mArticles.observe(this, mArticlesAdapter);
+        }
+    }
+
     private void cleanupArticlesView() {
         if (mArticlesAdapter != null) {
             mArticlesAdapter.setCallbacks(null);
-            mViewModel.articles.removeObserver(mArticlesAdapter);
+            if (mArticles != null) {
+                mArticles.removeObserver(mArticlesAdapter);
+            }
         }
         mArticlesAdapter = null;
     }
 
     // endregion ArticlesView
 
-    public static class ArticleListViewModel extends ViewModel {
-        LiveData<List<Article>> articles;
+    public static class ArticleListViewModel extends AndroidViewModel {
+        private final ArticleRoomDatabase mAemDb;
+
+        @Nullable
+        private String mTool;
+        @Nullable
+        private Locale mLocale;
+        @Nullable
+        private Set<String> mTags;
+        @Nullable
+        private LiveData<List<Article>> mArticles;
+
+        public ArticleListViewModel(@NonNull final Application application) {
+            super(application);
+            mAemDb = ArticleRoomDatabase.getInstance(application);
+        }
+
+        LiveData<List<Article>> getArticles(@NonNull final String tool, @NonNull final Locale locale) {
+            // re-initialize the articles LiveData if necessary
+            if (isArticlesLiveDataStale(tool, locale, null)) {
+                mTool = tool;
+                mLocale = locale;
+                mTags = null;
+                mArticles = mAemDb.articleDao().getArticles(tool, locale);
+            }
+
+            return mArticles;
+        }
+
+        LiveData<List<Article>> getArticlesForTags(@NonNull final String tool, @NonNull final Locale locale,
+                                                   @NonNull final Set<String> tags) {
+            // re-initialize the articles LiveData if necessary
+            if (isArticlesLiveDataStale(tool, locale, tags)) {
+                mTool = tool;
+                mLocale = locale;
+                mTags = tags;
+                mArticles = mAemDb.articleDao().getArticles(tool, locale, tags);
+            }
+
+            return mArticles;
+        }
+
+        private boolean isArticlesLiveDataStale(@NonNull final String tool, @NonNull final Locale locale,
+                                                @Nullable final Set<String> tags) {
+            return mArticles == null ||
+                    !Objects.equal(mTool, tool) ||
+                    !Objects.equal(mLocale, locale) ||
+                    !Objects.equal(tags, mTags);
+        }
     }
 }

--- a/ui/articles-aem-renderer/room-schemas/org.cru.godtools.articles.aem.db.ArticleRoomDatabase/7.json
+++ b/ui/articles-aem-renderer/room-schemas/org.cru.godtools.articles.aem.db.ArticleRoomDatabase/7.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 6,
-    "identityHash": "d08c813f2f5d73744bbd61e463a1a67f",
+    "version": 7,
+    "identityHash": "27c5151599f702d9e2c3ef3276c7d961",
     "entities": [
       {
         "tableName": "translations",
@@ -263,8 +263,8 @@
         "foreignKeys": []
       },
       {
-        "tableName": "categories",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleUri` TEXT NOT NULL, `category` TEXT NOT NULL, PRIMARY KEY(`articleUri`, `category`), FOREIGN KEY(`articleUri`) REFERENCES `articles`(`uri`) ON UPDATE RESTRICT ON DELETE CASCADE )",
+        "tableName": "articleTags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleUri` TEXT NOT NULL, `tag` TEXT NOT NULL, PRIMARY KEY(`articleUri`, `tag`), FOREIGN KEY(`articleUri`) REFERENCES `articles`(`uri`) ON UPDATE RESTRICT ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "articleUri",
@@ -273,8 +273,8 @@
             "notNull": true
           },
           {
-            "fieldPath": "category",
-            "columnName": "category",
+            "fieldPath": "tag",
+            "columnName": "tag",
             "affinity": "TEXT",
             "notNull": true
           }
@@ -282,7 +282,7 @@
         "primaryKey": {
           "columnNames": [
             "articleUri",
-            "category"
+            "tag"
           ],
           "autoGenerate": false
         },
@@ -395,7 +395,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"d08c813f2f5d73744bbd61e463a1a67f\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"27c5151599f702d9e2c3ef3276c7d961\")"
     ]
   }
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/AemImportRepository.kt
@@ -18,9 +18,9 @@ abstract class AemImportRepository internal constructor(private val db: ArticleR
                 insertOrIgnore(it)
                 update(it.uri, it.uuid, it.title)
 
-                // replace all categories
-                removeAllCategories(it.uri)
-                insertOrIgnore(it.categoryObjects)
+                // replace all tags
+                removeAllTags(it.uri)
+                insertOrIgnoreTags(it.tagObjects)
             }
         }
 

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
@@ -80,4 +80,13 @@ interface ArticleDao {
         WHERE $GET_ARTICLES_WHERE AND
             c.category = :category""")
     fun getArticles(tool: String, locale: Locale, category: String): LiveData<List<Article>>
+
+    @AnyThread
+    @Query("""
+        SELECT DISTINCT a.*
+        FROM $GET_ARTICLES_FROM
+             JOIN articleTags AS tag ON tag.articleUri = a.uri
+        WHERE $GET_ARTICLES_WHERE AND
+            tag.tag IN (:tags)""")
+    fun getArticles(tool: String, locale: Locale, tags: Collection<@JvmSuppressWildcards String>): LiveData<List<Article>>
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
@@ -79,5 +79,5 @@ interface ArticleDao {
              JOIN articleTags AS tag ON tag.articleUri = a.uri
         WHERE $GET_ARTICLES_WHERE AND
             tag.tag IN (:tags)""")
-    fun getArticles(tool: String, locale: Locale, tags: Collection<@JvmSuppressWildcards String>): LiveData<List<Article>>
+    fun getArticles(tool: String, locale: Locale, tags: List<@JvmSuppressWildcards String>): LiveData<List<Article>>
 }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
@@ -76,15 +76,6 @@ interface ArticleDao {
     @Query("""
         SELECT DISTINCT a.*
         FROM $GET_ARTICLES_FROM
-             JOIN categories AS c ON c.articleUri = a.uri
-        WHERE $GET_ARTICLES_WHERE AND
-            c.category = :category""")
-    fun getArticles(tool: String, locale: Locale, category: String): LiveData<List<Article>>
-
-    @AnyThread
-    @Query("""
-        SELECT DISTINCT a.*
-        FROM $GET_ARTICLES_FROM
              JOIN articleTags AS tag ON tag.articleUri = a.uri
         WHERE $GET_ARTICLES_WHERE AND
             tag.tag IN (:tags)""")

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleDao.kt
@@ -33,7 +33,7 @@ interface ArticleDao {
 
     @WorkerThread
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insertOrIgnore(categories: Collection<Article.Category>)
+    fun insertOrIgnoreTags(tags: Collection<Article.Tag>)
 
     @WorkerThread
     @Insert(onConflict = OnConflictStrategy.IGNORE)
@@ -48,8 +48,8 @@ interface ArticleDao {
     fun updateContent(uri: Uri, uuid: String?, content: String?)
 
     @WorkerThread
-    @Query("DELETE FROM categories WHERE articleUri = :articleUri")
-    fun removeAllCategories(articleUri: Uri)
+    @Query("DELETE FROM articleTags WHERE articleUri = :articleUri")
+    fun removeAllTags(articleUri: Uri)
 
     @WorkerThread
     @Query("""

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
@@ -24,9 +24,9 @@ import org.cru.godtools.articles.aem.model.TranslationRef;
 @Database(entities = {
         TranslationRef.class, TranslationRef.TranslationAemImport.class,
         AemImport.class, AemImport.AemImportArticle.class,
-        Article.class, Article.Category.class,
+        Article.class, Article.Category.class, Article.Tag.class,
         Article.ArticleResource.class, Resource.class
-}, version = 6)
+}, version = 7)
 @TypeConverters({DateConverter.class, LocaleConverter.class, UriConverter.class})
 public abstract class ArticleRoomDatabase extends RoomDatabase {
     private static final String DATABASE_NAME = "aem_article_cache.db";

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/db/ArticleRoomDatabase.java
@@ -24,7 +24,7 @@ import org.cru.godtools.articles.aem.model.TranslationRef;
 @Database(entities = {
         TranslationRef.class, TranslationRef.TranslationAemImport.class,
         AemImport.class, AemImport.AemImportArticle.class,
-        Article.class, Article.Category.class, Article.Tag.class,
+        Article.class, Article.Tag.class,
         Article.ArticleResource.class, Resource.class
 }, version = 7)
 @TypeConverters({DateConverter.class, LocaleConverter.class, UriConverter.class})

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
@@ -127,6 +127,31 @@ public class Article {
     }
 
     @Immutable
+    @Entity(tableName = "articleTags", primaryKeys = {"articleUri", "tag"},
+            foreignKeys = {
+                    @ForeignKey(entity = Article.class,
+                            onUpdate = ForeignKey.RESTRICT, onDelete = ForeignKey.CASCADE,
+                            parentColumns = {"uri"}, childColumns = {"articleUri"})
+            })
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public static class Tag {
+        @NonNull
+        public final Uri articleUri;
+
+        @NonNull
+        public final String tag;
+
+        public Tag(@NonNull final Article article, @NonNull final String tag) {
+            this(article.uri, tag);
+        }
+
+        public Tag(@NonNull final Uri articleUri, @NonNull final String tag) {
+            this.articleUri = articleUri;
+            this.tag = tag;
+        }
+    }
+
+    @Immutable
     @Entity(tableName = "articleResources", primaryKeys = {"articleUri", "resourceUri"},
             indices = {@Index("resourceUri")},
             foreignKeys = {

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
@@ -102,31 +102,6 @@ public class Article {
     }
 
     @Immutable
-    @Entity(tableName = "categories", primaryKeys = {"articleUri", "category"},
-            foreignKeys = {
-                    @ForeignKey(entity = Article.class,
-                            onUpdate = ForeignKey.RESTRICT, onDelete = ForeignKey.CASCADE,
-                            parentColumns = {"uri"}, childColumns = {"articleUri"})
-            })
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    public static class Category {
-        @NonNull
-        public final Uri articleUri;
-
-        @NonNull
-        public final String category;
-
-        public Category(@NonNull final Article article, @NonNull final String category) {
-            this(article.uri, category);
-        }
-
-        public Category(@NonNull final Uri articleUri, @NonNull final String category) {
-            this.articleUri = articleUri;
-            this.category = category;
-        }
-    }
-
-    @Immutable
     @Entity(tableName = "articleTags", primaryKeys = {"articleUri", "tag"},
             foreignKeys = {
                     @ForeignKey(entity = Article.class,

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/model/Article.java
@@ -72,7 +72,7 @@ public class Article {
 
     @Ignore
     @NonNull
-    private List<String> mCategories = ImmutableList.of();
+    private List<String> mTags = ImmutableList.of();
 
     @Ignore
     @NonNull
@@ -82,15 +82,15 @@ public class Article {
         this.uri = uri;
     }
 
-    public void setCategories(@NonNull final List<String> categories) {
-        mCategories = ImmutableList.copyOf(categories);
+    public void setTags(@NonNull final List<String> tags) {
+        mTags = ImmutableList.copyOf(tags);
     }
 
     @NonNull
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    public List<Category> getCategoryObjects() {
-        return Stream.of(mCategories)
-                .map(category -> new Category(this, category))
+    public List<Tag> getTagObjects() {
+        return Stream.of(mTags)
+                .map(tag -> new Tag(this, tag))
                 .toList();
     }
 

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/service/support/AemJsonParser.java
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/service/support/AemJsonParser.java
@@ -33,8 +33,6 @@ public class AemJsonParser {
     private static final String TYPE_PAGE = "cq:Page";
     private static final String SUBTYPE_XFPAGE = "cq/experience-fragments/components/xfpage";
 
-    private static final String PREFIX_TAG_CATEGORY = "godtools:category/";
-
     private static final String CREATED_TAG = "jcr:created";
     private static final String LAST_MODIFIED_TAG = "cq:lastModified";
 
@@ -100,16 +98,17 @@ public class AemJsonParser {
             article.uuid = content.optString(TAG_UUID, article.uuid);
             article.title = content.optString(TAG_TITLE, article.title);
 
-            // parse any categories
-            final JSONArray tags = content.optJSONArray(TAG_TAGS);
-            final List<String> categories = new ArrayList<>();
-            for (int i = 0; i < tags.length(); i++) {
-                final String tag = tags.optString(i, "");
-                if (tag.startsWith(PREFIX_TAG_CATEGORY)) {
-                    categories.add(tag.substring(PREFIX_TAG_CATEGORY.length()));
+            // store any tags
+            final JSONArray tagsJson = content.optJSONArray(TAG_TAGS);
+            final List<String> tags = new ArrayList<>();
+            for (int i = 0; i < tagsJson.length(); i++) {
+                final String tag = tagsJson.optString(i, null);
+                if (tag == null) {
+                    continue;
                 }
+                tags.add(tag);
             }
-            article.setCategories(categories);
+            article.setTags(tags);
 
             if (content.has(LAST_MODIFIED_TAG)) {
                 article.mDateUpdated = getDateLongFromJsonString(content.optString(LAST_MODIFIED_TAG));


### PR DESCRIPTION
- Parse AEM tags for a category from the manifest xml
- Track all tags for an article in the AEM article cache database
- Load articles based on the AEM tags in a specific category