### PR TITLE
GT-765 Add SwipeRefreshLayout to Profile

### DIFF
--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -3,14 +3,17 @@ package org.cru.godtools.activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.view.MenuItem
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
+import androidx.annotation.MainThread
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.observe
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import butterknife.BindView
 import com.google.android.material.navigation.NavigationView
 import me.thekey.android.TheKey
@@ -19,6 +22,8 @@ import me.thekey.android.view.dialog.LoginDialogFragment
 import org.ccci.gto.android.common.base.Constants.INVALID_LAYOUT_RES
 import org.ccci.gto.android.common.base.Constants.INVALID_STRING_RES
 import org.ccci.gto.android.common.compat.util.LocaleCompat
+import org.ccci.gto.android.common.sync.event.SyncFinishedEvent
+import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.ccci.gto.android.common.util.content.ComponentNameUtils
 import org.ccci.gto.android.common.util.view.MenuUtils
 import org.cru.godtools.BuildConfig
@@ -40,6 +45,8 @@ import org.cru.godtools.tutorial.activity.startTutorialActivity
 import org.cru.godtools.ui.about.startAboutActivity
 import org.cru.godtools.ui.languages.startLanguageSettingsActivity
 import org.cru.godtools.ui.profile.startProfileActivity
+import org.greenrobot.eventbus.Subscribe
+import org.greenrobot.eventbus.ThreadMode
 import org.keynote.godtools.android.activity.MainActivity
 import java.util.Locale
 import javax.inject.Inject
@@ -55,16 +62,32 @@ private const val SHARE_LINK = "{{share_link}}"
 
 private const val TAG_KEY_LOGIN_DIALOG = "keyLoginDialog"
 
+private const val EXTRA_SYNC_HELPER = "org.cru.godtools.activity.BasePlatformActivity.SYNC_HELPER"
+
 abstract class BasePlatformActivity(@LayoutRes contentLayoutId: Int = INVALID_LAYOUT_RES) :
     BaseDesignActivity(contentLayoutId), NavigationView.OnNavigationItemSelectedListener {
     @Inject
     protected lateinit var theKey: TheKey
 
     // region Lifecycle
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // restore any saved state
+        savedInstanceState?.restoreSyncState()
+    }
+
     @CallSuper
     override fun onContentChanged() {
         super.onContentChanged()
         setupNavigationDrawer()
+        setupSyncUi()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        eventBus.register(this)
+        syncHelper.triggerSync()
     }
 
     @CallSuper
@@ -74,6 +97,9 @@ abstract class BasePlatformActivity(@LayoutRes contentLayoutId: Int = INVALID_LA
             supportActionBar?.setHomeButtonEnabled(true)
         }
     }
+
+    @CallSuper
+    protected open fun onSyncData(helper: SwipeRefreshSyncHelper, force: Boolean) = Unit
 
     @CallSuper
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -168,9 +194,19 @@ abstract class BasePlatformActivity(@LayoutRes contentLayoutId: Int = INVALID_LA
         else -> super.onBackPressed()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.saveSyncState()
+    }
+
     override fun onStop() {
         super.onStop()
         eventBus.unregister(this)
+    }
+
+    override fun onDestroy() {
+        cleanupSyncUi()
+        super.onDestroy()
     }
     // endregion Lifecycle
 
