### PR TITLE
remove our block on new permissions for older versions of Android

### DIFF
--- a/library/analytics/src/main/AndroidManifest.xml
+++ b/library/analytics/src/main/AndroidManifest.xml
@@ -8,14 +8,6 @@
     <!-- Permissions required for Firebase Analytics -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <!-- Only request this permission on versions of android with runtime permissions.
-         This isn't critical app functionality and we don't want to force users to have to accept the update.
-         The permission originally comes from the firebase-analytics dependency. -->
-    <uses-permission
-        android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"
-        tools:node="remove" />
-    <uses-permission-sdk-23 android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE" />
-
     <application>
         <activity
             android:name="com.adobe.mobile.MessageFullScreenActivity"


### PR DESCRIPTION
We have another permission related to performance monitoring that is required, so we are biting the bullet with this upgrade and prompting for all deferred permissions with this single upgrade.