### PR TITLE
launch the key signup page instead of Okta

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,9 @@ android {
 
             buildConfigField "String", "OKTA_CLIENT_ID", "\"0oatqowo16nlzqJRV0h7\""
             buildConfigField "String", "OKTA_DISCOVERY_URI", "\"https://cru.oktapreview.com\""
+
+            buildConfigField "String", "THEKEY_URI", "\"https://stage.thekey.me/cas/login\""
+            buildConfigField "String", "THEKEY_CLIENT_ID", "\"5337397229970887848\""
         }
         production {
             dimension "env"
@@ -53,6 +56,9 @@ android {
 
             buildConfigField "String", "OKTA_CLIENT_ID", "\"0oa1ju0zx08vYGgbB0h8\""
             buildConfigField "String", "OKTA_DISCOVERY_URI", "\"https://signon.okta.com\""
+
+            buildConfigField "String", "THEKEY_URI", "\"https://thekey.me/cas/login\""
+            buildConfigField "String", "THEKEY_CLIENT_ID", "\"5337397229970887848\""
         }
     }
 

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.LiveData
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.navigation.NavigationView
+import com.okta.oidc.OktaAuthenticationActivity
 import com.okta.oidc.clients.BaseAuth.REMOVE_TOKENS
 import com.okta.oidc.clients.BaseAuth.SIGN_OUT_SESSION
 import com.okta.oidc.clients.web.WebAuthClient
@@ -64,10 +65,15 @@ internal val URI_HELP = Uri.parse("https://godtoolsapp.com/faq/")
 internal val URI_PRIVACY = Uri.parse("https://www.cru.org/about/privacy.html")
 internal val URI_TERMS_OF_USE = Uri.parse("https://godtoolsapp.com/terms-of-use/")
 internal val URI_COPYRIGHT = Uri.parse("https://godtoolsapp.com/copyright/")
-private val URI_SIGNUP = Uri.parse(
-    "https://thekey.me/cas/login?response_type=code&client_id=5337397229970887848" +
-        "&redirect_uri=https%3A%2F%2Fgodtoolsapp.com%2F&action=signup&scope="
-)
+private val URI_SIGNUP = Uri.parse(BuildConfig.THEKEY_URI).buildUpon()
+    .appendQueryParameter("response_type", "code")
+    .appendQueryParameter("client_id", BuildConfig.THEKEY_CLIENT_ID)
+    .appendQueryParameter("action", "signup")
+    .appendQueryParameter("scope", "")
+    .appendQueryParameter("redirect_uri", "${BuildConfig.OKTA_AUTH_SCHEME}:/signup")
+    .build()
+
+private const val REQUEST_SIGNUP = 100
 
 private const val EXTRA_SYNC_HELPER = "org.cru.godtools.activity.BasePlatformActivity.SYNC_HELPER"
 
@@ -146,11 +152,11 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             true
         }
         R.id.action_login -> {
-            launchLogin(false)
+            launchLogin()
             true
         }
         R.id.action_signup -> {
-            openUrl(URI_SIGNUP)
+            launchSignup()
             true
         }
         R.id.action_logout -> {
@@ -198,6 +204,13 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             true
         }
         else -> onOptionsItemSelected(item)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when (requestCode) {
+            REQUEST_SIGNUP -> if (resultCode == RESULT_OK) launchLogin()
+            else -> super.onActivityResult(requestCode, resultCode, data)
+        }
     }
 
     override fun onBackPressed() = when {
@@ -300,8 +313,14 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
         }
     }
 
-    private fun launchLogin(signup: Boolean) {
-        // TODO: figure out how to handle signup
+    private fun launchSignup() {
+        val intent = Intent(this, OktaAuthenticationActivity::class.java)
+            .putExtra("com.okta.auth.AUTH_URI", URI_SIGNUP)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        startActivityForResult(intent, REQUEST_SIGNUP)
+    }
+
+    private fun launchLogin() {
         oktaClient.signIn(this, null)
     }
 

--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -64,6 +64,10 @@ internal val URI_HELP = Uri.parse("https://godtoolsapp.com/faq/")
 internal val URI_PRIVACY = Uri.parse("https://www.cru.org/about/privacy.html")
 internal val URI_TERMS_OF_USE = Uri.parse("https://godtoolsapp.com/terms-of-use/")
 internal val URI_COPYRIGHT = Uri.parse("https://godtoolsapp.com/copyright/")
+private val URI_SIGNUP = Uri.parse(
+    "https://thekey.me/cas/login?response_type=code&client_id=5337397229970887848" +
+        "&redirect_uri=https%3A%2F%2Fgodtoolsapp.com%2F&action=signup&scope="
+)
 
 private const val EXTRA_SYNC_HELPER = "org.cru.godtools.activity.BasePlatformActivity.SYNC_HELPER"
 
@@ -146,7 +150,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             true
         }
         R.id.action_signup -> {
-            launchLogin(true)
+            openUrl(URI_SIGNUP)
             true
         }
         R.id.action_logout -> {


### PR DESCRIPTION
Since Okta self-service registration is still not enabled we are going with the temporary solution of using the key account creation form to create a user account, and then the user will have to know to use login after creating the account to continue.