### PR TITLE
Disable automatic screen detection in Appsee

### DIFF
--- a/app/src/main/java/org/cru/godtools/service/AppseeAnalyticService.kt
+++ b/app/src/main/java/org/cru/godtools/service/AppseeAnalyticService.kt
@@ -89,7 +89,10 @@ class AppseeAnalyticService private constructor(application: Application) :
 
     override fun onAppseeSessionEnded(appseeSessionEndedInfo: AppseeSessionEndedInfo) {}
 
-    override fun onAppseeScreenDetected(appseeScreenDetectedInfo: AppseeScreenDetectedInfo) {}
+    override fun onAppseeScreenDetected(appseeScreenDetectedInfo: AppseeScreenDetectedInfo) {
+        // we don't want to use automatic screen detection, we will manually track screen names using analytics events
+        appseeScreenDetectedInfo.screenName = null
+    }
 
     // endregion AppSee LifeCycle Callbacks
 


### PR DESCRIPTION
The `K$c` screen being recorded was the automatic screen name for activities when they started. using the official Appsee proguard rules did fix the name, but it was still events that we did not want to track.

`onAppseeScreenDetected` is triggered only for automatic screen detection, and setting the screenName to null will skip tracking that screen event which is the desired behavior.

see: https://support.appsee.com/customer/en/portal/articles/2686094-how-can-i-join-rename-or-ignore-specific-screens-