@@ -321,4 +357,37 @@ abstract class BasePlatformActivity(@LayoutRes contentLayoutId: Int = INVALID_LA
 
     private fun launchTrainingTutorial() = startTutorialActivity(PageSet.TRAINING)
     // endregion Navigation Menu actions
+
+    // region Sync Logic
+    protected open val swipeRefreshLayout: SwipeRefreshLayout? get() = null
+
+    private val syncHelper = SwipeRefreshSyncHelper()
+
+    private fun SwipeRefreshSyncHelper.triggerSync(force: Boolean = false) {
+        onSyncData(this, force)
+        updateState()
+    }
+
+    @MainThread
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    internal fun syncCompleted(event: SyncFinishedEvent) = syncHelper.updateState()
+
+    private fun Bundle.restoreSyncState() {
+        syncHelper.onRestoreInstanceState(getBundle(EXTRA_SYNC_HELPER))
+    }
+
+    private fun setupSyncUi() {
+        syncHelper.refreshLayout = swipeRefreshLayout
+        swipeRefreshLayout?.setOnRefreshListener { syncHelper.triggerSync(true) }
+    }
+
+    private fun cleanupSyncUi() {
+        swipeRefreshLayout?.setOnRefreshListener(null)
+        syncHelper.refreshLayout = null
+    }
+
+    private fun Bundle.saveSyncState() {
+        putBundle(EXTRA_SYNC_HELPER, syncHelper.onSaveInstanceState())
+    }
+    // endregion Sync Logic
 }

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -40,6 +40,7 @@ import org.cru.godtools.base.Constants.URI_SHARE_BASE
 import org.cru.godtools.base.ui.activity.BaseDesignActivity
 import org.cru.godtools.base.ui.util.openUrl
 import org.cru.godtools.base.util.deviceLocale
+import org.cru.godtools.fragment.BasePlatformFragment
 import org.cru.godtools.tutorial.PageSet
 import org.cru.godtools.tutorial.activity.startTutorialActivity
 import org.cru.godtools.ui.about.startAboutActivity
