### PR TITLE
GT-1043 Update tool UI controllers to be created via Dagger

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/ContentKey.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/ContentKey.kt
@@ -1,0 +1,10 @@
+package org.cru.godtools.tract.dagger
+
+import dagger.MapKey
+import kotlin.reflect.KClass
+import org.cru.godtools.xml.model.Base
+
+@MapKey
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+annotation class ContentKey(val value: KClass<out Base>)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -16,6 +16,7 @@ import org.cru.godtools.tract.ui.controller.LinkController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
+import org.cru.godtools.tract.ui.controller.VideoController
 import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Fallback
@@ -26,6 +27,7 @@ import org.cru.godtools.xml.model.Link
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
+import org.cru.godtools.xml.model.Video
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -79,4 +81,9 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Text::class)
     internal abstract fun textControllerFactory(factory: TextController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Video::class)
+    internal abstract fun videoControllerFactory(factory: VideoController.Factory): BaseController.Factory<*>
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -6,12 +6,19 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import org.cru.godtools.tract.ui.controller.BaseController
+import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TextController
+import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Text
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class UiControllerModule {
+    @Binds
+    @IntoMap
+    @ContentKey(Paragraph::class)
+    internal abstract fun paragraphControllerFactory(factory: ParagraphController.Factory): BaseController.Factory<*>
+
     @Binds
     @IntoMap
     @ContentKey(Text::class)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -17,6 +17,7 @@ import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
 import org.cru.godtools.tract.ui.controller.VideoController
+import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Fallback
@@ -28,6 +29,7 @@ import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
 import org.cru.godtools.xml.model.Video
+import org.cru.godtools.xml.model.tips.InlineTip
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -56,6 +58,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Image::class)
     internal abstract fun imageControllerFactory(factory: ImageController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(InlineTip::class)
+    internal abstract fun inlineTipControllerFactory(factory: InlineTipController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -9,10 +9,12 @@ import org.cru.godtools.tract.ui.controller.BaseController
 import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ParagraphController
+import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
 import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Paragraph
+import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
 
 @Module
@@ -32,6 +34,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Paragraph::class)
     internal abstract fun paragraphControllerFactory(factory: ParagraphController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Tabs::class)
+    internal abstract fun tabsControllerFactory(factory: TabsController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -5,12 +5,14 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
+import org.cru.godtools.tract.ui.controller.AnimationController
 import org.cru.godtools.tract.ui.controller.BaseController
 import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
+import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Paragraph
@@ -20,6 +22,11 @@ import org.cru.godtools.xml.model.Text
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class UiControllerModule {
+    @Binds
+    @IntoMap
+    @ContentKey(Animation::class)
+    internal abstract fun animationControllerFactory(factory: AnimationController.Factory): BaseController.Factory<*>
+
     @Binds
     @IntoMap
     @ContentKey(Fallback::class)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -10,6 +10,7 @@ import org.cru.godtools.tract.ui.controller.BaseController
 import org.cru.godtools.tract.ui.controller.ButtonController
 import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
+import org.cru.godtools.tract.ui.controller.ImageController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
@@ -17,6 +18,7 @@ import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
+import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
@@ -43,6 +45,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Form::class)
     internal abstract fun formControllerFactory(factory: FormController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Image::class)
+    internal abstract fun imageControllerFactory(factory: ImageController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -6,14 +6,21 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import org.cru.godtools.tract.ui.controller.BaseController
+import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TextController
+import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Text
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class UiControllerModule {
+    @Binds
+    @IntoMap
+    @ContentKey(Fallback::class)
+    internal abstract fun fallbackControllerFactory(factory: FallbackController.Factory): BaseController.Factory<*>
+
     @Binds
     @IntoMap
     @ContentKey(Paragraph::class)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -1,0 +1,19 @@
+package org.cru.godtools.tract.dagger
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import org.cru.godtools.tract.ui.controller.BaseController
+import org.cru.godtools.tract.ui.controller.TextController
+import org.cru.godtools.xml.model.Text
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UiControllerModule {
+    @Binds
+    @IntoMap
+    @ContentKey(Text::class)
+    internal abstract fun textControllerFactory(factory: TextController.Factory): BaseController.Factory<*>
+}

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -7,12 +7,14 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import org.cru.godtools.tract.ui.controller.AnimationController
 import org.cru.godtools.tract.ui.controller.BaseController
+import org.cru.godtools.tract.ui.controller.ButtonController
 import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
 import org.cru.godtools.xml.model.Animation
+import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Paragraph
@@ -26,6 +28,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Animation::class)
     internal abstract fun animationControllerFactory(factory: AnimationController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Button::class)
+    internal abstract fun buttonControllerFactory(factory: ButtonController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -12,6 +12,7 @@ import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ImageController
 import org.cru.godtools.tract.ui.controller.InputController
+import org.cru.godtools.tract.ui.controller.LinkController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
@@ -21,6 +22,7 @@ import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
+import org.cru.godtools.xml.model.Link
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
@@ -57,6 +59,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Input::class)
     internal abstract fun inputControllerFactory(factory: InputController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Link::class)
+    internal abstract fun linkControllerFactory(factory: LinkController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -7,9 +7,11 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
 import org.cru.godtools.tract.ui.controller.BaseController
 import org.cru.godtools.tract.ui.controller.FallbackController
+import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TextController
 import org.cru.godtools.xml.model.Fallback
+import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Text
 
@@ -20,6 +22,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Fallback::class)
     internal abstract fun fallbackControllerFactory(factory: FallbackController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Form::class)
+    internal abstract fun formControllerFactory(factory: FormController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/dagger/UiControllerModule.kt
@@ -11,6 +11,7 @@ import org.cru.godtools.tract.ui.controller.ButtonController
 import org.cru.godtools.tract.ui.controller.FallbackController
 import org.cru.godtools.tract.ui.controller.FormController
 import org.cru.godtools.tract.ui.controller.ImageController
+import org.cru.godtools.tract.ui.controller.InputController
 import org.cru.godtools.tract.ui.controller.ParagraphController
 import org.cru.godtools.tract.ui.controller.TabsController
 import org.cru.godtools.tract.ui.controller.TextController
@@ -19,6 +20,7 @@ import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Image
+import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
@@ -50,6 +52,11 @@ abstract class UiControllerModule {
     @IntoMap
     @ContentKey(Image::class)
     internal abstract fun imageControllerFactory(factory: ImageController.Factory): BaseController.Factory<*>
+
+    @Binds
+    @IntoMap
+    @ContentKey(Input::class)
+    internal abstract fun inputControllerFactory(factory: InputController.Factory): BaseController.Factory<*>
 
     @Binds
     @IntoMap

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/AnimationController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/AnimationController.kt
@@ -2,16 +2,22 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.tract.databinding.TractContentAnimationBinding
 import org.cru.godtools.xml.model.Animation
 
 internal class AnimationController private constructor(
     private val binding: TractContentAnimationBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Animation>(Animation::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentAnimationBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<AnimationController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/BaseController.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.tract.ui.controller
 
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -30,6 +31,10 @@ abstract class BaseController<T : Base> protected constructor(
     internal val root: View,
     private val parentController: BaseController<*>? = null
 ) : Observer<T?> {
+    interface Factory<U : BaseController<*>> {
+        fun create(parent: ViewGroup, parentController: BaseController<*>): U
+    }
+
     protected open val dao: GodToolsDao
         get() {
             checkNotNull(parentController) { "No GodToolsDao found in controller ancestors" }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ButtonController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ButtonController.kt
@@ -2,6 +2,9 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.analytics.model.ExitLinkActionEvent
 import org.cru.godtools.base.ui.util.openUrl
 import org.cru.godtools.tract.databinding.TractContentButtonBinding
@@ -10,10 +13,13 @@ import org.cru.godtools.xml.model.Button
 
 internal class ButtonController private constructor(
     private val binding: TractContentButtonBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Button>(Button::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentButtonBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<ButtonController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/CardController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/CardController.kt
@@ -4,6 +4,9 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
 import androidx.lifecycle.Lifecycle
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Job
 import org.ccci.gto.android.common.androidx.lifecycle.ConstrainedStateLifecycleOwner
 import org.ccci.gto.android.common.androidx.lifecycle.onPause
@@ -15,10 +18,24 @@ import org.cru.godtools.xml.model.Card
 
 class CardController private constructor(
     private val binding: TractContentCardBinding,
-    pageController: PageController
-) : ParentController<Card>(Card::class, binding.root, pageController) {
-    constructor(parent: ViewGroup, pageController: PageController) :
-        this(TractContentCardBinding.inflate(LayoutInflater.from(parent.context), parent, false), pageController)
+    pageController: PageController,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Card>(Card::class, binding.root, pageController, cacheFactory) {
+    @AssistedInject
+    internal constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted pageController: PageController,
+        cacheFactory: UiControllerCache.Factory
+    ) : this(
+        binding = TractContentCardBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        pageController = pageController,
+        cacheFactory = cacheFactory
+    )
+
+    @AssistedFactory
+    interface Factory {
+        fun create(parent: ViewGroup, pageController: PageController): CardController
+    }
 
     interface Callbacks {
         fun onToggleCard(controller: CardController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/FallbackController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/FallbackController.kt
@@ -2,15 +2,30 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentFallbackBinding
 import org.cru.godtools.xml.model.Fallback
 
 class FallbackController(
     binding: TractContentFallbackBinding,
-    parentController: BaseController<*>?
-) : ParentController<Fallback>(Fallback::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
-        this(TractContentFallbackBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+    parentController: BaseController<*>,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Fallback>(Fallback::class, binding.root, parentController, cacheFactory) {
+    @AssistedInject
+    internal constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted parentController: BaseController<*>,
+        cacheFactory: UiControllerCache.Factory
+    ) : this(
+        TractContentFallbackBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        parentController,
+        cacheFactory
+    )
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<FallbackController>
 
     override val contentContainer = binding.root
     override val contentToRender get() = model?.content?.take(1)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/FormController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/FormController.kt
@@ -2,16 +2,32 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.tract.databinding.TractContentParagraphBinding
 import org.cru.godtools.xml.model.Form
 
 class FormController private constructor(
     private val binding: TractContentParagraphBinding,
-    parentController: BaseController<*>?
-) : ParentController<Form>(Form::class, binding.content, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
-        this(TractContentParagraphBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+    parentController: BaseController<*>,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Form>(Form::class, binding.content, parentController, cacheFactory) {
+    @AssistedInject
+    internal constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted parentController: BaseController<*>,
+        cacheFactory: UiControllerCache.Factory
+    ) : this(
+        TractContentParagraphBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        parentController,
+        cacheFactory
+    )
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<FormController>
+
     override val contentContainer get() = binding.content
 
     override fun validate(ids: Set<Event.Id>): Boolean {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/HeroController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/HeroController.kt
@@ -1,5 +1,8 @@
 package org.cru.godtools.tract.ui.controller
 
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Job
 import org.ccci.gto.android.common.androidx.lifecycle.ConstrainedStateLifecycleOwner
 import org.ccci.gto.android.common.androidx.lifecycle.onPause
@@ -8,16 +11,22 @@ import org.cru.godtools.tract.databinding.TractPageHeroBinding
 import org.cru.godtools.xml.model.AnalyticsEvent.Trigger
 import org.cru.godtools.xml.model.Hero
 
-class HeroController internal constructor(private val binding: TractPageHeroBinding, pageController: PageController) :
-    ParentController<Hero>(Hero::class, binding.root, pageController) {
+class HeroController @AssistedInject internal constructor(
+    @Assisted private val binding: TractPageHeroBinding,
+    @Assisted pageController: PageController,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Hero>(Hero::class, binding.root, pageController, cacheFactory = cacheFactory) {
+    @AssistedFactory
+    interface Factory {
+        fun create(binding: TractPageHeroBinding, pageController: PageController): HeroController
+    }
+
     override val lifecycleOwner = pageController.lifecycleOwner?.let { ConstrainedStateLifecycleOwner(it) }
 
     override val contentContainer get() = binding.content
     private var pendingAnalyticsEvents: List<Job>? = null
 
     init {
-        binding.controller = this
-
         lifecycleOwner?.lifecycle?.apply {
             onResume {
                 pendingAnalyticsEvents =
@@ -27,6 +36,3 @@ class HeroController internal constructor(private val binding: TractPageHeroBind
         }
     }
 }
-
-fun TractPageHeroBinding.bindController(pageController: PageController) =
-    controller ?: HeroController(this, pageController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ImageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ImageController.kt
@@ -2,15 +2,21 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentImageBinding
 import org.cru.godtools.xml.model.Image
 
 internal class ImageController private constructor(
     private val binding: TractContentImageBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Image>(Image::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentImageBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<ImageController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/InputController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/InputController.kt
@@ -4,16 +4,22 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import androidx.core.content.getSystemService
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.tract.databinding.TractContentInputBinding
 import org.cru.godtools.xml.model.Input
 
 class InputController private constructor(
     private val binding: TractContentInputBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Input>(Input::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentInputBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<InputController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/LinkController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/LinkController.kt
@@ -2,16 +2,22 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentLinkBinding
 import org.cru.godtools.xml.model.AnalyticsEvent.Trigger
 import org.cru.godtools.xml.model.Link
 
 internal class LinkController private constructor(
     private val binding: TractContentLinkBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Link>(Link::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentLinkBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<LinkController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ModalController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ModalController.kt
@@ -9,8 +9,9 @@ import org.greenrobot.eventbus.EventBus
 
 class ModalController @AssistedInject internal constructor(
     @Assisted private val binding: TractContentModalBinding,
-    override val eventBus: EventBus
-) : ParentController<Modal>(Modal::class, binding.root, null) {
+    override val eventBus: EventBus,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Modal>(Modal::class, binding.root, cacheFactory = cacheFactory) {
     @AssistedFactory
     interface Factory {
         fun create(binding: TractContentModalBinding): ModalController

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -32,7 +32,8 @@ class PageController @AssistedInject internal constructor(
     @Assisted baseLifecycleOwner: LifecycleOwner?,
     override val dao: GodToolsDao,
     override val eventBus: EventBus,
-    private val settings: Settings
+    private val settings: Settings,
+    private val cardControllerFactory: CardController.Factory
 ) : BaseController<Page>(Page::class, binding.root), CardController.Callbacks, PageContentLayout.OnActiveCardListener {
     @AssistedFactory
     interface Factory {
@@ -185,7 +186,9 @@ class PageController @AssistedInject internal constructor(
             }
 
             // create and bind any needed view holders
-            cardControllers = holders.map { it ?: recycledCardControllers.acquire() ?: CardController(parent, this) }
+            cardControllers = holders.map {
+                it ?: recycledCardControllers.acquire() ?: cardControllerFactory.create(parent, this)
+            }
             cardControllers.forEachIndexed { i, it ->
                 it.model = visibleCards.getOrNull(i)
                 if (parent !== it.root.parent) parent.addCard(it.root, i)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -33,6 +33,7 @@ class PageController @AssistedInject internal constructor(
     override val dao: GodToolsDao,
     override val eventBus: EventBus,
     private val settings: Settings,
+    heroControllerFactory: HeroController.Factory,
     private val cardControllerFactory: CardController.Factory
 ) : BaseController<Page>(Page::class, binding.root), CardController.Callbacks, PageContentLayout.OnActiveCardListener {
     @AssistedFactory
@@ -52,7 +53,7 @@ class PageController @AssistedInject internal constructor(
             .also { binding.lifecycleOwner = it }
 
     @VisibleForTesting
-    internal val heroController = binding.hero.bindController(this)
+    internal val heroController = heroControllerFactory.create(binding.hero, this)
     var callbacks: Callbacks?
         get() = binding.callbacks
         set(value) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParagraphController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParagraphController.kt
@@ -2,15 +2,30 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentParagraphBinding
 import org.cru.godtools.xml.model.Paragraph
 
 class ParagraphController private constructor(
     private val binding: TractContentParagraphBinding,
-    parentController: BaseController<*>?
-) : ParentController<Paragraph>(Paragraph::class, binding.content, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
-        this(TractContentParagraphBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+    parentController: BaseController<*>,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Paragraph>(Paragraph::class, binding.content, parentController, cacheFactory) {
+    @AssistedInject
+    internal constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted parentController: BaseController<*>,
+        cacheFactory: UiControllerCache.Factory
+    ) : this(
+        TractContentParagraphBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        parentController,
+        cacheFactory
+    )
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<ParagraphController>
 
     override val contentContainer get() = binding.content
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
@@ -12,7 +12,7 @@ import org.cru.godtools.xml.model.Parent
 abstract class ParentController<T> protected constructor(
     clazz: KClass<T>,
     root: View,
-    parentController: BaseController<*>?,
+    parentController: BaseController<*>? = null,
     cacheFactory: UiControllerCache.Factory? = null
 ) : BaseController<T>(clazz, root, parentController) where T : Parent {
     // region Lifecycle

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
@@ -13,7 +13,7 @@ abstract class ParentController<T> protected constructor(
     clazz: KClass<T>,
     root: View,
     parentController: BaseController<*>? = null,
-    cacheFactory: UiControllerCache.Factory? = null
+    cacheFactory: UiControllerCache.Factory
 ) : BaseController<T>(clazz, root, parentController) where T : Parent {
     // region Lifecycle
     @CallSuper
@@ -39,10 +39,7 @@ abstract class ParentController<T> protected constructor(
 
     // region Child Content
     protected abstract val contentContainer: ViewGroup
-    private val childCache by lazy {
-        cacheFactory?.create(contentContainer, this)
-            ?: UiControllerCache(contentContainer, this)
-    }
+    private val childCache by lazy { cacheFactory.create(contentContainer, this) }
     private var children: List<BaseController<Content>>? = null
 
     protected open val contentToRender get() = model?.content

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ParentController.kt
@@ -12,7 +12,8 @@ import org.cru.godtools.xml.model.Parent
 abstract class ParentController<T> protected constructor(
     clazz: KClass<T>,
     root: View,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>?,
+    cacheFactory: UiControllerCache.Factory? = null
 ) : BaseController<T>(clazz, root, parentController) where T : Parent {
     // region Lifecycle
     @CallSuper
@@ -38,7 +39,10 @@ abstract class ParentController<T> protected constructor(
 
     // region Child Content
     protected abstract val contentContainer: ViewGroup
-    private val childCache by lazy { UiControllerCache(contentContainer, this) }
+    private val childCache by lazy {
+        cacheFactory?.create(contentContainer, this)
+            ?: UiControllerCache(contentContainer, this)
+    }
     private var children: List<BaseController<Content>>? = null
 
     protected open val contentToRender get() = model?.content

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabController.kt
@@ -1,13 +1,20 @@
 package org.cru.godtools.tract.ui.controller
 
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentTabBinding
 import org.cru.godtools.xml.model.AnalyticsEvent.Trigger
 import org.cru.godtools.xml.model.Tab
 
-class TabController internal constructor(private val binding: TractContentTabBinding, tabsController: TabsController) :
-    ParentController<Tab>(Tab::class, binding.content, tabsController) {
-    init {
-        binding.controller = this
+class TabController @AssistedInject internal constructor(
+    @Assisted private val binding: TractContentTabBinding,
+    @Assisted tabsController: TabsController,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<Tab>(Tab::class, binding.content, tabsController, cacheFactory) {
+    @AssistedFactory
+    interface Factory {
+        fun create(binding: TractContentTabBinding, tabsController: TabsController): TabController
     }
 
     override val contentContainer get() = binding.content
@@ -16,6 +23,3 @@ class TabController internal constructor(private val binding: TractContentTabBin
         triggerAnalyticsEvents(model?.analyticsEvents, Trigger.SELECTED, Trigger.DEFAULT)
     }
 }
-
-internal fun TractContentTabBinding.bindController(tabsController: TabsController) =
-    controller ?: TabController(this, tabsController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabsController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabsController.kt
@@ -17,16 +17,24 @@ import org.cru.godtools.xml.model.primaryColor
 
 class TabsController private constructor(
     private val binding: TractContentTabsBinding,
-    parentController: BaseController<*>
+    parentController: BaseController<*>,
+    tabControllerFactory: TabController.Factory
 ) : BaseController<Tabs>(Tabs::class, binding.root, parentController), OnTabSelectedListener {
     @AssistedInject
-    internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
-        this(TractContentTabsBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+    constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted parentController: BaseController<*>,
+        tabControllerFactory: TabController.Factory
+    ) : this(
+        TractContentTabsBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        parentController,
+        tabControllerFactory
+    )
 
     @AssistedFactory
     interface Factory : BaseController.Factory<TabsController>
 
-    private val tabController = binding.tab.bindController(this)
+    private val tabController = tabControllerFactory.create(binding.tab, this)
 
     init {
         binding.tabs.addOnTabSelectedListener(this)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabsController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TabsController.kt
@@ -6,6 +6,9 @@ import androidx.annotation.CallSuper
 import androidx.annotation.UiThread
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.ccci.gto.android.common.material.tabs.setBackgroundTint
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.tract.databinding.TractContentTabsBinding
@@ -14,10 +17,14 @@ import org.cru.godtools.xml.model.primaryColor
 
 class TabsController private constructor(
     private val binding: TractContentTabsBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Tabs>(Tabs::class, binding.root, parentController), OnTabSelectedListener {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject
+    internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentTabsBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<TabsController>
 
     private val tabController = binding.tab.bindController(this)
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TextController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/TextController.kt
@@ -2,15 +2,21 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentTextBinding
 import org.cru.godtools.xml.model.Text
 
 internal class TextController private constructor(
     private val binding: TractContentTextBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Text>(Text::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentTextBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<TextController>
 
     public override fun onBind() {
         super.onBind()

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
 import org.cru.godtools.xml.model.Video
@@ -40,7 +39,6 @@ class UiControllerCache @AssistedInject internal constructor(
 
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
-            Image::class -> ImageController(parent, parentController)
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)
             Link::class -> LinkController(parent, parentController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
 import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
@@ -40,7 +39,6 @@ class UiControllerCache @AssistedInject internal constructor(
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
             InlineTip::class -> InlineTipController(parent, parentController)
-            Input::class -> InputController(parent, parentController)
             Link::class -> LinkController(parent, parentController)
             Video::class -> VideoController(parent, parentController)
             else -> {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
 
@@ -38,7 +37,6 @@ class UiControllerCache @AssistedInject internal constructor(
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
             InlineTip::class -> InlineTipController(parent, parentController)
-            Video::class -> VideoController(parent, parentController)
             else -> {
                 val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")
                 if (ApplicationUtils.isDebuggable(parent.context)) throw e

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.Link
 import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
@@ -39,7 +38,6 @@ class UiControllerCache @AssistedInject internal constructor(
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
             InlineTip::class -> InlineTipController(parent, parentController)
-            Link::class -> LinkController(parent, parentController)
             Video::class -> VideoController(parent, parentController)
             else -> {
                 val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -11,7 +11,6 @@ import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Base
 import org.cru.godtools.xml.model.Button
-import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
@@ -47,7 +46,6 @@ class UiControllerCache @AssistedInject internal constructor(
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
             Animation::class -> AnimationController(parent, parentController)
             Button::class -> ButtonController(parent, parentController)
-            Form::class -> FormController(parent, parentController)
             Image::class -> ImageController(parent, parentController)
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -22,7 +22,7 @@ import timber.log.Timber
 class UiControllerCache @AssistedInject internal constructor(
     @Assisted private val parent: ViewGroup,
     @Assisted private val parentController: BaseController<*>,
-    private val controllerFactories: Map<Class<out Base>, @JvmSuppressWildcards BaseController.Factory<*>> = emptyMap()
+    private val controllerFactories: Map<Class<out Base>, @JvmSuppressWildcards BaseController.Factory<*>>
 ) {
     @AssistedFactory
     interface Factory {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -11,7 +11,6 @@ import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Base
 import org.cru.godtools.xml.model.Button
-import org.cru.godtools.xml.model.Fallback
 import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
@@ -48,7 +47,6 @@ class UiControllerCache @AssistedInject internal constructor(
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
             Animation::class -> AnimationController(parent, parentController)
             Button::class -> ButtonController(parent, parentController)
-            Fallback::class -> FallbackController(parent, parentController)
             Form::class -> FormController(parent, parentController)
             Image::class -> ImageController(parent, parentController)
             InlineTip::class -> InlineTipController(parent, parentController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -14,7 +14,6 @@ import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
-import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
 import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
@@ -50,7 +49,6 @@ class UiControllerCache @AssistedInject internal constructor(
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)
             Link::class -> LinkController(parent, parentController)
-            Tabs::class -> TabsController(parent, parentController)
             Text::class -> TextController(parent, parentController)
             Video::class -> VideoController(parent, parentController)
             else -> {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
@@ -41,7 +40,6 @@ class UiControllerCache @AssistedInject internal constructor(
 
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
-            Button::class -> ButtonController(parent, parentController)
             Image::class -> ImageController(parent, parentController)
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -8,13 +8,11 @@ import dagger.assisted.AssistedInject
 import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
-import org.cru.godtools.xml.model.Animation
 import org.cru.godtools.xml.model.Base
 import org.cru.godtools.xml.model.Button
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
-import org.cru.godtools.xml.model.Text
 import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
@@ -43,13 +41,11 @@ class UiControllerCache @AssistedInject internal constructor(
 
     private fun <T : Base> createController(clazz: KClass<T>) =
         controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
-            Animation::class -> AnimationController(parent, parentController)
             Button::class -> ButtonController(parent, parentController)
             Image::class -> ImageController(parent, parentController)
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)
             Link::class -> LinkController(parent, parentController)
-            Text::class -> TextController(parent, parentController)
             Video::class -> VideoController(parent, parentController)
             else -> {
                 val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -16,7 +16,6 @@ import org.cru.godtools.xml.model.Form
 import org.cru.godtools.xml.model.Image
 import org.cru.godtools.xml.model.Input
 import org.cru.godtools.xml.model.Link
-import org.cru.godtools.xml.model.Paragraph
 import org.cru.godtools.xml.model.Tabs
 import org.cru.godtools.xml.model.Text
 import org.cru.godtools.xml.model.Video
@@ -55,7 +54,6 @@ class UiControllerCache @AssistedInject internal constructor(
             InlineTip::class -> InlineTipController(parent, parentController)
             Input::class -> InputController(parent, parentController)
             Link::class -> LinkController(parent, parentController)
-            Paragraph::class -> ParagraphController(parent, parentController)
             Tabs::class -> TabsController(parent, parentController)
             Text::class -> TextController(parent, parentController)
             Video::class -> VideoController(parent, parentController)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -25,11 +25,11 @@ import timber.log.Timber
 
 class UiControllerCache @AssistedInject internal constructor(
     @Assisted private val parent: ViewGroup,
-    @Assisted private val parentController: BaseController<*>?
+    @Assisted private val parentController: BaseController<*>
 ) {
     @AssistedFactory
     interface Factory {
-        fun create(parent: ViewGroup, parentController: BaseController<*>?): UiControllerCache
+        fun create(parent: ViewGroup, parentController: BaseController<*>): UiControllerCache
     }
 
     private val pools = mutableMapOf<KClass<*>, Pools.Pool<BaseController<*>>>()

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -2,6 +2,9 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.ViewGroup
 import androidx.core.util.Pools
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.tract.ui.controller.tips.InlineTipController
@@ -20,7 +23,15 @@ import org.cru.godtools.xml.model.Video
 import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
 
-internal class UiControllerCache(private val parent: ViewGroup, private val parentController: BaseController<*>?) {
+class UiControllerCache @AssistedInject internal constructor(
+    @Assisted private val parent: ViewGroup,
+    @Assisted private val parentController: BaseController<*>?
+) {
+    @AssistedFactory
+    interface Factory {
+        fun create(parent: ViewGroup, parentController: BaseController<*>?): UiControllerCache
+    }
+
     private val pools = mutableMapOf<KClass<*>, Pools.Pool<BaseController<*>>>()
 
     @Suppress("UNCHECKED_CAST")

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/UiControllerCache.kt
@@ -7,9 +7,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
-import org.cru.godtools.tract.ui.controller.tips.InlineTipController
 import org.cru.godtools.xml.model.Base
-import org.cru.godtools.xml.model.tips.InlineTip
 import timber.log.Timber
 
 class UiControllerCache @AssistedInject internal constructor(
@@ -35,13 +33,10 @@ class UiControllerCache @AssistedInject internal constructor(
     }
 
     private fun <T : Base> createController(clazz: KClass<T>) =
-        controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: when (clazz) {
-            InlineTip::class -> InlineTipController(parent, parentController)
-            else -> {
-                val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")
-                if (ApplicationUtils.isDebuggable(parent.context)) throw e
-                Timber.e(e, "Unsupported Content class specified: %s", clazz.simpleName)
-                null
-            }
-        } as BaseController<T>?
+        controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: run {
+            val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")
+            if (ApplicationUtils.isDebuggable(parent.context)) throw e
+            Timber.e(e, "Unsupported Content class specified: %s", clazz.simpleName)
+            null
+        }
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/VideoController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/VideoController.kt
@@ -2,15 +2,21 @@ package org.cru.godtools.tract.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentVideoBinding
 import org.cru.godtools.xml.model.Video
 
 internal class VideoController private constructor(
     private val binding: TractContentVideoBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<Video>(Video::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentVideoBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<VideoController>
 
     init {
         binding.controller = this

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
@@ -2,16 +2,22 @@ package org.cru.godtools.tract.ui.controller.tips
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractContentInlineTipBinding
 import org.cru.godtools.tract.ui.controller.BaseController
 import org.cru.godtools.xml.model.tips.InlineTip
 
 internal class InlineTipController private constructor(
     private val binding: TractContentInlineTipBinding,
-    parentController: BaseController<*>?
+    parentController: BaseController<*>
 ) : BaseController<InlineTip>(InlineTip::class, binding.root, parentController) {
-    internal constructor(parent: ViewGroup, parentController: BaseController<*>?) :
+    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
         this(TractContentInlineTipBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+
+    @AssistedFactory
+    interface Factory : BaseController.Factory<InlineTipController>
 
     init {
         binding.lifecycleOwner = lifecycleOwner

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
@@ -5,14 +5,16 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import org.cru.godtools.tract.databinding.TractTipPageBinding
 import org.cru.godtools.tract.ui.controller.ParentController
+import org.cru.godtools.tract.ui.controller.UiControllerCache
 import org.cru.godtools.tract.ui.tips.TipCallbacks
 import org.cru.godtools.xml.model.tips.TipPage
 import org.greenrobot.eventbus.EventBus
 
 class TipPageController @AssistedInject internal constructor(
     @Assisted private val binding: TractTipPageBinding,
-    override val eventBus: EventBus
-) : ParentController<TipPage>(TipPage::class, binding.root, null) {
+    override val eventBus: EventBus,
+    cacheFactory: UiControllerCache.Factory
+) : ParentController<TipPage>(TipPage::class, binding.root, cacheFactory = cacheFactory) {
     @AssistedFactory
     interface Factory {
         fun create(binding: TractTipPageBinding): TipPageController

--- a/ui/tract-renderer/src/main/res/layout/tract_content_tab.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_tab.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
-    <data>
-        <variable name="controller" type="org.cru.godtools.tract.ui.controller.TabController" />
-    </data>
-
     <LinearLayout
         android:id="@+id/content"
         android:layout_width="match_parent"

--- a/ui/tract-renderer/src/main/res/layout/tract_page_hero.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_page_hero.xml
@@ -6,7 +6,6 @@
     <data>
         <import type="org.cru.godtools.xml.model.StylesKt" />
 
-        <variable name="controller" type="org.cru.godtools.tract.ui.controller.HeroController" />
         <variable name="model" type="org.cru.godtools.xml.model.Hero" />
     </data>
 

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/HeroControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/HeroControllerTest.kt
@@ -48,7 +48,7 @@ class HeroControllerTest {
         }
         baseLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.CREATED
 
-        controller = HeroController(binding, pageController)
+        controller = HeroController(binding, pageController, mock())
     }
 
     @After

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
@@ -61,6 +61,8 @@ class PageControllerTest {
     lateinit var eventBus: EventBus
     @Inject
     lateinit var settings: Settings
+    @Inject
+    lateinit var cardControllerFactory: CardController.Factory
     private val baseLifecycleOwner = TestLifecycleOwner()
 
     private lateinit var controller: PageController
@@ -70,7 +72,7 @@ class PageControllerTest {
         hiltRule.inject()
         val activity = Robolectric.buildActivity(TestActivity::class.java).create().get()
         binding = TractPageBinding.inflate(LayoutInflater.from(activity))
-        controller = PageController(binding, baseLifecycleOwner, dao, eventBus, settings)
+        controller = PageController(binding, baseLifecycleOwner, dao, eventBus, settings, cardControllerFactory)
         baseLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
     }
 

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
@@ -62,6 +62,8 @@ class PageControllerTest {
     @Inject
     lateinit var settings: Settings
     @Inject
+    lateinit var heroControllerFactory: HeroController.Factory
+    @Inject
     lateinit var cardControllerFactory: CardController.Factory
     private val baseLifecycleOwner = TestLifecycleOwner()
 
@@ -72,7 +74,15 @@ class PageControllerTest {
         hiltRule.inject()
         val activity = Robolectric.buildActivity(TestActivity::class.java).create().get()
         binding = TractPageBinding.inflate(LayoutInflater.from(activity))
-        controller = PageController(binding, baseLifecycleOwner, dao, eventBus, settings, cardControllerFactory)
+        controller = PageController(
+            binding,
+            baseLifecycleOwner,
+            dao,
+            eventBus,
+            settings,
+            heroControllerFactory,
+            cardControllerFactory
+        )
         baseLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
     }
 


### PR DESCRIPTION
This updates all the tool UI controllers to utilize Dagger for creation. The long term goal of this is to allow the controllers to be split between the various renderer modules based on where they are actually used