### PR TITLE
GT-986 the updateShortcutActor should always accept requests

### DIFF
--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -205,8 +205,8 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     @VisibleForTesting
     @OptIn(ObsoleteCoroutinesApi::class)
     internal val updateShortcutsActor = coroutineScope.actor<Unit>(capacity = CONFLATED) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            channel.consumeAsFlow().conflate().collectLatest {
+        channel.consumeAsFlow().conflate().collectLatest {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
                 delay(DELAY_UPDATE_SHORTCUTS)
                 updateShortcuts()
             }

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -169,6 +169,11 @@ class GodToolsShortcutManagerTest {
     fun verifyUpdateExistingShortcutsNotAvailableForOldSdks() {
         assumeThat(Build.VERSION.SDK_INT, lessThan(Build.VERSION_CODES.N_MR1))
         coroutineScope.advanceUntilIdle()
+        assertTrue(
+            "Ensure actor can still accept requests, even though they are no-ops",
+            shortcutManager.updateShortcutsActor.offer(Unit)
+        )
+        coroutineScope.advanceUntilIdle()
         verifyZeroInteractions(dao)
     }
     // endregion Update Existing Shortcuts


### PR DESCRIPTION
On older versions of android there was a non-fatal exception thrown anytime the shortcut manager would have ran because the `updateShortcutActor` would finish processing and shutdown on launch.