@@ -360,11 +361,14 @@ abstract class BasePlatformActivity(@LayoutRes contentLayoutId: Int = INVALID_LA
 
     // region Sync Logic
     protected open val swipeRefreshLayout: SwipeRefreshLayout? get() = null
+    open val handleChildrenSyncs get() = swipeRefreshLayout != null
 
     private val syncHelper = SwipeRefreshSyncHelper()
 
     private fun SwipeRefreshSyncHelper.triggerSync(force: Boolean = false) {
         onSyncData(this, force)
+        if (handleChildrenSyncs) supportFragmentManager.fragments.filterIsInstance<BasePlatformFragment<*>>()
+            .forEach { with(it) { triggerSync(force) } }
         updateState()
     }
 

--- a/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
+++ b/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
@@ -12,6 +12,7 @@ import butterknife.BindView
 import org.ccci.gto.android.common.sync.event.SyncFinishedEvent
 import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
+import org.cru.godtools.activity.BasePlatformActivity
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.Settings.Companion.PREF_FEATURE_DISCOVERED
 import org.cru.godtools.base.Settings.Companion.PREF_PARALLEL_LANGUAGE
@@ -97,7 +98,7 @@ abstract class BasePlatformFragment<B : ViewDataBinding>(@LayoutRes layoutId: In
     private val syncHelper = SwipeRefreshSyncHelper()
 
     private fun triggerInitialSync() {
-        syncHelper.triggerSync()
+        if ((activity as? BasePlatformActivity)?.handleChildrenSyncs != true) syncHelper.triggerSync()
     }
 
     internal fun SwipeRefreshSyncHelper.triggerSync(force: Boolean = false) {

--- a/app/src/main/java/org/cru/godtools/fragment/ToolsFragment.java
+++ b/app/src/main/java/org/cru/godtools/fragment/ToolsFragment.java
@@ -13,6 +13,7 @@ import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropM
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
 
 import org.ccci.gto.android.common.support.v4.util.FragmentUtils;
+import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper;
 import org.cru.godtools.R;
 import org.cru.godtools.adapter.BannerHeaderAdapter;
 import org.cru.godtools.base.util.LocaleUtils;
@@ -123,6 +124,12 @@ public class ToolsFragment extends BasePlatformFragment implements ToolsAdapterC
         updateVisibleBanner();
     }
 
+    @CallSuper
+    public void onSyncData(@NonNull final SwipeRefreshSyncHelper helper, final boolean force) {
+        super.onSyncData(helper, force);
+        helper.sync(GodToolsSyncServiceKt.syncTools(requireContext(), force));
+    }
+
     @Override
     protected void onUpdateFeatureDiscovery(@NonNull final String feature) {
         super.onUpdateFeatureDiscovery(feature);
@@ -222,12 +229,6 @@ public class ToolsFragment extends BasePlatformFragment implements ToolsAdapterC
         mDataModel.getMode().setValue(mMode);
     }
     // endregion Data Model
-
-    @CallSuper
-    protected void syncData(final boolean force) {
-        super.syncData(force);
-        getSyncHelper().sync(GodToolsSyncServiceKt.syncTools(requireContext(), force));
-    }
 
     private void setupDataBinding() {
         if (mBinding != null) {

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import org.ccci.gto.android.common.support.v4.util.FragmentUtils
+import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
 import org.cru.godtools.databinding.LanguagesFragmentBinding
 import org.cru.godtools.fragment.BasePlatformFragment
@@ -41,6 +42,12 @@ class LanguagesFragment() : BasePlatformFragment<LanguagesFragmentBinding>(R.lay
     override fun onBindingCreated(binding: LanguagesFragmentBinding, savedInstanceState: Bundle?) {
         super.onBindingCreated(binding, savedInstanceState)
         binding.setupLanguagesList()
+    }
+
+    @CallSuper
+    override fun onSyncData(helper: SwipeRefreshSyncHelper, force: Boolean) {
+        super.onSyncData(helper, force)
+        helper.sync(requireContext().syncLanguages(force))
     }
 
     override fun onUpdatePrimaryLanguage() {
@@ -110,12 +117,6 @@ class LanguagesFragment() : BasePlatformFragment<LanguagesFragmentBinding>(R.lay
         searchItem = null
     }
     // endregion Search Action Item
-
-    @CallSuper
-    override fun syncData(force: Boolean) {
-        super.syncData(force)
-        syncHelper.sync(requireContext().syncLanguages(force))
-    }
 
     // region Languages List
     private val languagesAdapter by lazy {

--- a/app/src/main/java/org/cru/godtools/ui/profile/GlobalActivityFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/profile/GlobalActivityFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import org.ccci.gto.android.common.db.findLiveData
+import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
 import org.cru.godtools.databinding.ProfilePageGlobalActivityFragmentBinding
 import org.cru.godtools.fragment.BasePlatformFragment
@@ -20,9 +21,9 @@ class GlobalActivityFragment :
         binding.globalActivity = viewModel.globalActivity
     }
 
-    override fun syncData(force: Boolean) {
-        super.syncData(force)
-        syncHelper.sync(requireContext().syncGlobalActivity(force))
+    override fun onSyncData(helper: SwipeRefreshSyncHelper, force: Boolean) {
+        super.onSyncData(helper, force)
+        helper.sync(requireContext().syncGlobalActivity(force))
     }
 }
 

--- a/app/src/main/java/org/cru/godtools/ui/profile/ProfileActivity.kt
+++ b/app/src/main/java/org/cru/godtools/ui/profile/ProfileActivity.kt
@@ -50,6 +50,8 @@ class ProfileActivity : BasePlatformActivity() {
     }
     // endregion Data Binding
 
+    override val swipeRefreshLayout get() = binding.refresh
+
     // region Pages
     private fun setupPages() {
         binding.pages.setHeightWrapContent()

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.java
@@ -11,6 +11,7 @@ import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetView;
 import com.google.android.material.tabs.TabLayout;
 
+import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper;
 import org.cru.godtools.BuildConfig;
 import org.cru.godtools.R;
 import org.cru.godtools.activity.BasePlatformActivity;
@@ -75,9 +76,6 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
         if (savedInstanceState != null) {
             mActiveState = savedInstanceState.getInt(EXTRA_ACTIVE_STATE, mActiveState);
         }
-
-        // sync any pending updates
-        syncData();
     }
 
     @Override
@@ -102,6 +100,13 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
     protected void onResume() {
         super.onResume();
         trackInAnalytics();
+    }
+
+    @Override
+    protected void onSyncData(@NonNull final SwipeRefreshSyncHelper syncHelper, final boolean force) {
+        super.onSyncData(syncHelper, force);
+        GodToolsSyncServiceKt.syncFollowups(this).sync();
+        GodToolsSyncServiceKt.syncToolShares(this).sync();
     }
 
     @Override
@@ -234,11 +239,6 @@ public class MainActivity extends BasePlatformActivity implements ToolsFragment.
         (new ViewModelProvider(this)).get(LaunchTrackingViewModel.class).trackLaunch();
     }
     // endregion Analytics
-
-    private void syncData() {
-        GodToolsSyncServiceKt.syncFollowups(this).sync();
-        GodToolsSyncServiceKt.syncToolShares(this).sync();
-    }
 
     @Override
     protected boolean isShowNavigationDrawerIndicator() {

--- a/app/src/main/res/layout/profile_activity.xml
+++ b/app/src/main/res/layout/profile_activity.xml
@@ -24,58 +24,64 @@
                 android:theme="@style/ThemeOverlay.GodTools.Toolbar.AppBar" />
         </com.google.android.material.appbar.AppBarLayout>
 
-        <androidx.core.widget.NestedScrollView
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/refresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_height="match_parent"
+                android:fillViewport="true">
 
-                <TextView
-                    android:id="@+id/name"
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:background="@color/white"
-                    android:gravity="center"
-                    android:paddingTop="32dp"
-                    android:text="@{(keyAttributes.firstName ?? ``) + ` ` + (keyAttributes.lastName ?? ``)}"
-                    android:textAppearance="@style/TextAppearance.GodTools.Large"
-                    android:textStyle="bold"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="John Smith" />
+                    android:orientation="vertical">
 
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tabs"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingTop="32dp"
-                    app:layout_constraintTop_toBottomOf="@id/name">
-
-                    <com.google.android.material.tabs.TabItem
-                        android:layout_width="0dp"
+                    <TextView
+                        android:id="@+id/name"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        tools:text="@string/profile_tab_activity" />
-                </com.google.android.material.tabs.TabLayout>
+                        android:background="@color/white"
+                        android:gravity="center"
+                        android:paddingTop="32dp"
+                        android:text="@{(keyAttributes.firstName ?? ``) + ` ` + (keyAttributes.lastName ?? ``)}"
+                        android:textAppearance="@style/TextAppearance.GodTools.Large"
+                        android:textStyle="bold"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="John Smith" />
 
-                <androidx.constraintlayout.widget.Group
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:elevation="4dp"
-                    app:constraint_referenced_ids="name, tabs" />
+                    <com.google.android.material.tabs.TabLayout
+                        android:id="@+id/tabs"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingTop="32dp"
+                        app:layout_constraintTop_toBottomOf="@id/name">
 
-                <androidx.viewpager2.widget.ViewPager2
-                    android:id="@+id/pages"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    android:background="@color/gray_F2"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintHeight_min="wrap"
-                    app:layout_constraintTop_toBottomOf="@id/tabs" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.core.widget.NestedScrollView>
+                        <com.google.android.material.tabs.TabItem
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            tools:text="@string/profile_tab_activity" />
+                    </com.google.android.material.tabs.TabLayout>
+
+                    <androidx.constraintlayout.widget.Group
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:elevation="4dp"
+                        app:constraint_referenced_ids="name, tabs" />
+
+                    <androidx.viewpager2.widget.ViewPager2
+                        android:id="@+id/pages"
+                        android:layout_width="match_parent"
+                        android:layout_height="0dp"
+                        android:background="@color/gray_F2"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintHeight_min="wrap"
+                        app:layout_constraintTop_toBottomOf="@id/tabs" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.core.widget.NestedScrollView>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>


### PR DESCRIPTION
This PR refactors the sync framework for activities and fragments to allow them to work together and share a common SwipeRefreshLayout. We then utilize this logic to have a SwipeRefreshLayout on the ProfileActivity that triggers the sync in the GlobalActivityFragment