### PR TITLE
GT-850 trigger the initial sync later in initialization

### DIFF
--- a/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
+++ b/app/src/main/java/org/cru/godtools/fragment/BasePlatformFragment.kt
@@ -39,7 +39,10 @@ abstract class BasePlatformFragment<B : ViewDataBinding>(@LayoutRes layoutId: In
         savedInstanceState?.let {
             syncHelper.onRestoreInstanceState(it.getBundle(EXTRA_SYNC_HELPER))
         }
+    }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
         triggerInitialSync()
     }
 


### PR DESCRIPTION
the sync being triggered in onCreate was causing a crash when the parent activity was being re-created because the activity was still being created and hadn't initialized it's views yet.
onActivityCreated has the contract that it will be called once the activity has been created.