### PR TITLE
GT-908 enable instant app functionality for the core app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:dist="http://schemas.android.com/apk/distribution"
     package="org.cru.godtools">
 
     <!-- Unused permissions, kept around for older android in case we want to start using them again -->
@@ -30,6 +31,8 @@
         android:name="android.hardware.location"
         android:required="false" />
 
+    <dist:module dist:instant="true" />
+
     <application
         android:name=".GodToolsApplication"
         android:allowBackup="false"
@@ -48,6 +51,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+                <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="@string/account_deeplink_host" />
                 <data android:path="@string/account_deeplink_path" />


### PR DESCRIPTION
This makes the entire app an Instant App. This is a functional first step, over time we may want to move some functionality out into other dynamic features. The 2 that immediately come to mind are: move tutorial content to its own feature, and move the tract logic into its own feature.

the tutorial dynamic feature would reduce instant app size by probably 30-40% due to all the large images in the tutorial. the tract dynamic feature wouldn't have a functional benefit at this time, but could long term if we start making other parts of the app instant-app capable