### PR TITLE
Re-enable ktlint import rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,5 @@
 insert_final_newline=true
 
 [*.{kt,kts}]
-disabled_rules=import-ordering
 indent_size=4
 max_line_length = 120

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -34,6 +34,12 @@
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
       </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/app/src/debug/java/org/cru/godtools/dagger/FlipperModule.kt
+++ b/app/src/debug/java/org/cru/godtools/dagger/FlipperModule.kt
@@ -19,6 +19,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.multibindings.ElementsIntoSet
 import dagger.multibindings.IntoSet
+import javax.inject.Singleton
 import okhttp3.Interceptor
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton
 import org.ccci.gto.android.common.dagger.okhttp3.InterceptorType
@@ -26,7 +27,6 @@ import org.ccci.gto.android.common.dagger.okhttp3.InterceptorType.Type.NETWORK_I
 import org.ccci.gto.android.common.facebook.flipper.plugins.databases.DefaultSqliteDatabaseProvider
 import org.ccci.gto.android.common.facebook.flipper.plugins.databases.SQLiteOpenHelperDatabaseConnectionProvider
 import org.keynote.godtools.android.db.GodToolsDatabase
-import javax.inject.Singleton
 
 @Module
 abstract class FlipperModule {

--- a/app/src/main/java/org/cru/godtools/GodToolsApplication.kt
+++ b/app/src/main/java/org/cru/godtools/GodToolsApplication.kt
@@ -4,6 +4,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.instantapps.InstantApps
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.android.DaggerApplication
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.compat.util.LocaleCompat.toLanguageTag
 import org.ccci.gto.android.common.dagger.eager.EagerSingletonInitializer
 import org.ccci.gto.android.common.firebase.crashlytics.timber.CrashlyticsTree
@@ -11,8 +13,6 @@ import org.ccci.gto.android.common.util.LocaleUtils
 import org.cru.godtools.dagger.ApplicationModule
 import org.cru.godtools.dagger.DaggerApplicationComponent
 import timber.log.Timber
-import java.util.Locale
-import javax.inject.Inject
 
 open class GodToolsApplication : DaggerApplication() {
     override fun onCreate() {

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -19,6 +19,8 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import butterknife.BindView
 import com.google.android.material.navigation.NavigationView
 import dagger.Lazy
+import java.util.Locale
+import javax.inject.Inject
 import me.thekey.android.TheKey
 import me.thekey.android.livedata.defaultSessionGuidLiveData
 import me.thekey.android.view.dialog.LoginDialogFragment
@@ -53,8 +55,6 @@ import org.cru.godtools.ui.profile.startProfileActivity
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.keynote.godtools.android.activity.MainActivity
-import java.util.Locale
-import javax.inject.Inject
 
 internal val MAILTO_SUPPORT = Uri.parse("mailto:support@godtoolsapp.com")
 internal val URI_SUPPORT = Uri.parse("https://godtoolsapp.com/#contact")

--- a/app/src/main/java/org/cru/godtools/dagger/ApplicationComponent.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/ApplicationComponent.kt
@@ -3,8 +3,8 @@ package org.cru.godtools.dagger
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import dagger.android.AndroidInjector
-import org.cru.godtools.GodToolsApplication
 import javax.inject.Singleton
+import org.cru.godtools.GodToolsApplication
 
 @Singleton
 @Component(

--- a/app/src/main/java/org/cru/godtools/dagger/ConfigModule.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/ConfigModule.kt
@@ -2,9 +2,9 @@ package org.cru.godtools.dagger
 
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.api.ApiModule
-import javax.inject.Named
 
 @Module
 class ConfigModule {

--- a/app/src/main/java/org/cru/godtools/dagger/EventBusModule.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/EventBusModule.kt
@@ -6,13 +6,13 @@ import dagger.Provides
 import dagger.Reusable
 import dagger.multibindings.IntoSet
 import dagger.multibindings.Multibinds
+import javax.inject.Singleton
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton.ThreadMode
 import org.ccci.gto.android.common.eventbus.TimberLogger
 import org.cru.godtools.AppEventBusIndex
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.meta.SubscriberInfoIndex
-import javax.inject.Singleton
 
 @Module
 abstract class EventBusModule {

--- a/app/src/main/java/org/cru/godtools/dagger/ServicesModule.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/ServicesModule.kt
@@ -8,6 +8,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Singleton
 import me.thekey.android.TheKey
 import me.thekey.android.core.TheKeyImpl
 import me.thekey.android.eventbus.EventBusEventsManager
@@ -26,7 +27,6 @@ import org.cru.godtools.service.AccountListRegistrationService
 import org.cru.godtools.shortcuts.ShortcutModule
 import org.cru.godtools.sync.SyncModule
 import org.greenrobot.eventbus.EventBus
-import javax.inject.Singleton
 
 @Module(
     includes = [

--- a/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
+++ b/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
@@ -9,6 +9,7 @@ import androidx.annotation.MainThread
 import androidx.databinding.ViewDataBinding
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import butterknife.BindView
+import javax.inject.Inject
 import org.ccci.gto.android.common.sync.event.SyncFinishedEvent
 import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
@@ -20,7 +21,6 @@ import org.cru.godtools.sync.GodToolsSyncService
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import javax.inject.Inject
 
 private const val EXTRA_SYNC_HELPER = "org.cru.godtools.fragment.BasePlatformFragment.SYNC_HELPER"
 

--- a/app/src/main/java/org/cru/godtools/service/AccountListRegistrationService.kt
+++ b/app/src/main/java/org/cru/godtools/service/AccountListRegistrationService.kt
@@ -3,6 +3,9 @@ package org.cru.godtools.service
 import android.os.AsyncTask
 import androidx.annotation.WorkerThread
 import dagger.Lazy
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 import me.thekey.android.TheKey
 import me.thekey.android.eventbus.event.LoginEvent
 import org.cru.godtools.api.BuildConfig.CAMPAIGN_FORMS_ID
@@ -12,9 +15,6 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class AccountListRegistrationService @Inject internal constructor(

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguageSelectionActivity.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguageSelectionActivity.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Intent
 import androidx.annotation.MainThread
 import androidx.fragment.app.commit
+import java.util.Locale
+import javax.inject.Inject
 import org.cru.godtools.R
 import org.cru.godtools.activity.BasePlatformActivity
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
@@ -11,8 +13,6 @@ import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_LA
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.download.manager.GodToolsDownloadManager
-import java.util.Locale
-import javax.inject.Inject
 
 private const val EXTRA_PRIMARY = "org.cru.godtools.ui.languages.LanguageSelectionActivity.PRIMARY"
 

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguageSettingsFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguageSettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.switchMap
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.orEmpty
 import org.ccci.gto.android.common.db.findLiveData
 import org.cru.godtools.R
@@ -12,7 +13,6 @@ import org.cru.godtools.databinding.LanguageSettingsFragmentBinding
 import org.cru.godtools.fragment.BasePlatformFragment
 import org.cru.godtools.model.Language
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
 
 class LanguageSettingsFragment :
     BasePlatformFragment<LanguageSettingsFragmentBinding>(R.layout.language_settings_fragment),

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguagesAdapter.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguagesAdapter.kt
@@ -6,10 +6,10 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView.NO_ID
+import java.util.Locale
 import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
 import org.cru.godtools.databinding.ListItemLanguageBinding
 import org.cru.godtools.model.Language
-import java.util.Locale
 
 class LanguagesAdapter(lifecycleOwner: LifecycleOwner? = null, private val selected: LiveData<Locale?>) :
     SimpleDataBindingAdapter<ListItemLanguageBinding>(lifecycleOwner), LanguageSelectedListener,

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragment.kt
@@ -10,13 +10,13 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import java.util.Locale
 import org.ccci.gto.android.common.support.v4.util.FragmentUtils
 import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
 import org.cru.godtools.databinding.LanguagesFragmentBinding
 import org.cru.godtools.fragment.BasePlatformFragment
 import splitties.fragmentargs.argOrDefault
-import java.util.Locale
 
 class LanguagesFragment() : BasePlatformFragment<LanguagesFragmentBinding>(R.layout.languages_fragment),
     LocaleSelectedListener {

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragmentViewModel.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguagesFragmentViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import java.util.Locale
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.dagger.viewmodel.AssistedSavedStateViewModelFactory
 import org.ccci.gto.android.common.db.Query
@@ -18,7 +19,6 @@ import org.cru.godtools.base.Settings
 import org.cru.godtools.model.Language
 import org.keynote.godtools.android.db.Contract
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
 
 private const val KEY_QUERY = "query"
 private const val KEY_IS_SEARCH_VIEW_OPEN = "isSearchViewOpen"

--- a/app/src/main/java/org/cru/godtools/ui/profile/GlobalActivityFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/profile/GlobalActivityFragment.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.ui.profile
 import android.os.Bundle
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
+import javax.inject.Inject
 import org.ccci.gto.android.common.db.findLiveData
 import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
 import org.cru.godtools.R
@@ -10,7 +11,6 @@ import org.cru.godtools.databinding.ProfilePageGlobalActivityFragmentBinding
 import org.cru.godtools.fragment.BasePlatformFragment
 import org.cru.godtools.model.GlobalActivityAnalytics
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
 
 class GlobalActivityFragment :
     BasePlatformFragment<ProfilePageGlobalActivityFragmentBinding>(R.layout.profile_page_global_activity_fragment) {

--- a/app/src/main/java/org/cru/godtools/ui/tooldetails/ToolDetailsFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tooldetails/ToolDetailsFragment.kt
@@ -14,6 +14,8 @@ import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstan
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
 import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
 import dagger.Lazy
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.viewpager2.widget.setHeightWrapContent
 import org.ccci.gto.android.common.material.tabs.notifyChanged
 import org.cru.godtools.R
@@ -30,8 +32,6 @@ import org.cru.godtools.ui.tools.analytics.model.ToolOpenButtonAnalyticsActionEv
 import org.cru.godtools.util.openToolActivity
 import org.cru.godtools.xml.model.Manifest
 import splitties.fragmentargs.arg
-import java.util.Locale
-import javax.inject.Inject
 
 class ToolDetailsFragment() : BasePlatformFragment<ToolDetailsFragmentBinding>(R.layout.tool_details_fragment),
     LinkClickedListener {

--- a/app/src/main/java/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.orEmpty
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
@@ -21,7 +22,6 @@ import org.cru.godtools.model.Translation
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
 
 class ToolDetailsFragmentDataModel @Inject constructor(
     private val dao: GodToolsDao,

--- a/app/src/main/java/org/cru/godtools/ui/tooldetails/analytics/model/ToolDetailsScreenEvent.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tooldetails/analytics/model/ToolDetailsScreenEvent.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.ui.tooldetails.analytics.model
 
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import java.util.Locale
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 
 class ToolDetailsScreenEvent(tool: String, locale: Locale? = null) : AnalyticsScreenEvent("$tool-tool-info", locale) {
     override val adobeSiteSection get() = ADOBE_SITE_SECTION_TOOLS

--- a/app/src/main/java/org/cru/godtools/ui/tooldetails/databinding/ToolDetailsBindingAdapter.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tooldetails/databinding/ToolDetailsBindingAdapter.kt
@@ -4,8 +4,8 @@ import android.annotation.SuppressLint
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import androidx.databinding.adapters.TextViewBindingAdapter
-import org.cru.godtools.base.util.getDisplayName
 import java.util.Locale
+import org.cru.godtools.base.util.getDisplayName
 
 @BindingAdapter("languages")
 @SuppressLint("RestrictedApi")

--- a/app/src/main/java/org/cru/godtools/ui/tools/ToolsAdapterToolViewModel.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tools/ToolsAdapterToolViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.orEmpty
@@ -19,7 +20,6 @@ import org.cru.godtools.model.Language
 import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
 
 class ToolsAdapterToolViewModel @Inject constructor(
     private val dao: GodToolsDao,

--- a/app/src/main/java/org/cru/godtools/ui/tools/ToolsFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tools/ToolsFragment.kt
@@ -17,6 +17,8 @@ import com.h6ah4i.android.widget.advrecyclerview.animator.DraggableItemAnimator
 import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager
 import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils
 import com.sergivonavi.materialbanner.BannerInterface
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.onDestroy
 import org.ccci.gto.android.common.recyclerview.advrecyclerview.draggable.SimpleOnItemDragEventListener
 import org.ccci.gto.android.common.sync.swiperefreshlayout.widget.SwipeRefreshSyncHelper
@@ -40,8 +42,6 @@ import org.cru.godtools.widget.BannerType
 import org.keynote.godtools.android.db.GodToolsDao
 import splitties.fragmentargs.arg
 import splitties.fragmentargs.argOrDefault
-import java.util.Locale
-import javax.inject.Inject
 
 class ToolsFragment() : BasePlatformFragment<ToolsFragmentBinding>(R.layout.tools_fragment), ToolsAdapterCallbacks {
     companion object {

--- a/app/src/main/java/org/cru/godtools/ui/tools/ToolsFragmentDataModel.kt
+++ b/app/src/main/java/org/cru/godtools/ui/tools/ToolsFragmentDataModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.getAsLiveData
@@ -18,8 +20,6 @@ import org.cru.godtools.ui.tools.ToolsFragment.Companion.MODE_AVAILABLE
 import org.cru.godtools.widget.BannerType
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
-import javax.inject.Inject
 
 class ToolsFragmentDataModel @Inject constructor(private val dao: GodToolsDao, settings: Settings) : ViewModel() {
     val mode = MutableLiveData(MODE_ADDED)

--- a/app/src/main/java/org/cru/godtools/util/ActivityUtils.kt
+++ b/app/src/main/java/org/cru/godtools/util/ActivityUtils.kt
@@ -1,10 +1,10 @@
 package org.cru.godtools.util
 
 import android.app.Activity
+import java.util.Locale
 import org.cru.godtools.article.ui.categories.startCategoriesActivity
 import org.cru.godtools.model.Tool.Type
 import org.cru.godtools.tract.activity.startTractActivity
-import java.util.Locale
 
 fun Activity.openToolActivity(code: String, type: Type, vararg languages: Locale, showTips: Boolean = false) =
     when (type) {

--- a/app/src/test/java/org/cru/godtools/databinding/ToolsListItemToolBindingTest.kt
+++ b/app/src/test/java/org/cru/godtools/databinding/ToolsListItemToolBindingTest.kt
@@ -12,6 +12,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
+import java.util.Locale
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
@@ -26,7 +27,6 @@ import org.junit.runner.RunWith
 import org.keynote.godtools.android.activity.MainActivity
 import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)

--- a/app/src/test/java/org/cru/godtools/ui/languages/LanguageSettingsFragmentBindingTest.kt
+++ b/app/src/test/java/org/cru/godtools/ui/languages/LanguageSettingsFragmentBindingTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.Locale
 import org.cru.godtools.databinding.LanguageSettingsFragmentBinding
 import org.cru.godtools.model.Language
 import org.junit.Assert.assertEquals
@@ -19,7 +20,6 @@ import org.junit.runner.RunWith
 import org.keynote.godtools.android.activity.MainActivity
 import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)

--- a/library/analytics/src/debug/java/org/cru/godtools/analytics/TimberAnalyticsService.kt
+++ b/library/analytics/src/debug/java/org/cru/godtools/analytics/TimberAnalyticsService.kt
@@ -1,6 +1,8 @@
 package org.cru.godtools.analytics
 
 import androidx.annotation.MainThread
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.base.model.Event
@@ -8,8 +10,6 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TAG = "AnalyticsService"
 

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/adobe/AdobeAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/adobe/AdobeAnalyticsService.kt
@@ -12,6 +12,10 @@ import com.adobe.mobile.Config
 import com.adobe.mobile.Visitor
 import com.adobe.mobile.VisitorID.VisitorIDAuthenticationState
 import com.karumi.weak.weak
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import javax.inject.Inject
+import javax.inject.Singleton
 import me.thekey.android.Attributes
 import me.thekey.android.TheKey
 import me.thekey.android.eventbus.event.TheKeyEvent
@@ -24,10 +28,6 @@ import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /* Property Keys */
 private const val ADOBE_ATTR_APP_NAME = "cru.appname"

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
@@ -5,6 +5,8 @@ import androidx.annotation.WorkerThread
 import com.appsflyer.AFLogger
 import com.appsflyer.AppsFlyerConversionListener
 import com.appsflyer.AppsFlyerLib
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -18,8 +20,6 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TAG = "AppsFlyerAnalytics"
 

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/facebook/FacebookAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/facebook/FacebookAnalyticsService.kt
@@ -3,14 +3,14 @@ package org.cru.godtools.analytics.facebook
 import android.content.Context
 import androidx.annotation.WorkerThread
 import com.facebook.appevents.AppEventsLogger
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class FacebookAnalyticsService @Inject internal constructor(context: Context, eventBus: EventBus) {

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
@@ -8,6 +8,8 @@ import androidx.annotation.MainThread
 import com.google.android.gms.common.wrappers.InstantApps
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.karumi.weak.weak
+import javax.inject.Inject
+import javax.inject.Singleton
 import me.thekey.android.TheKey
 import me.thekey.android.eventbus.event.TheKeyEvent
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
@@ -17,8 +19,6 @@ import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val USER_PROP_APP_TYPE = "godtools_app_type"
 private const val VALUE_APP_TYPE_INSTANT = "instant"

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/snowplow/SnowplowAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/snowplow/SnowplowAnalyticsService.kt
@@ -14,6 +14,8 @@ import com.snowplowanalytics.snowplow.tracker.events.Event
 import com.snowplowanalytics.snowplow.tracker.events.ScreenView
 import com.snowplowanalytics.snowplow.tracker.events.Structured
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson
+import javax.inject.Inject
+import javax.inject.Singleton
 import me.thekey.android.Attributes
 import me.thekey.android.TheKey
 import okhttp3.OkHttpClient
@@ -26,8 +28,6 @@ import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TAG = "SnwplwAnalyticsService"
 

--- a/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
@@ -9,6 +9,9 @@ import com.tinder.streamadapter.coroutines.CoroutinesStreamAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.TlsVersion
@@ -39,9 +42,6 @@ import org.cru.godtools.model.jsonapi.ToolTypeConverter
 import retrofit2.Retrofit
 import retrofit2.create
 import timber.log.Timber
-import java.util.concurrent.TimeUnit
-import javax.inject.Named
-import javax.inject.Singleton
 
 @Module(includes = [OkHttp3Module::class])
 object ApiModule {

--- a/library/api/src/main/java/org/cru/godtools/api/model/NavigationEvent.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/model/NavigationEvent.kt
@@ -1,9 +1,9 @@
 package org.cru.godtools.api.model
 
-import org.ccci.gto.android.common.jsonapi.annotation.JsonApiId
-import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
 import java.util.Locale
 import java.util.UUID
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiId
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
 
 @JsonApiType("navigation-event")
 data class NavigationEvent(

--- a/library/base/src/main/java/org/cru/godtools/base/FileManager.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/FileManager.kt
@@ -3,10 +3,10 @@ package org.cru.godtools.base
 import android.content.Context
 import androidx.annotation.WorkerThread
 import dagger.Reusable
-import org.cru.godtools.base.util.getGodToolsFile
 import java.io.FileNotFoundException
 import java.io.InputStream
 import javax.inject.Inject
+import org.cru.godtools.base.util.getGodToolsFile
 
 @Reusable
 class FileManager @Inject internal constructor(private val context: Context) {

--- a/library/base/src/main/java/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.kt
@@ -7,6 +7,7 @@ import androidx.core.content.edit
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
+import java.util.Locale
 import me.thekey.android.TheKey
 import org.ccci.gto.android.common.androidx.lifecycle.getBooleanLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.getIntLiveData
@@ -14,7 +15,6 @@ import org.ccci.gto.android.common.androidx.lifecycle.getStringLiveData
 import org.ccci.gto.android.common.compat.util.LocaleCompat.forLanguageTag
 import org.ccci.gto.android.common.compat.util.LocaleCompat.toLanguageTag
 import org.cru.godtools.base.util.SingletonHolder
-import java.util.Locale
 
 private const val PREFS_SETTINGS = "GodTools"
 private const val PREF_ADDED_TO_CAMPAIGN = "added_to_campaign."

--- a/library/base/src/main/java/org/cru/godtools/base/util/LocaleUtils.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/util/LocaleUtils.kt
@@ -5,10 +5,10 @@ package org.cru.godtools.base.util
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.ConfigurationCompat
+import java.util.Locale
 import org.ccci.gto.android.common.util.LocaleUtils
 import org.ccci.gto.android.common.util.content.localize
 import timber.log.Timber
-import java.util.Locale
 
 @VisibleForTesting
 internal const val STRING_RES_LANGUAGE_NAME_PREFIX = "language_name_"

--- a/library/base/src/test/java/org/cru/godtools/base/SettingsTest.kt
+++ b/library/base/src/test/java/org/cru/godtools/base/SettingsTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.UUID
 import me.thekey.android.TheKey
 import org.cru.godtools.base.Settings.Companion.FEATURE_LOGIN
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
@@ -14,7 +15,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.UUID
 
 private const val FEATURE_TEST = "testFeature"
 

--- a/library/base/src/test/java/org/cru/godtools/base/util/LocaleUtilsGetDisplayNameTest.kt
+++ b/library/base/src/test/java/org/cru/godtools/base/util/LocaleUtilsGetDisplayNameTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -17,7 +18,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.stubbing.OngoingStubbing
 import org.robolectric.annotation.Config
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)

--- a/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.kt
+++ b/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.kt
@@ -7,6 +7,9 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.db.AbstractDao
 import org.ccci.gto.android.common.db.AsyncDao
@@ -36,9 +39,6 @@ import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TrainingTipTable
 import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
-import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) : AbstractDao(database), AsyncDao,

--- a/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDatabase.kt
+++ b/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.database.SQLException
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.ccci.gto.android.common.db.CommonTables.LastSyncTable
 import org.ccci.gto.android.common.db.WalSQLiteOpenHelper
@@ -18,8 +20,6 @@ import org.keynote.godtools.android.db.Contract.TrainingTipTable
 import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import timber.log.Timber
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val DATABASE_NAME = "resource.db"
 private const val DATABASE_VERSION = 44

--- a/library/initial-content/src/main/java/org/cru/godtools/init/content/InitialContentImporter.kt
+++ b/library/initial-content/src/main/java/org/cru/godtools/init/content/InitialContentImporter.kt
@@ -1,12 +1,12 @@
 package org.cru.godtools.init.content
 
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.cru.godtools.init.content.task.Tasks
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class InitialContentImporter @Inject internal constructor(tasks: Tasks) {

--- a/library/initial-content/src/main/java/org/cru/godtools/init/content/task/Tasks.kt
+++ b/library/initial-content/src/main/java/org/cru/godtools/init/content/task/Tasks.kt
@@ -3,6 +3,9 @@ package org.cru.godtools.init.content.task
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import dagger.Reusable
+import java.io.IOException
+import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
@@ -29,9 +32,6 @@ import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
 import timber.log.Timber
-import java.io.IOException
-import java.util.Locale
-import javax.inject.Inject
 
 private const val TAG = "InitialContentTasks"
 

--- a/library/model/src/main/java/org/cru/godtools/model/Followup.kt
+++ b/library/model/src/main/java/org/cru/godtools/model/Followup.kt
@@ -1,10 +1,10 @@
 package org.cru.godtools.model
 
+import java.util.Date
+import java.util.Locale
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
-import java.util.Date
-import java.util.Locale
 
 private const val JSON_API_TYPE_FOLLOWUP = "follow_up"
 

--- a/library/model/src/main/java/org/cru/godtools/model/Language.kt
+++ b/library/model/src/main/java/org/cru/godtools/model/Language.kt
@@ -1,11 +1,11 @@
 package org.cru.godtools.model
 
 import android.content.Context
+import java.util.Locale
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
 import org.cru.godtools.base.util.getDisplayName
-import java.util.Locale
 
 private const val JSON_API_TYPE_LANGUAGE = "language"
 

--- a/library/model/src/main/java/org/cru/godtools/model/Translation.kt
+++ b/library/model/src/main/java/org/cru/godtools/model/Translation.kt
@@ -1,10 +1,10 @@
 package org.cru.godtools.model
 
+import java.util.Date
+import java.util.Locale
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
-import java.util.Date
-import java.util.Locale
 
 private const val JSON_API_TYPE_TRANSLATION = "translation"
 

--- a/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -3,6 +3,10 @@ package org.cru.godtools.sync
 import android.content.ContentResolver
 import android.os.Bundle
 import androidx.work.WorkManager
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,10 +22,6 @@ import org.cru.godtools.sync.task.ToolSyncTasks
 import org.cru.godtools.sync.work.scheduleSyncFollowupWork
 import org.cru.godtools.sync.work.scheduleSyncToolSharesWork
 import org.greenrobot.eventbus.EventBus
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 
 private const val EXTRA_SYNCTYPE = "org.cru.godtools.sync.GodToolsSyncService.EXTRA_SYNCTYPE"
 private const val SYNCTYPE_NONE = 0

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/AnalyticsSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/AnalyticsSyncTasks.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.sync.task
 
 import android.os.Bundle
 import androidx.annotation.RestrictTo
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -10,8 +12,6 @@ import org.ccci.gto.android.common.base.TimeConstants
 import org.cru.godtools.api.AnalyticsApi
 import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val SYNC_TIME_GLOBAL_ACTIVITY = "last_synced.global_activity"
 private const val STALE_DURATION_GLOBAL_ACTIVITY = TimeConstants.DAY_IN_MS

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/BaseDataSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/BaseDataSyncTasks.kt
@@ -6,6 +6,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.collection.LongSparseArray
 import androidx.collection.SimpleArrayMap
 import androidx.collection.forEach
+import java.util.Locale
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.get
 import org.ccci.gto.android.common.jsonapi.util.Includes
@@ -24,7 +25,6 @@ import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 abstract class BaseDataSyncTasks internal constructor(protected val dao: GodToolsDao, eventBus: EventBus) :

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/FollowupSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/FollowupSyncTasks.kt
@@ -1,5 +1,8 @@
 package org.cru.godtools.sync.task
 
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -12,9 +15,6 @@ import org.cru.godtools.api.FollowupApi
 import org.cru.godtools.model.Followup
 import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.GodToolsDao
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class FollowupSyncTasks @Inject internal constructor(

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/LanguagesSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/LanguagesSyncTasks.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.sync.task
 
 import android.os.Bundle
 import androidx.collection.SimpleArrayMap
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -16,8 +18,6 @@ import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
 import timber.log.Timber
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val SYNC_TIME_LANGUAGES = "last_synced.languages"
 private const val STALE_DURATION_LANGUAGES = TimeConstants.WEEK_IN_MS

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -3,6 +3,9 @@ package org.cru.godtools.sync.task
 import android.os.Bundle
 import androidx.annotation.AnyThread
 import androidx.collection.SimpleArrayMap
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -22,9 +25,6 @@ import org.cru.godtools.model.Translation
 import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val SYNC_TIME_TOOLS = "last_synced.tools"
 private const val STALE_DURATION_TOOLS = TimeConstants.DAY_IN_MS

--- a/library/sync/src/test/java/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
+++ b/library/sync/src/test/java/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
@@ -11,6 +11,7 @@ import com.nhaarman.mockitokotlin2.same
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.Locale
 import org.ccci.gto.android.common.db.Expression
 import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.model.Language
@@ -20,7 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
 
 class BaseDataSyncTasksTest {
     private lateinit var dao: GodToolsDao

--- a/library/xml-model/src/main/java/org/cru/godtools/xml/model/Manifest.kt
+++ b/library/xml-model/src/main/java/org/cru/godtools/xml/model/Manifest.kt
@@ -6,6 +6,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
+import java.util.Locale
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
@@ -15,7 +16,6 @@ import org.cru.godtools.xml.XMLNS_ARTICLE
 import org.cru.godtools.xml.XMLNS_MANIFEST
 import org.cru.godtools.xml.model.tips.Tip
 import org.xmlpull.v1.XmlPullParser
-import java.util.Locale
 
 private const val XML_MANIFEST = "manifest"
 private const val XML_TYPE = "type"

--- a/library/xml-model/src/main/java/org/cru/godtools/xml/service/ManifestParser.kt
+++ b/library/xml-model/src/main/java/org/cru/godtools/xml/service/ManifestParser.kt
@@ -2,6 +2,12 @@ package org.cru.godtools.xml.service
 
 import androidx.annotation.AnyThread
 import androidx.annotation.VisibleForTesting
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.kotlin.coroutines.MutexMap
@@ -12,12 +18,6 @@ import org.cru.godtools.base.FileManager
 import org.cru.godtools.xml.model.Manifest
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
-import java.io.FileNotFoundException
-import java.io.IOException
-import java.io.InputStream
-import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Singleton
 
 @Singleton
 class ManifestParser @Inject internal constructor(private val fileManager: FileManager) {

--- a/library/xml-model/src/test/java/org/cru/godtools/xml/model/CategoryTest.kt
+++ b/library/xml-model/src/test/java/org/cru/godtools/xml/model/CategoryTest.kt
@@ -1,13 +1,13 @@
 package org.cru.godtools.xml.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
 import org.cru.godtools.xml.util.getXmlParserForResource
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class CategoryTest {

--- a/library/xml-model/src/test/java/org/cru/godtools/xml/model/ManifestTest.kt
+++ b/library/xml-model/src/test/java/org/cru/godtools/xml/model/ManifestTest.kt
@@ -1,11 +1,11 @@
 package org.cru.godtools.xml.model
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
 import org.cru.godtools.xml.util.getXmlParserForResource
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class ManifestTest {

--- a/library/xml-model/src/test/java/org/cru/godtools/xml/service/ManifestParserTest.kt
+++ b/library/xml-model/src/test/java/org/cru/godtools/xml/service/ManifestParserTest.kt
@@ -3,6 +3,9 @@ package org.cru.godtools.xml.service
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.util.Locale
 import kotlinx.coroutines.runBlocking
 import org.cru.godtools.base.FileManager
 import org.cru.godtools.xml.model.TOOL_CODE
@@ -12,9 +15,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.io.FileNotFoundException
-import java.io.IOException
-import java.util.Locale
 
 private const val MANIFEST = "manifest.xml"
 

--- a/library/xml-model/src/test/java/org/cru/godtools/xml/util/TestParserUtils.kt
+++ b/library/xml-model/src/test/java/org/cru/godtools/xml/util/TestParserUtils.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.xml.util
 
-import org.cru.godtools.xml.service.xmlPullParser
 import java.io.InputStream
+import org.cru.godtools.xml.service.xmlPullParser
 
 fun Any.getXmlParserForResource(name: String) = getInputStreamForResource(name).xmlPullParser()
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/AemArticleRendererModule.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/AemArticleRendererModule.kt
@@ -10,6 +10,7 @@ import dagger.Reusable
 import dagger.android.ContributesAndroidInjector
 import dagger.multibindings.IntoMap
 import dagger.multibindings.IntoSet
+import javax.inject.Singleton
 import okhttp3.OkHttpClient
 import org.ccci.gto.android.common.api.retrofit2.converter.JSONObjectConverterFactory
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton
@@ -24,7 +25,6 @@ import org.cru.godtools.article.aem.ui.AemArticleViewModel
 import retrofit2.Retrofit
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
-import javax.inject.Singleton
 
 @Module
 abstract class AemArticleRendererModule {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/analytics/model/ArticleAnalyticsScreenEvent.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/analytics/model/ArticleAnalyticsScreenEvent.kt
@@ -1,8 +1,8 @@
 package org.cru.godtools.article.aem.analytics.model
 
+import java.util.Locale
 import org.cru.godtools.article.aem.model.Article
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
-import java.util.Locale
 
 private const val SCREEN_ARTICLE_PREFIX = "Article : "
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/AemImportDao.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/AemImportDao.kt
@@ -6,9 +6,9 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import java.util.Date
 import org.cru.godtools.article.aem.model.AemImport
 import org.cru.godtools.article.aem.model.AemImport.AemImportArticle
-import java.util.Date
 
 @Dao
 interface AemImportDao {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/AemImportRepository.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/AemImportRepository.kt
@@ -3,10 +3,10 @@ package org.cru.godtools.article.aem.db
 import androidx.annotation.WorkerThread
 import androidx.room.Dao
 import androidx.room.Transaction
+import java.util.Date
 import org.ccci.gto.android.common.base.TimeConstants.WEEK_IN_MS
 import org.cru.godtools.article.aem.model.AemImport
 import org.cru.godtools.article.aem.model.Article
-import java.util.Date
 
 @Dao
 abstract class AemImportRepository internal constructor(private val db: ArticleRoomDatabase) {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ArticleDao.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ArticleDao.kt
@@ -8,8 +8,8 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import org.cru.godtools.article.aem.model.Article
 import java.util.Locale
+import org.cru.godtools.article.aem.model.Article
 
 private const val GET_ARTICLES_FROM = """
     translationAemImports AS t

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ArticleRepository.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ArticleRepository.kt
@@ -1,8 +1,8 @@
 package org.cru.godtools.article.aem.db
 
+import androidx.annotation.WorkerThread
 import androidx.room.Dao
 import androidx.room.Transaction
-import androidx.annotation.WorkerThread
 import org.cru.godtools.article.aem.model.Article
 
 @Dao

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ResourceDao.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/ResourceDao.kt
@@ -6,9 +6,9 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import java.util.Date
 import okhttp3.MediaType
 import org.cru.godtools.article.aem.model.Resource
-import java.util.Date
 
 @Dao
 interface ResourceDao {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/TranslationDao.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/db/TranslationDao.kt
@@ -6,9 +6,9 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import java.util.Locale
 import org.cru.godtools.article.aem.model.TranslationRef
 import org.cru.godtools.article.aem.model.TranslationRef.TranslationAemImport
-import java.util.Locale
 
 private const val TRANSLATION_KEY = "tool = :tool AND language = :language AND version = :version"
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/AemImport.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/AemImport.kt
@@ -5,8 +5,8 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import org.ccci.gto.android.common.base.TimeConstants.DAY_IN_MS
 import java.util.Date
+import org.ccci.gto.android.common.base.TimeConstants.DAY_IN_MS
 
 private const val STALE_AGE = DAY_IN_MS
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.net.Uri
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import okhttp3.MediaType
-import org.cru.godtools.article.aem.util.getFile
 import java.io.File
 import java.io.FileInputStream
 import java.util.Date
+import okhttp3.MediaType
+import org.cru.godtools.article.aem.util.getFile
 
 @Entity(tableName = TABLE_NAME_RESOURCE)
 class Resource(@field:PrimaryKey val uri: Uri) {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/TranslationRef.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/TranslationRef.kt
@@ -6,10 +6,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import org.cru.godtools.model.Language
-import org.cru.godtools.model.Translation
 import java.util.Locale
 import javax.annotation.concurrent.Immutable
+import org.cru.godtools.model.Language
+import org.cru.godtools.model.Translation
 
 fun Translation?.toTranslationRefKey(): TranslationRef.Key? {
     return this?.run {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -13,6 +13,8 @@ import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
 import com.google.common.util.concurrent.Futures
+import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
@@ -29,8 +31,6 @@ import org.cru.godtools.article.aem.util.removeExtension
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivity
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
-import java.util.Locale
-import javax.inject.Inject
 
 fun Activity.startAemArticleActivity(toolCode: String?, language: Locale, articleUri: Uri) {
     val extras = BaseSingleToolActivity.buildExtras(this, toolCode, language).apply {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleViewModel.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleViewModel.kt
@@ -11,10 +11,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.cru.godtools.article.aem.R
 import org.cru.godtools.article.aem.db.ArticleDao
-import javax.inject.Inject
 
 internal class AemArticleViewModel @Inject constructor(
     application: Application,

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
@@ -9,16 +9,16 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.WorkerThread
 import com.karumi.weak.weak
-import org.cru.godtools.article.aem.db.ResourceDao
-import org.cru.godtools.article.aem.model.Resource
-import org.cru.godtools.article.aem.service.AemArticleManager
-import org.cru.godtools.base.ui.util.openUrl
-import timber.log.Timber
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
+import org.cru.godtools.article.aem.db.ResourceDao
+import org.cru.godtools.article.aem.model.Resource
+import org.cru.godtools.article.aem.service.AemArticleManager
+import org.cru.godtools.base.ui.util.openUrl
+import timber.log.Timber
 
 private const val TAG = "ArticleWebViewClient"
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/ResourceUtils.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/ResourceUtils.kt
@@ -2,8 +2,8 @@ package org.cru.godtools.article.aem.util
 
 import android.content.Context
 import androidx.annotation.WorkerThread
-import org.jetbrains.annotations.Contract
 import java.io.File
+import org.jetbrains.annotations.Contract
 
 private val resourcesDir = "aem-resources"
 

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
@@ -2,13 +2,13 @@ package org.cru.godtools.article.aem.db
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.Locale
 import org.cru.godtools.article.aem.model.TranslationRef
 import org.cru.godtools.article.aem.model.toTranslationRefKey
 import org.cru.godtools.model.Translation
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.Locale
 
 class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : TranslationRepository(db) {}

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/analytics/model/ArticlesAnalyticsScreenEvent.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/analytics/model/ArticlesAnalyticsScreenEvent.kt
@@ -1,8 +1,7 @@
 package org.cru.godtools.article.analytics.model
 
-import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
-
 import java.util.Locale
+import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
 
 private const val SCREEN_ARTICLES_ALL = "All Articles"
 private const val SCREEN_ARTICLES_CATEGORY_PREFIX = "Category : "

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesActivity.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesActivity.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.article.ui.articles
 import android.app.Activity
 import android.content.Intent
 import androidx.fragment.app.commit
+import java.util.Locale
 import org.cru.godtools.article.EXTRA_CATEGORY
 import org.cru.godtools.article.R
 import org.cru.godtools.article.aem.model.Article
@@ -12,7 +13,6 @@ import org.cru.godtools.article.analytics.model.ArticlesCategoryAnalyticsScreenE
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivity
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
-import java.util.Locale
 
 fun Activity.startArticlesActivity(toolCode: String, language: Locale, category: String?) {
     val extras = BaseSingleToolActivity.buildExtras(this, toolCode, language).apply {

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesFragment.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesFragment.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import butterknife.BindView
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
@@ -23,8 +25,6 @@ import org.cru.godtools.base.tool.fragment.BaseToolFragment
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import splitties.fragmentargs.argOrNull
-import java.util.Locale
-import javax.inject.Inject
 
 private val resetRefreshLayoutTask = WeakTask.Task<SwipeRefreshLayout> { it.isRefreshing = false }
 

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesActivity.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.MainThread
 import androidx.fragment.app.commit
+import java.util.Locale
 import org.cru.godtools.article.R
 import org.cru.godtools.article.ui.articles.startArticlesActivity
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
@@ -14,7 +15,6 @@ import org.cru.godtools.base.tool.analytics.model.SCREEN_CATEGORIES
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
 import org.cru.godtools.xml.model.Category
-import java.util.Locale
 
 fun Context.createCategoriesIntent(toolCode: String, language: Locale): Intent {
     return Intent(this, CategoriesActivity::class.java)

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesFragment.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesFragment.kt
@@ -3,13 +3,13 @@ package org.cru.godtools.article.ui.categories
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.map
+import java.util.Locale
 import org.ccci.gto.android.common.recyclerview.decorator.VerticalSpaceItemDecoration
 import org.ccci.gto.android.common.util.findListener
 import org.cru.godtools.article.R
 import org.cru.godtools.article.databinding.ArticleCategoriesFragmentBinding
 import org.cru.godtools.base.tool.fragment.BaseToolFragment
 import org.cru.godtools.xml.model.Category
-import java.util.Locale
 
 class CategoriesFragment : BaseToolFragment<ArticleCategoriesFragmentBinding>, CategorySelectedListener {
     constructor() : super(R.layout.article_categories_fragment)

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/BaseToolRendererModule.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/BaseToolRendererModule.kt
@@ -7,11 +7,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.Reusable
 import dagger.multibindings.IntoMap
+import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.net.isConnectedLiveData
 import org.ccci.gto.android.common.dagger.viewmodel.ViewModelKey
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivityDataModel
 import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
-import javax.inject.Named
 
 @Module
 abstract class BaseToolRendererModule {

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -7,6 +7,7 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.observe
+import java.util.Locale
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.util.os.getLocale
 import org.ccci.gto.android.common.util.os.putLocale
@@ -14,7 +15,6 @@ import org.cru.godtools.base.Constants
 import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import org.cru.godtools.model.Language
 import org.cru.godtools.xml.model.Manifest
-import java.util.Locale
 
 abstract class BaseSingleToolActivity<B : ViewDataBinding>(
     @LayoutRes contentLayoutId: Int,

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -1,12 +1,12 @@
 package org.cru.godtools.base.tool.activity
 
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
 
 internal class BaseSingleToolActivityDataModel @Inject constructor(
     manifestManager: ManifestManager,

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -18,6 +18,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.util.graphics.toHslColor
@@ -41,9 +44,6 @@ import org.cru.godtools.xml.model.Manifest
 import org.cru.godtools.xml.model.navBarColor
 import org.cru.godtools.xml.model.navBarControlColor
 import org.keynote.godtools.android.db.GodToolsDao
-import java.io.IOException
-import javax.inject.Inject
-import javax.inject.Named
 
 abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId: Int) :
     ImmersiveActivity<B>(contentLayoutId) {

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsScreenEvent.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsScreenEvent.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.base.tool.analytics.model
 
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import java.util.Locale
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 
 const val SCREEN_CATEGORIES = "Categories"
 

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/fragment/BaseToolFragment.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/fragment/BaseToolFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.viewModels
 import androidx.viewbinding.ViewBinding
+import java.util.Locale
 import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import org.cru.godtools.base.ui.fragment.BaseFragment
 import splitties.fragmentargs.arg
-import java.util.Locale
 
 abstract class BaseToolFragment<B : ViewBinding>(@LayoutRes contentLayoutId: Int) :
     BaseFragment<B>(contentLayoutId) {

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/service/ManifestManager.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/service/ManifestManager.kt
@@ -6,6 +6,8 @@ import androidx.annotation.WorkerThread
 import androidx.lifecycle.liveData
 import androidx.lifecycle.switchMap
 import dagger.Reusable
+import java.util.Locale
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -20,8 +22,6 @@ import org.cru.godtools.xml.service.Result
 import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
-import javax.inject.Inject
 
 @Reusable
 class ManifestManager @Inject constructor(

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/viewmodel/LatestPublishedManifestDataModel.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/viewmodel/LatestPublishedManifestDataModel.kt
@@ -2,11 +2,11 @@ package org.cru.godtools.base.tool.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.cru.godtools.base.tool.service.ManifestManager
-import java.util.Locale
-import javax.inject.Inject
 
 open class LatestPublishedManifestDataModel @Inject constructor(manifestManager: ManifestManager) : ViewModel() {
     val toolCode = MutableLiveData<String?>()

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/activity/ToolStateTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/activity/ToolStateTest.kt
@@ -1,13 +1,13 @@
 package org.cru.godtools.base.tool.activity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.EnumSet
 import org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState
 import org.cru.godtools.model.Translation
 import org.cru.godtools.xml.model.Manifest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class ToolStateTest {

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ActivityToolLoadingBindingTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ActivityToolLoadingBindingTest.kt
@@ -5,13 +5,13 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.EnumSet
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class ActivityToolLoadingBindingTest {

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ActivityToolMissingBindingTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ActivityToolMissingBindingTest.kt
@@ -5,13 +5,13 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.EnumSet
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class ActivityToolMissingBindingTest {

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ToolGenericFragmentActivityBindingTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/ToolGenericFragmentActivityBindingTest.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.EnumSet
 import org.cru.godtools.base.tool.R
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.junit.Assert
@@ -13,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class ToolGenericFragmentActivityBindingTest {

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.kt
@@ -17,13 +17,13 @@ import androidx.lifecycle.Lifecycle
 import butterknife.BindView
 import butterknife.ButterKnife
 import dagger.android.AndroidInjection
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.onDestroy
 import org.ccci.gto.android.common.base.Constants.INVALID_LAYOUT_RES
 import org.ccci.gto.android.common.dagger.viewmodel.DaggerSavedStateViewModelProviderFactory
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ui.R2
 import org.greenrobot.eventbus.EventBus
-import javax.inject.Inject
 
 private const val EXTRA_FEATURE_DISCOVERY = "org.cru.godtools.BaseActivity.FEATURE_DISCOVERY"
 private const val EXTRA_FEATURE = "org.cru.godtools.BaseActivity.FEATURE"

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/BaseBottomSheetDialogFragment.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/BaseBottomSheetDialogFragment.kt
@@ -8,8 +8,8 @@ import androidx.databinding.ViewDataBinding
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
-import org.ccci.gto.android.common.dagger.viewmodel.DaggerSavedStateViewModelProviderFactory
 import javax.inject.Inject
+import org.ccci.gto.android.common.dagger.viewmodel.DaggerSavedStateViewModelProviderFactory
 
 abstract class BaseBottomSheetDialogFragment<B : ViewBinding> : BottomSheetDialogFragment() {
     // region Lifecycle

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/BaseFragment.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/BaseFragment.kt
@@ -11,9 +11,9 @@ import androidx.viewbinding.ViewBinding
 import butterknife.ButterKnife
 import butterknife.Unbinder
 import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
 import org.ccci.gto.android.common.base.Constants.INVALID_LAYOUT_RES
 import org.ccci.gto.android.common.dagger.viewmodel.DaggerSavedStateViewModelProviderFactory
-import javax.inject.Inject
 
 abstract class BaseFragment<B : ViewBinding> @JvmOverloads constructor(
     @LayoutRes contentLayoutId: Int? = INVALID_LAYOUT_RES

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
@@ -9,8 +9,8 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
 import androidx.core.content.res.ResourcesCompat
-import org.cru.godtools.base.ui.R
 import java.util.Locale
+import org.cru.godtools.base.ui.R
 
 @OptIn(ExperimentalStdlibApi::class)
 private val typefaces = buildMap<Locale, Int> {

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/util/ModelUtils.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/util/ModelUtils.kt
@@ -3,10 +3,10 @@
 package org.cru.godtools.base.ui.util
 
 import android.content.Context
+import java.util.Locale
 import org.ccci.gto.android.common.util.content.localize
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
-import java.util.Locale
 
 @JvmName("getTranslationName")
 fun Translation?.getName(tool: Tool?, context: Context?) =

--- a/ui/base/src/test/java/org/cru/godtools/base/ui/util/ModelUtilsRobolectricTest.kt
+++ b/ui/base/src/test/java/org/cru/godtools/base/ui/util/ModelUtilsRobolectricTest.kt
@@ -3,13 +3,13 @@ package org.cru.godtools.base.ui.util
 import android.app.Activity
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
 import org.cru.godtools.model.Tool
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class ModelUtilsRobolectricTest {

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -13,6 +13,12 @@ import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import com.squareup.picasso.Picasso
+import java.io.IOException
+import java.lang.ref.WeakReference
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -45,12 +51,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
 import timber.log.Timber
-import java.io.IOException
-import java.lang.ref.WeakReference
-import java.util.Locale
-import java.util.concurrent.atomic.AtomicReference
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val TYPE_TOOL = "tool|"
 

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.EnumSet
 import org.cru.godtools.base.Settings
 import org.cru.godtools.model.Tool
 import org.greenrobot.eventbus.EventBus
@@ -15,7 +16,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class GodToolsShortcutManagerTest {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/LanguageToggleController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/LanguageToggleController.kt
@@ -1,12 +1,12 @@
 package org.cru.godtools.tract.activity
 
 import com.google.android.material.tabs.TabLayout
+import java.util.Locale
 import org.ccci.gto.android.common.material.tabs.setBackgroundTint
 import org.cru.godtools.base.util.getDisplayName
 import org.cru.godtools.model.Language
 import org.cru.godtools.xml.model.Manifest
 import org.cru.godtools.xml.model.navBarControlColor
-import java.util.Locale
 
 class LanguageToggleController(private val tabs: TabLayout) {
     var activeLocale: Locale? = null

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/ModalActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/ModalActivity.kt
@@ -9,6 +9,7 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.observe
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.util.os.getLocale
 import org.ccci.gto.android.common.util.os.putLocale
@@ -27,7 +28,6 @@ import org.cru.godtools.tract.ui.controller.bindController
 import org.cru.godtools.xml.model.Modal
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import javax.inject.Inject
 
 internal fun Activity.startModalActivity(modal: Modal) = startActivity(
     Intent(this, ModalActivity::class.java).putExtras(Bundle(4).apply {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.map
 import androidx.lifecycle.observe
 import com.google.android.instantapps.InstantApps
 import com.google.android.material.tabs.TabLayout
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
@@ -64,8 +66,6 @@ import org.cru.godtools.xml.model.navBarControlColor
 import org.cru.godtools.xml.model.tips.Tip
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import java.util.Locale
-import javax.inject.Inject
 
 private const val EXTRA_LANGUAGES = "org.cru.godtools.tract.activity.TractActivity.LANGUAGES"
 private const val EXTRA_INITIAL_PAGE = "org.cru.godtools.tract.activity.TractActivity.INITIAL_PAGE"

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivityDataModel.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import java.util.Locale
+import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
@@ -32,8 +34,6 @@ import org.cru.godtools.model.TranslationKey
 import org.cru.godtools.xml.model.Manifest
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
-import javax.inject.Named
 
 private const val STATE_ACTIVE_LOCALE = "activeLocale"
 private const val STATE_LIVE_SHARE_TUTORIAL_SHOWN = "liveShareTutorialShown"

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ToggleLanguageAnalyticsActionEvent.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/ToggleLanguageAnalyticsActionEvent.kt
@@ -1,10 +1,10 @@
 package org.cru.godtools.tract.analytics.model
 
+import java.util.Locale
 import org.ccci.gto.android.common.compat.util.LocaleCompat.toLanguageTag
 import org.cru.godtools.analytics.adobe.ADOBE_ATTR_LANGUAGE_SECONDARY
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
-import java.util.Locale
 
 private const val ACTION_TOGGLE_LANGUAGE = "Parallel Language Toggled"
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEvent.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEvent.kt
@@ -1,8 +1,8 @@
 package org.cru.godtools.tract.analytics.model
 
+import java.util.Locale
 import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
-import java.util.Locale
 
 class TractPageAnalyticsScreenEvent(tool: String, locale: Locale, page: Int, card: Int?) :
     ToolAnalyticsScreenEvent(tractPageToScreenName(tool, page, card), tool, locale) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/liveshare/TractPublisherController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/liveshare/TractPublisherController.kt
@@ -8,6 +8,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.tinder.StateMachine
 import com.tinder.scarlet.WebSocket
+import java.util.UUID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.consumeEach
@@ -24,7 +25,6 @@ import org.cru.godtools.api.TractShareService.Companion.PARAM_CHANNEL_ID
 import org.cru.godtools.api.model.NavigationEvent
 import org.cru.godtools.api.model.PublisherInfo
 import timber.log.Timber
-import java.util.UUID
 
 private const val TAG = "TractPublisherContrller"
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/liveshare/TractSubscriberController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/liveshare/TractSubscriberController.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tinder.StateMachine
 import com.tinder.scarlet.WebSocket
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.consumeEach
@@ -19,7 +20,6 @@ import org.cru.godtools.api.TractShareService.Companion.CHANNEL_SUBSCRIBER
 import org.cru.godtools.api.TractShareService.Companion.PARAM_CHANNEL_ID
 import org.cru.godtools.api.model.NavigationEvent
 import timber.log.Timber
-import javax.inject.Inject
 
 private const val TAG = "TractSubscribrControllr"
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/service/FollowupService.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/service/FollowupService.kt
@@ -3,6 +3,8 @@ package org.cru.godtools.tract.service
 import android.os.AsyncTask
 import androidx.annotation.WorkerThread
 import dagger.Lazy
+import javax.inject.Inject
+import javax.inject.Singleton
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.model.Followup
 import org.cru.godtools.sync.GodToolsSyncService
@@ -10,8 +12,6 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import org.keynote.godtools.android.db.GodToolsDao
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private const val FIELD_NAME = "name"
 private const val FIELD_EMAIL = "email"

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tract.ui.controller
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.lifecycle.Observer
+import kotlin.reflect.KClass
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -15,7 +16,6 @@ import org.cru.godtools.xml.model.Base
 import org.cru.godtools.xml.model.layoutDirection
 import org.cru.godtools.xml.model.tips.Tip
 import org.greenrobot.eventbus.EventBus
-import kotlin.reflect.KClass
 
 abstract class BaseController<T : Base> protected constructor(
     private val modelClass: KClass<T>,

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
@@ -4,10 +4,10 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.annotation.CallSuper
 import androidx.annotation.UiThread
+import kotlin.reflect.KClass
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.xml.model.Content
 import org.cru.godtools.xml.model.Parent
-import kotlin.reflect.KClass
 
 abstract class ParentController<T> protected constructor(
     clazz: KClass<T>,

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.ViewGroup
 import androidx.core.util.Pools
+import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
@@ -15,7 +16,6 @@ import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
 import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
-import kotlin.reflect.KClass
 
 internal class UiControllerCache(private val parent: ViewGroup, private val parentController: BaseController<*>?) {
     private val pools = mutableMapOf<KClass<*>, Pools.Pool<BaseController<*>>>()

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.map
 import androidx.lifecycle.observe
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
@@ -25,8 +27,6 @@ import org.cru.godtools.xml.model.tips.Tip
 import org.keynote.godtools.android.db.Contract.TrainingTipTable
 import org.keynote.godtools.android.db.GodToolsDao
 import splitties.fragmentargs.arg
-import java.util.Locale
-import javax.inject.Inject
 
 class TipBottomSheetDialogFragment() : BaseBottomSheetDialogFragment<TractTipBinding>(), TipCallbacks {
     internal constructor(tip: Tip) : this() {

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/LanguageToggleControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/LanguageToggleControllerTest.kt
@@ -7,12 +7,12 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class LanguageToggleControllerTest {

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDataModelTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDataModelTest.kt
@@ -14,6 +14,7 @@ import com.nhaarman.mockitokotlin2.nullableArgumentCaptor
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.Locale
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -32,7 +33,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.keynote.godtools.android.db.GodToolsDao
-import java.util.Locale
 
 private const val TOOL = "kgp"
 

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDeepLinkTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityDeepLinkTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tract.activity
 
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -10,7 +11,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class TractActivityDeepLinkTest {

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/databinding/TractActivityBindingTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/databinding/TractActivityBindingTest.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.EnumSet
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.cru.godtools.tract.R
 import org.junit.Assert.assertEquals
@@ -13,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import java.util.EnumSet
 
 @RunWith(AndroidJUnit4::class)
 class TractActivityBindingTest {

--- a/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/PageSet.kt
+++ b/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/PageSet.kt
@@ -1,9 +1,9 @@
 package org.cru.godtools.tutorial
 
+import java.util.Locale
 import org.ccci.gto.android.common.compat.util.LocaleCompat
 import org.ccci.gto.android.common.util.LocaleUtils
 import org.cru.godtools.base.Settings
-import java.util.Locale
 
 enum class PageSet(
     internal val feature: String? = null,

--- a/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/analytics/model/TutorialAnalyticsScreenEvent.kt
+++ b/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/analytics/model/TutorialAnalyticsScreenEvent.kt
@@ -1,8 +1,8 @@
 package org.cru.godtools.tutorial.analytics.model
 
+import java.util.Locale
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.tutorial.PageSet
-import java.util.Locale
 
 class TutorialAnalyticsScreenEvent(private val tutorial: PageSet, page: Int, locale: Locale?) :
     AnalyticsScreenEvent("${tutorial.analyticsBaseScreenName}-${page + 1}", locale) {

--- a/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageSetTest.kt
+++ b/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageSetTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tutorial
 
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
 import org.hamcrest.Matchers.greaterThanOrEqualTo
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -9,7 +10,6 @@ import org.junit.Assume.assumeThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [17, 21, 28])


### PR DESCRIPTION
the Kotlin 1.4 AndroidStudio plugin adds the ability to specify import sort order. This PR sets the import order to match the android import ordering recommended in the official android Kotlin style guide [here](https://developer.android.com/kotlin/style-guide#import_statements), it also corrects the import order for all the existing files and re-enables the ktlint check to enforce import order