### PR TITLE
GT-1002 Shortcuts crash

### DIFF
--- a/ui/shortcuts/build.gradle
+++ b/ui/shortcuts/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "com.google.dagger:hilt-android:${deps.hilt}"
     implementation "com.squareup.picasso:picasso:${deps.picasso}"
 
+    testImplementation "org.ccci.gto.android.testing:gto-support-timber:${deps.gtoSupport}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${deps.kotlinCoroutines}"
 
     kapt "com.google.dagger:dagger-compiler:${deps.dagger}"

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -230,8 +230,9 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         updatePinnedShortcuts(shortcuts)
     }
 
+    @VisibleForTesting
     @RequiresApi(Build.VERSION_CODES.N_MR1)
-    private suspend fun updateDynamicShortcuts(shortcuts: Map<String, ShortcutInfoCompat>) = try {
+    internal suspend fun updateDynamicShortcuts(shortcuts: Map<String, ShortcutInfoCompat>) = try {
         withContext(ioDispatcher) {
             shortcutManager?.dynamicShortcuts = Query.select<Tool>()
                 .where(ToolTable.FIELD_ADDED.eq(true))

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -232,21 +232,22 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     @RequiresApi(Build.VERSION_CODES.N_MR1)
-    internal suspend fun updateDynamicShortcuts(shortcuts: Map<String, ShortcutInfoCompat>) = withContext(ioDispatcher) {
-        val dynamicShortcuts = Query.select<Tool>()
-            .where(ToolTable.FIELD_ADDED.eq(true))
-            .orderBy(ToolTable.SQL_ORDER_BY_ORDER)
-            .get(dao).asSequence()
-            .mapNotNull { shortcuts[it.shortcutId]?.toShortcutInfo() }
-            .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
-            .toList()
+    internal suspend fun updateDynamicShortcuts(shortcuts: Map<String, ShortcutInfoCompat>) =
+        withContext(ioDispatcher) {
+            val dynamicShortcuts = Query.select<Tool>()
+                .where(ToolTable.FIELD_ADDED.eq(true))
+                .orderBy(ToolTable.SQL_ORDER_BY_ORDER)
+                .get(dao).asSequence()
+                .mapNotNull { shortcuts[it.shortcutId]?.toShortcutInfo() }
+                .take(ShortcutManagerCompat.getMaxShortcutCountPerActivity(context))
+                .toList()
 
-        try {
-            shortcutManager?.dynamicShortcuts = dynamicShortcuts
-        } catch (e: IllegalStateException) {
-            Timber.tag("GodToolsShortcutManager").e(e, "Error updating dynamic shortcuts")
+            try {
+                shortcutManager?.dynamicShortcuts = dynamicShortcuts
+            } catch (e: IllegalStateException) {
+                Timber.tag("GodToolsShortcutManager").e(e, "Error updating dynamic shortcuts")
+            }
         }
-    }
 
     @RequiresApi(Build.VERSION_CODES.N_MR1)
     private fun updatePinnedShortcuts(shortcuts: Map<String, ShortcutInfoCompat>) {

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -12,7 +12,6 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy


### PR DESCRIPTION
This prevents the updateDynamicShortcuts try-catch from intercepting the `CancellationException` that could be thrown if the coroutine is cancelled while processing