### PR TITLE
Rework activity navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,6 @@
         <activity
             android:name=".activity.AboutActivity"
             android:label="@string/title_about"
-            android:launchMode="singleTask"
             android:parentActivityName="org.keynote.godtools.android.activity.MainActivity"
             android:screenOrientation="@integer/default_screen_orientation">
             <meta-data
@@ -72,7 +71,6 @@
 
         <activity
             android:name=".activity.LanguageSettingsActivity"
-            android:launchMode="singleTask"
             android:label="@string/title_language_settings"
             android:parentActivityName="org.keynote.godtools.android.activity.MainActivity"
             android:screenOrientation="@integer/default_screen_orientation">

--- a/app/src/main/java/org/cru/godtools/activity/AboutActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/AboutActivity.java
@@ -21,7 +21,10 @@ public final class AboutActivity extends BasePlatformActivity {
     private static final String TAG_MAIN_FRAGMENT = "mainFragment";
 
     public static void start(@NonNull final Activity activity) {
-        activity.startActivity(new Intent(activity, AboutActivity.class));
+        final Intent intent = new Intent(activity, AboutActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .putExtras(buildExtras(activity));
+        activity.startActivity(intent);
     }
 
     /* BEGIN lifecycle */

--- a/app/src/main/java/org/cru/godtools/activity/LanguageSelectionActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/LanguageSelectionActivity.java
@@ -27,8 +27,9 @@ public class LanguageSelectionActivity extends BasePlatformActivity implements L
     private /*final*/ boolean mPrimary = true;
 
     public static void start(@NonNull final Activity activity, final boolean primary) {
-        final Intent intent = new Intent(activity, LanguageSelectionActivity.class);
-        intent.putExtra(EXTRA_PRIMARY, primary);
+        final Intent intent = new Intent(activity, LanguageSelectionActivity.class)
+                .putExtras(buildExtras(activity))
+                .putExtra(EXTRA_PRIMARY, primary);
         activity.startActivity(intent);
     }
 
@@ -43,7 +44,7 @@ public class LanguageSelectionActivity extends BasePlatformActivity implements L
             mPrimary = intent.getBooleanExtra(EXTRA_PRIMARY, mPrimary);
         }
 
-        setContentView(R.layout.activity_generic_fragment_with_nav_drawer);
+        setContentView(R.layout.activity_generic_fragment);
     }
 
     @Override

--- a/app/src/main/java/org/cru/godtools/activity/LanguageSettingsActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/LanguageSettingsActivity.java
@@ -20,7 +20,10 @@ public class LanguageSettingsActivity extends BasePlatformActivity {
     private static final String TAG_MAIN_FRAGMENT = "mainFragment";
 
     public static void start(@NonNull final Activity activity) {
-        activity.startActivity(new Intent(activity, LanguageSettingsActivity.class));
+        final Intent intent = new Intent(activity, LanguageSettingsActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                .putExtras(buildExtras(activity));
+        activity.startActivity(intent);
     }
 
     // region Lifecycle Events
@@ -58,10 +61,5 @@ public class LanguageSettingsActivity extends BasePlatformActivity {
         fm.beginTransaction()
                 .replace(R.id.frame, LanguageSettingsFragment.newInstance(), TAG_MAIN_FRAGMENT)
                 .commit();
-    }
-
-    @Override
-    public void supportNavigateUpTo(@NonNull final Intent upIntent) {
-        finish();
     }
 }

--- a/app/src/main/java/org/cru/godtools/activity/ToolDetailsActivity.java
+++ b/app/src/main/java/org/cru/godtools/activity/ToolDetailsActivity.java
@@ -25,8 +25,9 @@ public class ToolDetailsActivity extends BasePlatformActivity implements ToolDet
     private /*final*/ String mTool = Tool.INVALID_CODE;
 
     public static void start(@NonNull final Activity activity, @NonNull final String toolCode) {
-        final Intent intent = new Intent(activity, ToolDetailsActivity.class);
-        intent.putExtra(EXTRA_TOOL, toolCode);
+        final Intent intent = new Intent(activity, ToolDetailsActivity.class)
+                .putExtras(buildExtras(activity))
+                .putExtra(EXTRA_TOOL, toolCode);
         activity.startActivity(intent);
     }
 
@@ -99,10 +100,5 @@ public class ToolDetailsActivity extends BasePlatformActivity implements ToolDet
         fm.beginTransaction()
                 .replace(R.id.frame, ToolDetailsFragment.newInstance(mTool), TAG_MAIN_FRAGMENT)
                 .commit();
-    }
-
-    @Override
-    public void supportNavigateUpTo(@NonNull final Intent upIntent) {
-        finish();
     }
 }

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/ArticlesActivity.java
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/ArticlesActivity.java
@@ -35,8 +35,7 @@ public class ArticlesActivity extends BaseSingleToolActivity implements Articles
 
     public static void start(@NonNull final Activity activity, @NonNull final String toolCode,
                              @NonNull final Locale language, @Nullable final String category) {
-        final Bundle args = new Bundle();
-        populateExtras(args, toolCode, language);
+        final Bundle args = buildExtras(activity, toolCode, language);
         args.putString(EXTRA_CATEGORY, category);
         final Intent intent = new Intent(activity, ArticlesActivity.class).putExtras(args);
         activity.startActivity(intent);

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/ArticlesActivity.java
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/ArticlesActivity.java
@@ -21,8 +21,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentManager;
 
-import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
-import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
 import static org.cru.godtools.article.Constants.EXTRA_CATEGORY;
 
 public class ArticlesActivity extends BaseSingleToolActivity implements ArticlesFragment.Callbacks {
@@ -107,22 +105,4 @@ public class ArticlesActivity extends BaseSingleToolActivity implements Articles
         // otherwise default to the default toolbar title
         super.updateToolbarTitle();
     }
-
-    // region Up Navigation
-
-    @Nullable
-    @Override
-    public Intent getSupportParentActivityIntent() {
-        final Intent intent = super.getSupportParentActivityIntent();
-
-        // populate the CategoriesActivity intent
-        if (intent != null) {
-            intent.addFlags(FLAG_ACTIVITY_SINGLE_TOP | FLAG_ACTIVITY_CLEAR_TOP);
-            intent.putExtras(CategoriesActivity.populateExtras(new Bundle(), mTool, mLocale));
-        }
-
-        return intent;
-    }
-
-    // endregion Up Navigation
 }

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/CategoriesActivity.java
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/activity/CategoriesActivity.java
@@ -21,8 +21,7 @@ public class CategoriesActivity extends BaseSingleToolActivity implements Catego
 
     public static void start(@NonNull final Activity activity, @NonNull final String toolCode,
                              @NonNull final Locale language) {
-        final Bundle extras = new Bundle(2);
-        populateExtras(extras, toolCode, language);
+        final Bundle extras = buildExtras(activity, toolCode, language);
         final Intent intent = new Intent(activity, CategoriesActivity.class).putExtras(extras);
         activity.startActivity(intent);
     }

