### PR TITLE
upgrade appcompat to 1.2.0-alpha02 to fix a crash in YoutubePlayerView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,13 @@ buildscript {
         ]
         deps.androidX = [
                 annotation        : '1.1.0',
-                appCompat         : '1.1.0',
+                appCompat         : '1.2.0-alpha02',
                 archCore          : '2.1.0',
                 browser           : '1.2.0',
                 cardView          : '1.0.0',
                 collection        : '1.1.0',
                 constraintLayout  : '1.1.3',
-                core              : '1.1.0',
+                core              : '1.3.0-alpha01',
                 fragment          : '1.2.0',
                 lifecycle         : '2.1.0',
                 loader            : '1.1.0',


### PR DESCRIPTION
core needed to be upgraded to 1.3.0-alpha01 because of a transitive dependency in appcompat