### PR TITLE
GT-925 utilize showAllowingStateLoss when displaying the Live Share connecting dialog

### DIFF
--- a/ui/base/build.gradle
+++ b/ui/base/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     api "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
     implementation "androidx.browser:browser:${deps.androidX.browser}"
+    compileOnly "androidx.fragment:fragment-ktx:${deps.androidX.fragment}"
     api "com.google.android.material:material:${deps.materialDesign}"
 
     implementation "org.ccci.gto.android:gto-support-androidx-lifecycle:${deps.gtoSupport}"

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/DialogFragment.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/fragment/DialogFragment.kt
@@ -1,0 +1,10 @@
+package org.cru.godtools.base.ui.fragment
+
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
+
+@Deprecated("This will be in gto-support 3.6.2+")
+fun DialogFragment.showAllowingStateLoss(manager: FragmentManager, tag: String?) {
+    manager.commit(true) { add(this@showAllowingStateLoss, tag) }
+}

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -38,6 +38,7 @@ import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_LIVE_SHARE
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.cru.godtools.base.tool.model.view.bindBackgroundImage
+import org.cru.godtools.base.ui.fragment.showAllowingStateLoss
 import org.cru.godtools.tract.Constants.PARAM_LIVE_SHARE_STREAM
 import org.cru.godtools.tract.Constants.PARAM_PARALLEL_LANGUAGE
 import org.cru.godtools.tract.Constants.PARAM_PRIMARY_LANGUAGE
@@ -489,7 +490,7 @@ class TractActivity : BaseToolActivity<TractActivityBinding>(R.layout.tract_acti
                 settings.getFeatureDiscoveredCount("$FEATURE_TUTORIAL_LIVE_SHARE${dataModel.tool.value}") < 3 ->
                 startActivityForResult(buildTutorialActivityIntent(PageSet.LIVE_SHARE), REQUEST_LIVE_SHARE_TUTORIAL)
             publisherController.publisherInfo.value == null ->
-                LiveShareStartingDialogFragment().show(supportFragmentManager, null)
+                LiveShareStartingDialogFragment().showAllowingStateLoss(supportFragmentManager, null)
             else -> {
                 val subscriberId = publisherController.publisherInfo.value?.subscriberChannelId ?: return
                 val shareUrl = (buildShareLink() ?: return)


### PR DESCRIPTION
This dialog could be triggered from onActivityResult which is after onInstanceSaveState(), but is meant as a transient dialog so we don't really need to track it's state