### PR TITLE
include the maven directory in the travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ cache:
     - $HOME/.android/build-cache
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    # robolectric stores the test environments in the maven repo, this avoids having to re-download them every time
+    - $HOME/.m2
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.


### PR DESCRIPTION
robolectric downloads the various android SDKs to the local maven repo