### PR TITLE
don't intercept requests for data URIs

### DIFF
--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/fragment/AemArticleFragment.java
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/fragment/AemArticleFragment.java
@@ -181,7 +181,12 @@ public class AemArticleFragment extends BaseFragment {
         @Nullable
         @Override
         public WebResourceResponse shouldInterceptRequest(@NonNull final WebView view, @NonNull final String url) {
-            final WebResourceResponse response = getResponseFromFile(view.getContext(), Uri.parse(url));
+            final Uri uri = Uri.parse(url);
+            if ("data".equals(uri.getScheme())) {
+                return null;
+            }
+
+            final WebResourceResponse response = getResponseFromFile(view.getContext(), uri);
             if (response != null) {
                 return response;
             }


### PR DESCRIPTION
on Android Q there is a request for a `data:` uri that was causing it to display a not found UI for any article that was being loaded. Since `data:` URIs are completely self-contained we don't need to override processing.