### PR TITLE
GT-964 expose a LifecycleOwner within the tract tool renderer

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.tract.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.MainThread
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import androidx.viewpager.widget.PagerAdapter
@@ -12,7 +13,7 @@ import org.ccci.gto.android.common.androidx.lifecycle.onStart
 import org.ccci.gto.android.common.androidx.lifecycle.onStop
 import org.ccci.gto.android.common.eventbus.lifecycle.register
 import org.ccci.gto.android.common.support.v4.util.IdUtils
-import org.ccci.gto.android.common.viewpager.adapter.DataBindingPagerAdapter
+import org.ccci.gto.android.common.viewpager.adapter.BaseDataBindingPagerAdapter
 import org.ccci.gto.android.common.viewpager.adapter.DataBindingViewHolder
 import org.cru.godtools.api.model.NavigationEvent
 import org.cru.godtools.base.model.Event
@@ -28,11 +29,14 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 
+// XXX: we override BaseDataBindingPagerAdapter instead of DataBindingPagerAdapter to prevent DataBindingPagerAdapter
+//      from setting the lifecycleOwner for the databinding.
 class ManifestPagerAdapter @AssistedInject internal constructor(
     @Assisted lifecycleOwner: LifecycleOwner,
     private val pageControllerFactory: PageController.Factory,
     eventBus: EventBus
-) : DataBindingPagerAdapter<TractPageBinding>(lifecycleOwner), PageController.Callbacks, Observer<Manifest?> {
+) : BaseDataBindingPagerAdapter<TractPageBinding, DataBindingViewHolder<TractPageBinding>>(lifecycleOwner),
+    PageController.Callbacks, Observer<Manifest?> {
     @AssistedInject.Factory
     interface Factory {
         fun create(lifecycleOwner: LifecycleOwner): ManifestPagerAdapter
@@ -75,20 +79,28 @@ class ManifestPagerAdapter @AssistedInject internal constructor(
         manifest = t
     }
 
-    override fun onCreateViewDataBinding(parent: ViewGroup) =
-        TractPageBinding.inflate(LayoutInflater.from(parent.context), parent, false).apply {
-            bindController(pageControllerFactory).also {
-                it.callbacks = this@ManifestPagerAdapter
+    override fun onCreateViewHolder(parent: ViewGroup) = DataBindingViewHolder(
+        TractPageBinding.inflate(LayoutInflater.from(parent.context), parent, false).also { binding ->
+            binding.bindController(pageControllerFactory, lifecycleOwner).also {
+                it.callbacks = this
                 it.isTipsEnabled = showTips
             }
         }
+    )
 
     override fun onBindViewDataBinding(
         holder: DataBindingViewHolder<TractPageBinding>,
         binding: TractPageBinding,
         position: Int
     ) {
-        binding.controller?.model = getItem(position)
+        binding.controller?.let { controller ->
+            controller.model = getItem(position)
+            controller.lifecycleOwner?.apply { maxState = maxOf(maxState, Lifecycle.State.STARTED) }
+        }
+    }
+
+    override fun onViewDataBindingRecycled(holder: DataBindingViewHolder<TractPageBinding>, binding: TractPageBinding) {
+        binding.controller?.lifecycleOwner?.maxState = Lifecycle.State.CREATED
     }
 
     override fun onUpdatePrimaryItem(
@@ -102,7 +114,9 @@ class ManifestPagerAdapter @AssistedInject internal constructor(
 
         val oldController = oldBinding?.controller
         if (oldController !== controller) {
+            oldController?.lifecycleOwner?.maxState = Lifecycle.State.STARTED
             oldController?.isVisible = false
+            controller?.lifecycleOwner?.maxState = Lifecycle.State.RESUMED
             controller?.isVisible = true
         }
     }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.View
 import androidx.annotation.CallSuper
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import kotlin.reflect.KClass
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +28,7 @@ abstract class BaseController<T : Base> protected constructor(
             checkNotNull(parentController) { "No EventBus found in controller ancestors" }
             return parentController.eventBus
         }
+    internal open val lifecycleOwner: LifecycleOwner? get() = parentController?.lifecycleOwner
 
     var model: T? = null
         set(value) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -130,8 +130,12 @@ class PageController @AssistedInject internal constructor(
     }
 
     private fun updateVisibleCard(old: CardController?) {
-        if (!isVisible || old == activeCardController) return
+        if (old == activeCardController) return
 
+        if (old == null) heroController.lifecycleOwner?.maxState = Lifecycle.State.STARTED
+        if (activeCardController == null) heroController.lifecycleOwner?.maxState = Lifecycle.State.RESUMED
+
+        if (!isVisible) return
         (old ?: heroController).isVisible = false
         (activeCardController ?: heroController).isVisible = true
     }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/widget/PageContentLayout.java
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/widget/PageContentLayout.java
@@ -946,16 +946,14 @@ public class PageContentLayout extends FrameLayout implements NestedScrollingPar
         @UiThread
         @Override
         public void handleMessage(Message msg) {
-            super.handleMessage(msg);
-
-            final PageContentLayout layout = mPageContentLayout.get();
-            if (layout != null) {
-                switch (msg.what) {
-                    case MSG_BOUNCE_ANIMATION:
+            switch (msg.what) {
+                case MSG_BOUNCE_ANIMATION:
+                    final PageContentLayout layout = mPageContentLayout.get();
+                    if (layout != null && layout.mBounceFirstCard) {
                         layout.bounceFirstCard();
                         enqueueBounce(BOUNCE_ANIMATION_DELAY);
-                        break;
-                }
+                    }
+                    break;
             }
         }
     }

--- a/ui/tract-renderer/src/main/res/layout/tract_page.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_page.xml
@@ -11,8 +11,10 @@
 
         <variable name="controller" type="org.cru.godtools.tract.ui.controller.PageController" />
         <variable name="page" type="org.cru.godtools.xml.model.Page" />
+        <variable name="isVisible" type="Boolean" />
         <variable name="enableTips" type="Boolean" />
         <variable name="callbacks" type="org.cru.godtools.tract.ui.controller.PageController.Callbacks" />
+        <variable name="cardsDiscovered" type="androidx.lifecycle.LiveData&lt;Boolean&gt;" />
     </data>
 
     <RelativeLayout
@@ -38,7 +40,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginTop="?attr/actionBarSize"
-            android:layoutDirection="inherit">
+            android:layoutDirection="inherit"
+            app:bounceFirstCard="@{isVisible &amp;&amp; !cardsDiscovered}">
 
             <org.ccci.gto.android.common.widget.HackyNestedScrollView
                 android:id="@+id/initial_page_content"

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ExternalSingletonsModule.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ExternalSingletonsModule.kt
@@ -46,7 +46,11 @@ class ExternalSingletonsModule {
     @get:Provides
     val referenceLifecycle by lazy { mock<ReferenceLifecycle>() }
     @get:Provides
-    val settings by lazy { mock<Settings>() }
+    val settings by lazy {
+        mock<Settings> {
+            on { isFeatureDiscoveredLiveData(any()) } doAnswer { ImmutableLiveData(true) }
+        }
+    }
     @get:Provides
     val syncService by lazy { mock<GodToolsSyncService>(defaultAnswer = RETURNS_DEEP_STUBS) }
     @get:Provides

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
@@ -57,7 +57,7 @@ class PageControllerTest {
         hiltRule.inject()
         val activity = Robolectric.buildActivity(TestActivity::class.java).create().get()
         binding = TractPageBinding.inflate(LayoutInflater.from(activity))
-        controller = PageController(binding, eventBus, settings)
+        controller = PageController(binding, null, eventBus, settings)
     }
 
     @Test


### PR DESCRIPTION
Eventually I want to switch the manual management of an isVisible flag to utilizing `LifecycleOwners`