### PR TITLE
Increase the minimum version of Android required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ ext.versionCode = grgit.log(includes:['HEAD']).size() + 4029765
 ext {
     applicationId = 'org.keynote.godtools.android'
     compileSdk    = 29
-    minSdk        = 17
+    minSdk        = 19
     minSdkFeature = 21
     targetSdk     = 29
 }


### PR DESCRIPTION
This change is being made because Android 17 and 18 don't support auto-mirroring for images when
viewed in a RTL language. This causes the dynamic call to action arrow image to not correctly
display in RTL languages. The effort required to work around this issue isn't worth the percentage
of users this affects going forward.

This change will drop support for 0.4% of our current users. These users will continue to be able to
install and use the current version of GodTools, they just won't be able to get any new updates.