### PR TITLE
GT-849 Fix toggling language not consistently triggering analytics and navigation events

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -304,8 +304,18 @@ class TractActivity : BaseToolActivity<TractActivityBinding>(true, R.layout.trac
     // region TabLayout.OnTabSelectedListener
     override fun onTabSelected(tab: TabLayout.Tab) {
         val locale = tab.tag as? Locale ?: return
-        dataModel.setActiveLocale(locale)
         eventBus.post(ToggleLanguageAnalyticsActionEvent(dataModel.tool.value, locale))
+        dataModel.setActiveLocale(locale)
+
+        // trigger analytics & live share publisher events
+        // TODO: this should probably occur whenever the activeManifest changes language,
+        //       but we need to make sure it executes after the pagerAdapter is updated
+        pagerAdapter.primaryItem?.let {
+            val page = it.page ?: return@let
+            val card = it.activeCard
+            trackTractPage(page, card)
+            sendLiveShareNavigationEvent(page, card)
+        }
     }
 
     override fun onTabReselected(tab: TabLayout.Tab?) = Unit

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.java
@@ -173,7 +173,7 @@ public final class ManifestPagerAdapter extends ViewHolderPagerAdapter<RVPageVie
 
     // endregion Lifecycle Events
 
-    class RVPageViewHolder extends ViewHolderPagerAdapter.ViewHolder implements PageViewHolder.Callbacks {
+    public class RVPageViewHolder extends ViewHolderPagerAdapter.ViewHolder implements PageViewHolder.Callbacks {
         private final PageViewHolder mModelViewHolder;
 
         @BindView(R2.id.page)
@@ -234,7 +234,12 @@ public final class ManifestPagerAdapter extends ViewHolderPagerAdapter<RVPageVie
         }
 
         @Nullable
-        Card getActiveCard() {
+        public Page getPage() {
+            return mPage;
+        }
+
+        @Nullable
+        public Card getActiveCard() {
             return mModelViewHolder.getActiveCard();
         }
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/PageViewHolder.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/viewmodel/PageViewHolder.java
@@ -272,8 +272,9 @@ public class PageViewHolder extends ParentViewHolder<Page>
         mNeedsCardsRebind = false;
 
         // map old view holders to new location
+        final View invalid = mPageView; // We just need a non-null placeholder value that can't be a card view
+        View activeCard = mPageContentLayout.getActiveCard() != null ? invalid : null;
         final CardViewHolder[] holders = new CardViewHolder[mCards.length];
-        View activeCard = null;
         int lastNewPos = -1;
         for (final CardViewHolder holder : mCardViewHolders) {
             final Card card = holder.getModel();
@@ -294,7 +295,7 @@ public class PageViewHolder extends ParentViewHolder<Page>
                 holders[newPos] = holder;
 
                 // is this the active card? if so track it to restore it after we finish binding
-                if (activeCard == null && mPageContentLayout.getActiveCard() == holder.mRoot) {
+                if (activeCard == invalid && mPageContentLayout.getActiveCard() == holder.mRoot) {
                     activeCard = holder.mRoot;
                 }
 
@@ -333,7 +334,7 @@ public class PageViewHolder extends ParentViewHolder<Page>
         mBindingCards = false;
 
         // restore the active card
-        if (activeCard != null) {
+        if (activeCard != invalid) {
             mPageContentLayout.changeActiveCard(activeCard, false);
         } else {
             // trigger onActiveCard in case the active card changed during binding


### PR DESCRIPTION
When the language toggle was used navigation events were only being triggered if no card was active, but not when a card was active.

The trigger if no card was present was actually a bug in when we triggered `onActiveCardChanged`, it would incorrectly be triggered when no card was selected and we re-bound the cards to the layout.

Once this was fixed, I added an explicit trigger for analytics and navigation events when the language was toggled.