--- a/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/activity/AemArticleActivity.kt
+++ b/ui/articles-aem-renderer/src/main/java/org/cru/godtools/articles/aem/activity/AemArticleActivity.kt
@@ -115,8 +115,7 @@ class AemArticleActivity : BaseSingleToolActivity(false) {
     companion object {
         @JvmStatic
         fun start(activity: Activity, toolCode: String, language: Locale, articleUri: Uri) {
-            val extras = Bundle().apply {
-                BaseSingleToolActivity.populateExtras(this, toolCode, language)
+            val extras = buildExtras(activity, toolCode, language).apply {
                 putParcelable(EXTRA_ARTICLE, articleUri)
             }
             val intent = Intent(activity, AemArticleActivity::class.java).putExtras(extras)

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.java
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.java
@@ -1,5 +1,6 @@
 package org.cru.godtools.base.tool.activity;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -40,8 +41,10 @@ public abstract class BaseSingleToolActivity extends BaseToolActivity {
     @Nullable
     protected Manifest mManifest;
 
-    protected static Bundle populateExtras(@NonNull final Bundle extras, @NonNull final String toolCode,
-                                           @NonNull final Locale language) {
+    @NonNull
+    protected static Bundle buildExtras(@NonNull final Activity activity, @NonNull final String toolCode,
+                                        @NonNull final Locale language) {
+        final Bundle extras = buildExtras(activity);
         extras.putString(EXTRA_TOOL, toolCode);
         BundleUtils.putLocale(extras, EXTRA_LANGUAGE, language);
         return extras;

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.java
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.java
@@ -133,6 +133,19 @@ public abstract class BaseSingleToolActivity extends BaseToolActivity {
         return mManifest;
     }
 
+    // region Up Navigation
+
+    @NonNull
+    @Override
+    protected Bundle buildParentIntentExtras() {
+        final Bundle extras = super.buildParentIntentExtras();
+        extras.putString(EXTRA_TOOL, mTool);
+        BundleUtils.putLocale(extras, EXTRA_LANGUAGE, mLocale);
+        return extras;
+    }
+
+    // endregion Up Navigation
+
     class TranslationLoaderCallbacks implements LoaderManager.LoaderCallbacks<Translation> {
         @Nullable
         @Override

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.java
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.java
@@ -22,6 +22,9 @@ import androidx.lifecycle.Lifecycle;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
+import static android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP;
+import static android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP;
+
 public abstract class BaseActivity extends AppCompatActivity {
     private static final String EXTRA_LAUNCHING_COMPONENT = "org.cru.godtools.BaseActivity.launchingComponent";
 
@@ -105,6 +108,25 @@ public abstract class BaseActivity extends AppCompatActivity {
 
         // otherwise defer to default navigate behavior
         super.supportNavigateUpTo(upIntent);
+    }
+
+    @Nullable
+    @Override
+    public Intent getSupportParentActivityIntent() {
+        final Intent intent = super.getSupportParentActivityIntent();
+
+        if (intent != null) {
+            intent.addFlags(FLAG_ACTIVITY_SINGLE_TOP | FLAG_ACTIVITY_CLEAR_TOP);
+            intent.putExtras(buildParentIntentExtras());
+        }
+
+        return intent;
+    }
+
+    @NonNull
+    @CallSuper
+    protected Bundle buildParentIntentExtras() {
+        return new Bundle();
     }
 
     // endregion Up Navigation


### PR DESCRIPTION
This PR reworks some of the Activity navigation logic.

- Track the launching activity so that up navigation can be short-circuited to back navigation when possible
- utilize REORDER_TO_FRONT flag to handle navigating back and forth between about and language settings activities
- pass along any common extras an activity knows about when processing up navigation