### PR TITLE
GT-808 utilize LiveData for activeManifest and activeToolState

### DIFF
--- a/ui/article-aem-renderer/build.gradle
+++ b/ui/article-aem-renderer/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
     implementation project(':ui:base-tool')
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:${deps.kotlinCoroutines}"
+
     implementation "androidx.core:core-ktx:${deps.androidX.core}"
     implementation "androidx.fragment:fragment-ktx:${deps.androidX.fragment}"
     implementation "androidx.lifecycle:lifecycle-extensions:${deps.androidX.lifecycle}"

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -160,11 +160,11 @@ class AemArticleActivity : BaseArticleActivity(false) {
     override val shareLinkUri get() = dataModel.article.value?.run { shareUri?.toString() ?: canonicalUri?.toString() }
     // endregion Share Link logic
 
-    override fun determineActiveToolState(): Int {
+    override fun determineActiveToolState(): ToolState {
         return when {
-            article?.content != null -> STATE_LOADED
-            syncTask?.isDone != true -> STATE_LOADING
-            else -> STATE_NOT_FOUND
+            article?.content != null -> ToolState.LOADED
+            syncTask?.isDone != true -> ToolState.LOADING
+            else -> ToolState.NOT_FOUND
         }
     }
 

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -20,7 +20,7 @@ abstract class BaseSingleToolActivity(
     @LayoutRes contentLayoutId: Int = INVALID_LAYOUT_RES,
     private val requireTool: Boolean = true
 ) : BaseToolActivity(immersive, contentLayoutId) {
-    override var activeManifest: Manifest? = null
+    override val activeManifestLiveData get() = dataModel.manifest
     private var translationLoaded = false
     private var translation: Translation? = null
 
@@ -99,13 +99,8 @@ abstract class BaseSingleToolActivity(
     private fun validStartState() = !requireTool || hasTool()
 
     private fun startLoaders() {
-        dataModel.manifest.observe(this) { setManifest(it) }
+        dataModel.manifest.observe(this) { onUpdateActiveManifest() }
         dataModel.translation.observe(this) { setTranslation(it) }
-    }
-
-    private fun setManifest(manifest: Manifest?) {
-        activeManifest = manifest
-        onUpdateActiveManifest()
     }
 
     private fun setTranslation(translation: Translation?) {

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -87,11 +87,11 @@ abstract class BaseSingleToolActivity(
     }
 
     override fun determineActiveToolState() = when {
-        !hasTool() -> STATE_LOADED
-        activeManifest?.type?.let { isSupportedType(it) } == false -> STATE_INVALID_TYPE
-        activeManifest != null -> STATE_LOADED
-        translationLoaded && translation == null -> STATE_NOT_FOUND
-        else -> STATE_LOADING
+        !hasTool() -> ToolState.LOADED
+        activeManifest?.type?.let { isSupportedType(it) } == false -> ToolState.INVALID_TYPE
+        activeManifest != null -> ToolState.LOADED
+        translationLoaded && translation == null -> ToolState.NOT_FOUND
+        else -> ToolState.LOADING
     }
 
     protected abstract fun isSupportedType(type: Manifest.Type): Boolean

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -190,16 +190,18 @@ abstract class BaseToolActivity(
     @BindView(R2.id.mainContent)
     internal var mainContent: View? = null
 
+    enum class ToolState { LOADING, LOADED, NOT_FOUND, INVALID_TYPE }
+
     @CallSuper
     protected open fun updateVisibilityState() {
         val state = determineActiveToolState()
-        loadingContent?.visibility = if (state == STATE_LOADING) View.VISIBLE else View.GONE
-        mainContent?.visibility = if (state == STATE_LOADED) View.VISIBLE else View.GONE
+        loadingContent?.visibility = if (state == ToolState.LOADING) View.VISIBLE else View.GONE
+        mainContent?.visibility = if (state == ToolState.LOADED) View.VISIBLE else View.GONE
         missingContent?.visibility =
-            if (state == STATE_NOT_FOUND || state == STATE_INVALID_TYPE) View.VISIBLE else View.GONE
+            if (state == ToolState.NOT_FOUND || state == ToolState.INVALID_TYPE) View.VISIBLE else View.GONE
     }
 
-    protected abstract fun determineActiveToolState(): Int
+    protected abstract fun determineActiveToolState(): ToolState
     // endregion Tool state
 
     // region Tool sync/download logic
@@ -321,11 +323,4 @@ abstract class BaseToolActivity(
 
     override fun setTitle(title: CharSequence) =
         super.setTitle(title.applyTypefaceSpan(ManifestViewUtils.getTypeface(activeManifest, this)))
-
-    companion object {
-        const val STATE_LOADING = 0
-        const val STATE_LOADED = 1
-        const val STATE_NOT_FOUND = 2
-        const val STATE_INVALID_TYPE = 3
-    }
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -59,7 +59,7 @@ abstract class BaseToolActivity(
         BaseToolActivity_ViewBinding(this)
 
         super.onContentChanged()
-        updateVisibilityState()
+        activeToolStateLiveData.observe(this) { updateVisibilityState(it) }
     }
 
     override fun onSetupActionBar() {
@@ -199,19 +199,14 @@ abstract class BaseToolActivity(
         }
     }
 
-    protected open val activeToolStateLiveData: LiveData<ToolState>
-        get() = TODO("This should be abstract once it's fully supported")
+    protected abstract val activeToolStateLiveData: LiveData<ToolState>
 
-    @CallSuper
-    protected open fun updateVisibilityState() {
-        val state = determineActiveToolState()
+    private fun updateVisibilityState(state: ToolState = activeToolStateLiveData.value ?: ToolState.UNKNOWN) {
         loadingContent?.visibility = if (state == ToolState.LOADING) View.VISIBLE else View.GONE
         mainContent?.visibility = if (state == ToolState.LOADED) View.VISIBLE else View.GONE
         missingContent?.visibility =
             if (state == ToolState.NOT_FOUND || state == ToolState.INVALID_TYPE) View.VISIBLE else View.GONE
     }
-
-    protected open fun determineActiveToolState(): ToolState = activeToolStateLiveData.value ?: ToolState.UNKNOWN
     // endregion Tool state
 
     // region Tool sync/download logic

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -190,7 +190,17 @@ abstract class BaseToolActivity(
     @BindView(R2.id.mainContent)
     internal var mainContent: View? = null
 
-    enum class ToolState { LOADING, LOADED, NOT_FOUND, INVALID_TYPE }
+    enum class ToolState {
+        LOADING, LOADED, NOT_FOUND, INVALID_TYPE;
+
+        companion object {
+            // TODO: this should be an actual state
+            val UNKNOWN = LOADING
+        }
+    }
+
+    protected open val activeToolStateLiveData: LiveData<ToolState>
+        get() = TODO("This should be abstract once it's fully supported")
 
     @CallSuper
     protected open fun updateVisibilityState() {
@@ -201,7 +211,7 @@ abstract class BaseToolActivity(
             if (state == ToolState.NOT_FOUND || state == ToolState.INVALID_TYPE) View.VISIBLE else View.GONE
     }
 
-    protected abstract fun determineActiveToolState(): ToolState
+    protected open fun determineActiveToolState(): ToolState = activeToolStateLiveData.value ?: ToolState.UNKNOWN
     // endregion Tool state
 
     // region Tool sync/download logic

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.view.forEach
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.observe
 import butterknife.BindView
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
@@ -63,7 +64,7 @@ abstract class BaseToolActivity(
 
     override fun onSetupActionBar() {
         super.onSetupActionBar()
-        updateToolbar()
+        setupToolbar()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -92,11 +93,7 @@ abstract class BaseToolActivity(
     }
 
     @CallSuper
-    protected open fun onUpdateToolbar() = Unit
-
-    @CallSuper
     protected open fun onUpdateActiveManifest() {
-        updateToolbar()
         updateVisibilityState()
     }
     // endregion Lifecycle
@@ -114,31 +111,30 @@ abstract class BaseToolActivity(
         toolbarMenu = this
     }
 
-    private fun updateToolbar() {
-        toolbar?.apply {
-            val manifest = activeManifest
+    private fun setupToolbar() {
+        activeManifestLiveData.observe(this) { manifest ->
+            toolbar?.apply {
+                // set toolbar background color
+                setBackgroundColor(Manifest.getNavBarColor(manifest))
 
-            // set toolbar background color
-            setBackgroundColor(Manifest.getNavBarColor(manifest))
-
-            // set text & controls color
-            val controlColor = Manifest.getNavBarControlColor(manifest)
-            navigationIcon = toolbar!!.navigationIcon.tint(controlColor)
-            setTitleTextColor(controlColor)
-            setSubtitleTextColor(controlColor)
+                // set text & controls color
+                val controlColor = Manifest.getNavBarControlColor(manifest)
+                navigationIcon = navigationIcon.tint(controlColor)
+                setTitleTextColor(controlColor)
+                setSubtitleTextColor(controlColor)
+            }
+            updateToolbarTitle()
+            updateToolbarMenu(manifest)
         }
-        updateToolbarTitle()
-        updateToolbarMenu()
-        onUpdateToolbar()
     }
 
     protected open fun updateToolbarTitle() {
         title = Manifest.getTitle(activeManifest).orEmpty()
     }
 
-    private fun updateToolbarMenu() {
+    private fun updateToolbarMenu(manifest: Manifest? = activeManifest) {
         // tint all action icons
-        val controlColor = Manifest.getNavBarControlColor(activeManifest)
+        val controlColor = Manifest.getNavBarControlColor(manifest)
         toolbar?.apply { overflowIcon = overflowIcon.tint(controlColor) }
         toolbarMenu?.forEach { it.icon = it.icon.tint(controlColor) }
 

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -9,6 +9,7 @@ import android.widget.ProgressBar
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
 import androidx.core.view.forEach
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import butterknife.BindView
@@ -103,7 +104,8 @@ abstract class BaseToolActivity(
     /**
      * @return The currently active manifest that is a valid supported type for this activity, otherwise return null.
      */
-    protected abstract val activeManifest: Manifest?
+    protected val activeManifest get() = activeManifestLiveData.value
+    protected abstract val activeManifestLiveData: LiveData<Manifest?>
 
     // region Toolbar update logic
     private var toolbarMenu: Menu? = null

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -224,7 +224,6 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
     private val dataModel: TractActivityDataModel by viewModels()
     private fun setupDataModel() {
         dataModel.activeManifest.observe(this) { onUpdateActiveManifest() }
-        dataModel.activeState.observe(this) { updateVisibilityState() }
     }
     // endregion Data Model
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -347,7 +347,7 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
     )
 
     // region Active Translation management
-    override val activeManifest get() = dataModel.activeManifest.value
+    override val activeManifestLiveData get() = dataModel.activeManifest
 
     override fun determineActiveToolState() = dataModel.activeState.value ?: STATE_LOADING
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -349,7 +349,7 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
     // region Active Translation management
     override val activeManifestLiveData get() = dataModel.activeManifest
 
-    override fun determineActiveToolState() = dataModel.activeState.value ?: STATE_LOADING
+    override fun determineActiveToolState() = dataModel.activeState.value ?: ToolState.LOADING
 
     private fun setupActiveTranslationManagement() {
         isInitialSyncFinished.observe(this) { if (it) dataModel.isInitialSyncFinished.value = true }
@@ -365,13 +365,13 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
     }
 
     private fun updateActiveLocaleToAvailableLocaleIfNecessary(
-        activeState: Int? = dataModel.activeState.value,
+        activeState: ToolState? = dataModel.activeState.value,
         availableLocales: List<Locale> = dataModel.availableLocales.value.orEmpty(),
-        state: Map<Locale, Int> = dataModel.state.value.orEmpty()
+        state: Map<Locale, ToolState> = dataModel.state.value.orEmpty()
     ) {
         // only process if the active language is not found or invalid
-        if (activeState == STATE_NOT_FOUND || activeState == STATE_INVALID_TYPE) {
-            availableLocales.firstOrNull { state[it] != STATE_NOT_FOUND && state[it] != STATE_INVALID_TYPE }
+        if (activeState == ToolState.NOT_FOUND || activeState == ToolState.INVALID_TYPE) {
+            availableLocales.firstOrNull { state[it] != ToolState.NOT_FOUND && state[it] != ToolState.INVALID_TYPE }
                 ?.let { dataModel.setActiveLocale(it) }
         }
     }
@@ -393,10 +393,10 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
     companion object {
         internal fun determineState(manifest: Manifest?, translation: Translation?, isInitialSyncFinished: Boolean) =
             when {
-                manifest != null && manifest.type != Manifest.Type.TRACT -> STATE_INVALID_TYPE
-                manifest != null -> STATE_LOADED
-                translation == null && isInitialSyncFinished -> STATE_NOT_FOUND
-                else -> STATE_LOADING
+                manifest != null && manifest.type != Manifest.Type.TRACT -> ToolState.INVALID_TYPE
+                manifest != null -> ToolState.LOADED
+                translation == null && isInitialSyncFinished -> ToolState.NOT_FOUND
+                else -> ToolState.LOADING
             }
     }
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -348,8 +348,7 @@ class TractActivity : BaseToolActivity(true), TabLayout.OnTabSelectedListener, M
 
     // region Active Translation management
     override val activeManifestLiveData get() = dataModel.activeManifest
-
-    override fun determineActiveToolState() = dataModel.activeState.value ?: ToolState.LOADING
+    override val activeToolStateLiveData get() = dataModel.activeState
 
     private fun setupActiveTranslationManagement() {
         isInitialSyncFinished.observe(this) { if (it) dataModel.isInitialSyncFinished.value = true }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
@@ -62,7 +62,7 @@ class TractActivityDataModel @AssistedInject constructor(
         manifestCache.get(t, l).combineWith(translationCache.get(t, l), isInitialSyncFinished) { m, t, s ->
             determineState(m, t, s)
         }
-    }
+    }.distinctUntilChanged()
 
     val downloadProgress = distinctTool.switchCombineWith(activeLocale) { t, l ->
         when {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
@@ -22,9 +22,7 @@ import org.ccci.gto.android.common.dagger.viewmodel.AssistedSavedStateViewModelF
 import org.ccci.gto.android.common.db.Expression
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.getAsLiveData
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_INVALID_TYPE
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_LOADED
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_NOT_FOUND
+import org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.model.Language
@@ -108,26 +106,26 @@ class TractActivityDataModel @AssistedInject constructor(
         activeLocale.combineWith(primaryLocales, parallelLocales, state) { activeLocale, primary, parallel, state ->
             buildList {
                 primary
-                    .filterNot { state[it] == STATE_INVALID_TYPE || state[it] == STATE_NOT_FOUND }
+                    .filterNot { state[it] == ToolState.INVALID_TYPE || state[it] == ToolState.NOT_FOUND }
                     .let {
                         it.firstOrNull { it == activeLocale }
-                            ?: it.firstOrNull { state[it] == STATE_LOADED }
+                            ?: it.firstOrNull { state[it] == ToolState.LOADED }
                             ?: it.firstOrNull()
                     }
                     ?.let { add(it) }
                 parallel
                     .filterNot { contains(it) }
-                    .filterNot { state[it] == STATE_INVALID_TYPE || state[it] == STATE_NOT_FOUND }
+                    .filterNot { state[it] == ToolState.INVALID_TYPE || state[it] == ToolState.NOT_FOUND }
                     .let {
                         it.firstOrNull { it == activeLocale }
-                            ?: it.firstOrNull { state[it] == STATE_LOADED }
+                            ?: it.firstOrNull { state[it] == ToolState.LOADED }
                             ?: it.firstOrNull()
                     }
                     ?.let { add(it) }
             }
         }
     val visibleLocales =
-        availableLocales.combineWith(state) { locales, state -> locales.filter { state[it] == STATE_LOADED } }
+        availableLocales.combineWith(state) { locales, state -> locales.filter { state[it] == ToolState.LOADED } }
     // endregion Language Switcher
 
     private val manifestCache = object : LruCache<TranslationKey, LiveData<Manifest?>>(10) {

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDataModelTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDataModelTest.kt
@@ -15,8 +15,7 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_LOADING
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_NOT_FOUND
+import org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.model.Translation
@@ -245,13 +244,13 @@ class TractActivityDataModelTest {
         wheneverGetTranslation(TOOL, Locale.ENGLISH).thenReturn(translation)
 
         dataModel.state.observeForever(observer)
-        assertThat(dataModel.state.value, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, STATE_NOT_FOUND)))
+        assertThat(dataModel.state.value, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, ToolState.NOT_FOUND)))
         translation.value = Translation()
-        assertThat(dataModel.state.value, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, STATE_LOADING)))
-        argumentCaptor<Map<Locale, Int>> {
+        assertThat(dataModel.state.value, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, ToolState.LOADING)))
+        argumentCaptor<Map<Locale, ToolState>> {
             verify(observer, times(2)).onChanged(capture())
-            assertThat(firstValue, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, STATE_NOT_FOUND)))
-            assertThat(lastValue, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, STATE_LOADING)))
+            assertThat(firstValue, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, ToolState.NOT_FOUND)))
+            assertThat(lastValue, allOf(aMapWithSize(1), hasEntry(Locale.ENGLISH, ToolState.LOADING)))
         }
     }
     // endregion Property: state

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -1,10 +1,7 @@
 package org.cru.godtools.tract.activity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_INVALID_TYPE
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_LOADED
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_LOADING
-import org.cru.godtools.base.tool.activity.BaseToolActivity.Companion.STATE_NOT_FOUND
+import org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState
 import org.cru.godtools.model.Translation
 import org.cru.godtools.tract.activity.TractActivity.Companion.determineState
 import org.cru.godtools.xml.model.Manifest
@@ -17,10 +14,10 @@ import org.junit.runner.RunWith
 class TractActivityTest {
     @Test
     fun verifyDetermineState() {
-        assertEquals(STATE_LOADED, determineState(Manifest().apply { mType = Type.TRACT }, null, false))
-        assertEquals(STATE_INVALID_TYPE, determineState(Manifest().apply { mType = Type.ARTICLE }, null, false))
-        assertEquals(STATE_LOADING, determineState(null, null, false))
-        assertEquals(STATE_LOADING, determineState(null, Translation(), true))
-        assertEquals(STATE_NOT_FOUND, determineState(null, null, true))
+        assertEquals(ToolState.LOADED, determineState(Manifest().apply { mType = Type.TRACT }, null, false))
+        assertEquals(ToolState.INVALID_TYPE, determineState(Manifest().apply { mType = Type.ARTICLE }, null, false))
+        assertEquals(ToolState.LOADING, determineState(null, null, false))
+        assertEquals(ToolState.LOADING, determineState(null, Translation(), true))
+        assertEquals(ToolState.NOT_FOUND, determineState(null, null, true))
     }
 }


### PR DESCRIPTION
This shifts some logic around the active tool and tool state to utilize LiveData for the observer pattern instead of having to manually trigger re-evaluation whenever the underlying data changes.