### PR TITLE
GT-1001 Fix Youtube player memory leak

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
@@ -40,7 +40,7 @@ abstract class BaseController<T : Base> protected constructor(
             checkNotNull(parentController) { "No EventBus found in controller ancestors" }
             return parentController.eventBus
         }
-    internal open val lifecycleOwner: LifecycleOwner? get() = parentController?.lifecycleOwner
+    open val lifecycleOwner: LifecycleOwner? get() = parentController?.lifecycleOwner
 
     var model: T? = null
         set(value) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
@@ -21,6 +21,8 @@ class TipPageController @AssistedInject internal constructor(
         binding.controller = this
     }
 
+    override val lifecycleOwner get() = binding.lifecycleOwner
+
     var callbacks: TipCallbacks?
         get() = binding.callbacks
         set(value) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/tips/TipBottomSheetDialogFragment.kt
@@ -96,15 +96,12 @@ class TipBottomSheetDialogFragment() : BaseBottomSheetDialogFragment<TractTipBin
     // region Pages
     @Inject
     lateinit var tipPageAdapterFactory: TipPageAdapter.Factory
-    private val tipPageAdapter by lazy {
-        tipPageAdapterFactory.create(this).also {
-            it.callbacks = this
-            dataModel.tip.observe(this, it)
-        }
-    }
 
     private fun TractTipBinding.setupPages() {
-        pages.adapter = tipPageAdapter
+        pages.adapter = tipPageAdapterFactory.create(viewLifecycleOwner).also {
+            it.callbacks = this@TipBottomSheetDialogFragment
+            dataModel.tip.observe(viewLifecycleOwner, it)
+        }
         pages.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) = trackScreenAnalytics(position)
         })

--- a/ui/tract-renderer/src/main/res/layout/tract_content_video.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_video.xml
@@ -11,6 +11,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/tract_content_margin_horizontal"
         android:layout_marginRight="@dimen/tract_content_margin_horizontal"
+        app:lifecycleOwner="@{controller.lifecycleOwner}"
         app:recue="@{true}"
         app:useWebUi="true"
         app:videoId="@{model.videoId}" />


### PR DESCRIPTION
There was a memory leak when leaving a youtube video in a tip. This registers the YoutubePlayerView with the LIfecycleOwner so that the youtube player can cleanup after itself once the lifecycle is destroyed