### PR TITLE
GT-601 : Requested Changes from QA

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
@@ -191,7 +191,7 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
         int count = 0;
         if (mModel != null) {
             for (Card card : mModel.getPage().getCards()) {
-                if (isPrayerForm(card) || isPrayerSelection(card)) {
+                if (isPrayerForm(card)) {
                     continue;
                 }
                 count++;

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
@@ -136,7 +136,7 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
         int cardCount = getCardCount();
         String positionText = String.format(locale, "%d/%d", cardPositionCount, cardCount);
         mCardPositionView.setText(positionText);
-        if (isPrayerForm(mModel) || isPrayerSelection(mModel)) {
+        if (isPrayerForm(mModel)) {
             mPreviousCardView.setVisibility(View.INVISIBLE);
             mPreviousCardView.setEnabled(false);
             mCardPositionView.setVisibility(View.INVISIBLE);
@@ -169,17 +169,6 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
         if (card != null) {
             for (Content content : card.getContent()) {
                 if (content instanceof Form) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean isPrayerSelection(Card card) {
-        if (card != null) {
-            for (Event.Id dismissListener : card.getDismissListeners()) {
-                if (dismissListener.name.contains("followup-form")) {
                     return true;
                 }
             }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/CardViewHolder.java
@@ -14,8 +14,6 @@ import org.cru.godtools.tract.R2;
 import org.cru.godtools.tract.widget.TractPicassoImageView;
 import org.cru.godtools.xml.model.AnalyticsEvent.Trigger;
 import org.cru.godtools.xml.model.Card;
-import org.cru.godtools.xml.model.Content;
-import org.cru.godtools.xml.model.Form;
 import org.cru.godtools.xml.model.Styles;
 import org.cru.godtools.xml.model.Text;
 
@@ -136,7 +134,7 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
         int cardCount = getCardCount();
         String positionText = String.format(locale, "%d/%d", cardPositionCount, cardCount);
         mCardPositionView.setText(positionText);
-        if (isPrayerForm(mModel)) {
+        if (isCardHidden(mModel)) {
             mPreviousCardView.setVisibility(View.INVISIBLE);
             mPreviousCardView.setEnabled(false);
             mCardPositionView.setVisibility(View.INVISIBLE);
@@ -165,13 +163,9 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
 
     }
 
-    private boolean isPrayerForm(Card card) {
+    private boolean isCardHidden(Card card) {
         if (card != null) {
-            for (Content content : card.getContent()) {
-                if (content instanceof Form) {
-                    return true;
-                }
-            }
+            return card.isHidden();
         }
         return false;
     }
@@ -180,7 +174,7 @@ public final class CardViewHolder extends ParentViewHolder<Card> {
         int count = 0;
         if (mModel != null) {
             for (Card card : mModel.getPage().getCards()) {
-                if (isPrayerForm(card)) {
+                if (isCardHidden(card)) {
                     continue;
                 }
                 count++;

--- a/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
@@ -101,6 +101,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/card_position"
                     android:layout_marginBottom="@dimen/card_margin_bottom"
+                    android:paddingTop="8dp"
                     android:text="@string/tract_card_previous"
                     android:textAlignment="viewEnd"
                     android:gravity="end"
@@ -114,6 +115,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/next_card"
                     android:layout_marginBottom="@dimen/card_margin_bottom"
+                    android:paddingTop="8dp"
                     android:gravity="center"
                     tools:text="1/6" />
 
@@ -126,6 +128,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     android:textAlignment="viewStart"
                     android:layout_marginBottom="@dimen/card_margin_bottom"
+                    android:paddingTop="8dp"
                     android:gravity="start"
                     android:text="@string/tract_card_next"
                     android:textAllCaps="true" />


### PR DESCRIPTION
https://jira.cru.org/browse/GT-601

Two issues: 

1. Can you increase the buffer space between the footer of the card and the text on the card? The words Previous and Next are sometimes too close to the text on the card and I think it might be confusing. Is this easy to do?

2. Is there any way on the prayer screens to say 1/2 cards? Right now, it only shows that there is one card on that screen and I think a lot of people will miss the prayer screen sign up for follow up