### PR TITLE
GT-639 : Keyboard Not Dismissing appropriately

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/InputViewHolder.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/InputViewHolder.java
@@ -1,9 +1,11 @@
 package org.cru.godtools.tract.viewmodel;
 
+import android.content.Context;
 import android.content.res.ColorStateList;
 import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -77,8 +79,13 @@ final class InputViewHolder extends BaseViewHolder<Input> {
 
     @OnFocusChange(R2.id.input)
     void onFocusChanged(final boolean hasFocus) {
+        InputMethodManager keyboard = (InputMethodManager) mInputView.getContext()
+                .getSystemService(Context.INPUT_METHOD_SERVICE);
         if (!hasFocus) {
             onValidate();
+            keyboard.hideSoftInputFromWindow(mInputView.getWindowToken(), 0);
+        } else {
+            keyboard.showSoftInput(mInputView, 0);
         }
     }
 


### PR DESCRIPTION
https://jira.cru.org/browse/GT-639

On the prayer screen of the 4SL, KGP and THE FOUR, when a user goes to sign up for follow up, it's hard to figure out how to dismiss the keyboard. And it's hard to access the SEND option. If I choose No Thanks, it's really hard to figure out how to dismiss the keyboard - I never could figure out how to do it. 
