### PR TITLE
GT-670 : EditText to dark to view

### DIFF
--- a/ui/tract-renderer/src/main/res/layout/tract_content_input.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_input.xml
@@ -9,5 +9,6 @@
         android:id="@+id/input"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
         android:textCursorDrawable="@null" />
 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
https://jira.cru.org/browse/GT-670

I set the EditText to Transparent to allow visibility.