### PR TITLE
Checkstyle import order

### DIFF
--- a/analysis/checkstyle/checkstyle.xml
+++ b/analysis/checkstyle/checkstyle.xml
@@ -68,6 +68,11 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
         </module>
+        <module name="ImportOrder">
+            <property name="option" value="bottom" />
+            <property name="groups" value="android,com,junit,net,org,java,javax" />
+            <property name="sortStaticImportsAlphabetically" value="true" />
+        </module>
 
 
         <!-- Checks for Size Violations.                    -->

--- a/library/api/src/main/java/org/cru/godtools/api/model/ToolViews.java
+++ b/library/api/src/main/java/org/cru/godtools/api/model/ToolViews.java
@@ -1,12 +1,12 @@
 package org.cru.godtools.api.model;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute;
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore;
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType;
 import org.cru.godtools.model.Tool;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static org.cru.godtools.api.model.ToolViews.JSON_API_TYPE;
 


### PR DESCRIPTION
The desire behind a fixed import order is to prevent churn within git history.

We can adjust what import order we are enforcing as needs change