### PR TITLE
we can't specify an orientation for a transparent activity

### DIFF
--- a/ui/tract-renderer/src/main/AndroidManifest.xml
+++ b/ui/tract-renderer/src/main/AndroidManifest.xml
@@ -32,7 +32,6 @@
 
         <activity
             android:name=".activity.ModalActivity"
-            android:screenOrientation="@integer/default_screen_orientation"
             android:theme="@style/Theme.GodTools.Tract.Activity.Modal" />
     </application>
 </manifest>


### PR DESCRIPTION
this crash: https://fabric.io/cru/android/apps/org.keynote.godtools.android/issues/5be6cfe6f8b88c29635700f5?time=last-ninety-days

I had fixed this in the past, but I re-introduced the bug when I adjusted orientations for all activities.