### PR TITLE
GT-998 Toggle language analytics event

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/LanguageToggleController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/LanguageToggleController.kt
@@ -9,6 +9,9 @@ import org.cru.godtools.xml.model.Manifest
 import org.cru.godtools.xml.model.navBarControlColor
 
 class LanguageToggleController(private val tabs: TabLayout) {
+    var isUpdatingTabs: Boolean = false
+        private set
+
     var activeLocale: Locale? = null
         set(value) {
             val changed = value != field
@@ -35,21 +38,27 @@ class LanguageToggleController(private val tabs: TabLayout) {
         }
 
     private fun createTabs() {
-        // if the selected locale is no longer valid, we need to remove all tabs to prevent an onTabSelected callback
-        val selected = tabs.getTabAt(tabs.selectedTabPosition)?.tag as? Locale
-        if (selected != null && !locales.contains(selected)) tabs.removeAllTabs()
+        isUpdatingTabs = true
+        try {
+            // de-select the tab if the currently selected locale is no longer valid
+            val selected = tabs.getTabAt(tabs.selectedTabPosition)?.tag as? Locale
+            if (selected != null && !locales.contains(selected)) tabs.selectTab(null)
 
-        // update tabs
-        locales.forEachIndexed { i, locale ->
-            // if this is the selected locale, reposition the selected tab
-            if (locale == selected) while (tabs.selectedTabPosition > i) tabs.removeTabAt(i)
+            // update tabs
+            locales.forEachIndexed { i, locale ->
+                // if this is the selected locale, reposition the selected tab
+                if (locale == selected) while (tabs.selectedTabPosition > i) tabs.removeTabAt(i)
 
-            // insert a new tab if the current tab isn't correct
-            if (tabs.getTabAt(i)?.tag != locale) tabs.addTab(tabs.newTab().setTag(locale), i, locale == activeLocale)
+                // insert a new tab if the current tab isn't correct
+                if (tabs.getTabAt(i)?.tag != locale)
+                    tabs.addTab(tabs.newTab().setTag(locale), i, locale == activeLocale)
+            }
+
+            // remove any excess tabs
+            while (tabs.tabCount > locales.size) tabs.removeTabAt(locales.size)
+        } finally {
+            isUpdatingTabs = false
         }
-
-        // remove excess tabs
-        while (tabs.tabCount > locales.size) tabs.removeTabAt(locales.size)
         configureTabs()
     }
 
@@ -64,14 +73,19 @@ class LanguageToggleController(private val tabs: TabLayout) {
     }
 
     private fun updateSelectedTab() {
-        tabs.forEachTab { tab ->
-            val locale = tab.tag as? Locale
-            if (activeLocale != null && locale == activeLocale) {
-                if (!tab.isSelected) tab.select()
-                return
-            } else {
-                if (tab.isSelected) tabs.selectTab(null)
+        isUpdatingTabs = true
+        try {
+            tabs.forEachTab { tab ->
+                val locale = tab.tag as? Locale
+                if (activeLocale != null && locale == activeLocale) {
+                    if (!tab.isSelected) tab.select()
+                    return
+                } else {
+                    if (tab.isSelected) tabs.selectTab(null)
+                }
             }
+        } finally {
+            isUpdatingTabs = false
         }
     }
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -301,9 +301,10 @@ class TractActivity : BaseToolActivity<TractActivityBinding>(R.layout.tract_acti
     }
 
     // region Language Toggle
+    private lateinit var languageToggleController: LanguageToggleController
+
     private fun setupLanguageToggle() {
         ViewCompat.setClipToOutline(binding.languageToggle, true)
-        binding.languageToggle.addOnTabSelectedListener(this)
         dataModel.activeManifest.observe(this) { manifest ->
             // determine colors for the language toggle
             val controlColor = manifest.navBarControlColor
@@ -319,15 +320,19 @@ class TractActivity : BaseToolActivity<TractActivityBinding>(R.layout.tract_acti
             ViewUtils.setBackgroundTint(binding.languageToggle, controlColor)
         }
 
-        val controller = LanguageToggleController(binding.languageToggle)
-        dataModel.activeLocale.observe(this) { controller.activeLocale = it }
-        dataModel.activeManifest.observe(this) { controller.activeManifest = it }
-        dataModel.visibleLocales.observe(this) { controller.locales = it }
-        dataModel.languages.observe(this) { controller.languages = it }
+        languageToggleController = LanguageToggleController(binding.languageToggle).also { controller ->
+            dataModel.activeLocale.observe(this) { controller.activeLocale = it }
+            dataModel.activeManifest.observe(this) { controller.activeManifest = it }
+            dataModel.visibleLocales.observe(this) { controller.locales = it }
+            dataModel.languages.observe(this) { controller.languages = it }
+        }
+
+        binding.languageToggle.addOnTabSelectedListener(this)
     }
 
     // region TabLayout.OnTabSelectedListener
     override fun onTabSelected(tab: TabLayout.Tab) {
+        if (languageToggleController.isUpdatingTabs) return
         val locale = tab.tag as? Locale ?: return
         eventBus.post(ToggleLanguageAnalyticsActionEvent(dataModel.tool.value, locale))
         dataModel.setActiveLocale(locale)

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/LanguageToggleControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/LanguageToggleControllerTest.kt
@@ -4,11 +4,16 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.tabs.TabLayout
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import java.util.Locale
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -61,5 +66,41 @@ class LanguageToggleControllerTest {
         assertEquals(2, tabLayout.tabCount)
         assertEquals(-1, tabLayout.selectedTabPosition)
         verify(tabListener, never()).onTabSelected(any())
+    }
+
+    @Test
+    fun testIsUpdatingTabsValueWhenMakingStructuralChanges() {
+        tabListener = spy(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab?) = assertTrue(controller.isUpdatingTabs)
+            override fun onTabUnselected(tab: TabLayout.Tab?) = assertTrue(controller.isUpdatingTabs)
+            override fun onTabReselected(tab: TabLayout.Tab?) = assertTrue(controller.isUpdatingTabs)
+        })
+        tabLayout.addOnTabSelectedListener(tabListener)
+
+        // initial tabs
+        assertFalse(controller.isUpdatingTabs)
+        controller.activeLocale = Locale.ENGLISH
+        controller.locales = listOf(Locale.ENGLISH, Locale.FRENCH)
+        assertFalse(controller.isUpdatingTabs)
+        verify(tabListener).onTabSelected(any())
+        verifyNoMoreInteractions(tabListener)
+        clearInvocations(tabListener)
+
+        // change activeLocale
+        assertFalse(controller.isUpdatingTabs)
+        controller.activeLocale = Locale.FRENCH
+        assertFalse(controller.isUpdatingTabs)
+        verify(tabListener).onTabSelected(any())
+        verify(tabListener).onTabUnselected(any())
+        verifyNoMoreInteractions(tabListener)
+        clearInvocations(tabListener)
+
+        // change locales
+        assertFalse(controller.isUpdatingTabs)
+        controller.locales = listOf(Locale.ENGLISH)
+        assertFalse(controller.isUpdatingTabs)
+        verify(tabListener, never()).onTabSelected(any())
+        verify(tabListener).onTabUnselected(any())
+        verifyNoMoreInteractions(tabListener)
     }
 }


### PR DESCRIPTION
This fixes misfires of the toggle language analytics event. the event should only fire when the ToggleController isn't updating the visible language tabs.