### PR TITLE
make sure the gray background fills any empty space at the bottom

### DIFF
--- a/app/src/main/res/layout/tool_details_fragment.xml
+++ b/app/src/main/res/layout/tool_details_fragment.xml
@@ -24,6 +24,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@color/gray_E6"
             android:orientation="vertical">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -154,7 +155,6 @@
                 android:id="@+id/pages"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/gray_E6"
                 android:descendantFocusability="blocksDescendants"
                 android:focusable="false" />
         </LinearLayout>


### PR DESCRIPTION
previously on really tall screens (e.g. tablets) the gray color would stop after the view pager content and you would end up with a white background below the view pager. This addresses the issue by making the base background gray.

There still exists an issue where you can not swipe between pages from below the ViewPager content.

I tried addressing this by getting the ViewPager to fill the remaining space. this fixed the background color, but didn't solve the swiping issue because of how the ViewPager wraps an inner RecyclerView.

I opted to go with changing the background on the LinearLayout because the other solution didn't gain us anything and adds additional layout overhead of wrapping content or growing the content to fill the LinearLayout