### PR TITLE
Remove AsyncDao

### DIFF
--- a/library/db/build.gradle
+++ b/library/db/build.gradle
@@ -7,14 +7,12 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-androidx-lifecycle:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-core:${deps.gtoSupport}"
     api "org.ccci.gto.android:gto-support-db:${deps.gtoSupport}"
-    api "org.ccci.gto.android:gto-support-db-async:${deps.gtoSupport}"
     api "org.ccci.gto.android:gto-support-db-coroutines:${deps.gtoSupport}"
     api "org.ccci.gto.android:gto-support-db-livedata:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 
     implementation "com.google.dagger:dagger:${deps.dagger}"
     implementation "com.google.dagger:hilt-android:${deps.hilt}"
-    api "com.google.guava:guava:${deps.guava}"
 
     kapt "com.google.dagger:dagger-compiler:${deps.dagger}"
 }

--- a/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.kt
+++ b/library/db/src/main/java/org/keynote/godtools/android/db/GodToolsDao.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.db.AbstractDao
-import org.ccci.gto.android.common.db.AsyncDao
 import org.ccci.gto.android.common.db.CoroutinesFlowDao
 import org.ccci.gto.android.common.db.LiveDataDao
 import org.ccci.gto.android.common.db.LiveDataRegistry
@@ -44,8 +43,8 @@ import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 
 @Singleton
-class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) : AbstractDao(database), AsyncDao,
-    CoroutinesFlowDao, LiveDataDao {
+class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) : AbstractDao(database), CoroutinesFlowDao,
+    LiveDataDao {
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     override val liveDataRegistry = LiveDataRegistry()
 

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -22,6 +22,7 @@ import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.util.graphics.toHslColor
 import org.cru.godtools.base.Settings
@@ -345,7 +346,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         )
         settings.setFeatureDiscovered(Settings.FEATURE_TOOL_OPENED)
 
-        dao.updateSharesDeltaAsync(tool, 1)
+        GlobalScope.launch { dao.updateSharesDelta(tool, 1) }
     }
 
     override fun setTitle(title: CharSequence) =

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
@@ -16,6 +16,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.fragment.app.findListener
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
@@ -115,10 +117,11 @@ class TipBottomSheetDialogFragment() : BaseBottomSheetDialogFragment<TractTipBin
     }
 
     override fun closeTip(completed: Boolean) {
-        if (completed) dao.updateOrInsertAsync(
-            TrainingTip(tool, locale, tip).apply { isCompleted = true },
-            TrainingTipTable.COLUMN_IS_COMPLETED
-        )
+        if (completed) {
+            val trainingTip = TrainingTip(tool, locale, tip)
+            trainingTip.isCompleted = true
+            GlobalScope.launch { dao.updateOrInsert(trainingTip, TrainingTipTable.COLUMN_IS_COMPLETED) }
+        }
         dismissAllowingStateLoss()
     }
     // endregion TipPageController.Callbacks


### PR DESCRIPTION
`AsyncDao` utilizes Google Gauva and Futures. Modern android development relies on coroutines to asynchronously execute logic.

This PR removes `AsyncDao` in favor of coroutine alternatives