### PR TITLE
Don't crash on a duplicate language in the language table

### DIFF
--- a/app/src/main/java/org/cru/godtools/fragment/LanguagesFragment.java
+++ b/app/src/main/java/org/cru/godtools/fragment/LanguagesFragment.java
@@ -133,7 +133,7 @@ public class LanguagesFragment extends BasePlatformFragment implements Languages
             mLanguages = null;
         } else {
             mLanguages = Stream.of(languages)
-                    .collect(Collectors.toMap(l -> l.getDisplayName(getContext()), l -> l,
+                    .collect(Collectors.toMap(l -> l.getDisplayName(getContext()), l -> l, (l1, l2) -> l1,
                                               () -> new TreeMap<>(String::compareToIgnoreCase)));
         }
         updateLanguagesList();


### PR DESCRIPTION
The sync process will eventually resolve this inconsistent data, for now let's just present the language once

Fixes: https://console.firebase.google.com/u/0/project/godtools-b2f82/crashlytics/app/android:org.keynote.godtools.android/issues/5c031232f8b88c29632fa55a