### PR TITLE
GT-573 send a value with the analytics event

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/AdobeAnalyticsService.java
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/AdobeAnalyticsService.java
@@ -116,7 +116,7 @@ public final class AdobeAnalyticsService implements AnalyticsService, Applicatio
 
     @Override
     public void onTrackShareAction() {
-        trackAction(ACTION_SHARE, null, Collections.singletonMap(KEY_SHARE_CONTENT, null));
+        trackAction(ACTION_SHARE, null, Collections.singletonMap(KEY_SHARE_CONTENT, 1));
     }
 
     @Override

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ToggleLanguageAnalyticsActionEvent.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ToggleLanguageAnalyticsActionEvent.java
@@ -25,7 +25,7 @@ public final class ToggleLanguageAnalyticsActionEvent extends AnalyticsActionEve
         super(null, ACTION_TOGGLE_LANGUAGE);
         mTract = tract;
         final HashMap<String, Object> attrs = new HashMap<>();
-        attrs.put(KEY_ADOBE_TOGGLE_LANGUAGE, null);
+        attrs.put(KEY_ADOBE_TOGGLE_LANGUAGE, 1);
         attrs.put(KEY_CONTENT_LANGUAGE_SECONDARY, LocaleCompat.toLanguageTag(locale));
         mAttrs = Collections.unmodifiableMap(attrs);
     }


### PR DESCRIPTION
It appears that Adobe Analytics drops fields that don't have values