### PR TITLE
GT-1055 Allow the same type of model to have UI controller variations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
                 advrecyclerview    : '1.0.0',
                 androidInstantApps : '1.1.0',
                 appsFlyer          : '5.4.3',
+                autoValue          : '1.7.4',
                 circleindicator    : '2.1.6',
                 dagger             : '2.31.2',
                 eventbus           : '3.2.0',

--- a/ui/base-tool/build.gradle
+++ b/ui/base-tool/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     implementation "com.airbnb.android:lottie:${deps.lottie}"
     api "com.getkeepsafe.taptargetview:taptargetview:${deps.taptargetview}"
+    implementation "com.google.auto.value:auto-value-annotations:${deps.autoValue}"
     implementation "com.google.dagger:dagger:${deps.dagger}"
     implementation "com.google.dagger:hilt-android:${deps.hilt}"
     implementation "com.louiscad.splitties:splitties-fragmentargs:${deps.splitties}"
@@ -47,9 +48,11 @@ dependencies {
     implementation "jp.wasabeef:picasso-transformations:${deps.picassoTransforms}"
 
     kapt "androidx.hilt:hilt-compiler:${deps.androidX.hilt}"
+    kapt "com.google.auto.value:auto-value:${deps.autoValue}"
     kapt "com.google.dagger:dagger-compiler:${deps.dagger}"
     kapt "com.google.dagger:hilt-compiler:${deps.hilt}"
 
     testImplementation project(':ui:tract-renderer')
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${deps.kotlin}"
     kaptTest "androidx.databinding:databinding-compiler:${deps.androidX.databinding}"
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
@@ -74,7 +74,7 @@ abstract class BaseController<T : Base> protected constructor(
     // endregion Lifecycle
 
     fun supportsModel(model: Base) = modelClass.isInstance(model)
-    internal fun releaseTo(cache: UiControllerCache) = cache.release(modelClass, this)
+    internal fun releaseTo(cache: UiControllerCache) = model?.let { cache.release(it, this) }
 
     protected open fun updateLayoutDirection() {
         // HACK: In theory we should be able to set this on the root page only.

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ParentController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ParentController.kt
@@ -55,7 +55,7 @@ abstract class ParentController<T> protected constructor(
             if (next == null) next = existing.removeFirstOrNull()
 
             val child = next?.takeIf { it.supportsModel(model) }?.also { next = null }
-                ?: childCache.acquire(model.javaClass.kotlin)
+                ?: childCache.acquire(model)
                     ?.also { contentContainer.addView(it.root, contentContainer.indexOfChild(next?.root)) }
             child?.model = model
             child

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
@@ -7,13 +7,15 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.base.tool.ui.controller.BaseController
+import org.cru.godtools.base.tool.ui.controller.cache.UiControllerType.Companion.DEFAULT_VARIATION
 import org.cru.godtools.xml.model.Base
 import timber.log.Timber
 
 class UiControllerCache @AssistedInject internal constructor(
     @Assisted private val parent: ViewGroup,
     @Assisted private val parentController: BaseController<*>,
-    private val controllerFactories: Map<UiControllerType, @JvmSuppressWildcards BaseController.Factory<*>>
+    private val controllerFactories: Map<UiControllerType, @JvmSuppressWildcards BaseController.Factory<*>>,
+    private val variationResolvers: Set<@JvmSuppressWildcards VariationResolver>
 ) {
     @AssistedFactory
     fun interface Factory {
@@ -38,5 +40,8 @@ class UiControllerCache @AssistedInject internal constructor(
             null
         }
 
-    private fun Base.uiControllerType() = UiControllerType.create(javaClass.kotlin)
+    private fun Base.uiControllerType() = UiControllerType.create(
+        javaClass.kotlin,
+        variationResolvers.asSequence().mapNotNull { it.resolve(this) }.firstOrNull() ?: DEFAULT_VARIATION
+    )
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
@@ -14,7 +14,7 @@ import timber.log.Timber
 class UiControllerCache @AssistedInject internal constructor(
     @Assisted private val parent: ViewGroup,
     @Assisted private val parentController: BaseController<*>,
-    private val controllerFactories: Map<Class<out Base>, @JvmSuppressWildcards BaseController.Factory<*>>
+    private val controllerFactories: Map<UiControllerType, @JvmSuppressWildcards BaseController.Factory<*>>
 ) {
     @AssistedFactory
     fun interface Factory {
@@ -34,10 +34,12 @@ class UiControllerCache @AssistedInject internal constructor(
     }
 
     private fun <T : Base> createController(clazz: KClass<T>) =
-        controllerFactories[clazz.java]?.create(parent, parentController) as BaseController<T>? ?: run {
+        controllerFactories[clazz.uiControllerType()]?.create(parent, parentController) as BaseController<T>? ?: run {
             val e = IllegalArgumentException("Unsupported Content class specified: ${clazz.simpleName}")
             if (ApplicationUtils.isDebuggable(parent.context)) throw e
             Timber.e(e, "Unsupported Content class specified: %s", clazz.simpleName)
             null
         }
+
+    private fun KClass<out Base>.uiControllerType() = UiControllerType.create(this)
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
@@ -5,7 +5,6 @@ import androidx.core.util.Pools
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlin.reflect.KClass
 import org.ccci.gto.android.common.app.ApplicationUtils
 import org.cru.godtools.base.tool.ui.controller.BaseController
 import org.cru.godtools.xml.model.Base
@@ -24,11 +23,11 @@ class UiControllerCache @AssistedInject internal constructor(
     private val pools = mutableMapOf<UiControllerType, Pools.Pool<BaseController<*>>>()
     private val UiControllerType.pool get() = pools.getOrPut(this) { Pools.SimplePool(5) }
 
-    fun <T : Base> acquire(clazz: KClass<T>) =
-        (clazz.uiControllerType().pool.acquire() ?: clazz.uiControllerType().createController()) as? BaseController<T>
-    fun <T : Base> release(clazz: KClass<T>, instance: BaseController<T>) {
+    fun <T : Base> acquire(model: T) =
+        model.uiControllerType().let { (it.pool.acquire() ?: it.createController()) as? BaseController<T> }
+    fun <T : Base> release(model: T, instance: BaseController<T>) {
         instance.model = null
-        clazz.uiControllerType().pool.release(instance)
+        model.uiControllerType().pool.release(instance)
     }
 
     private fun UiControllerType.createController() =
@@ -39,5 +38,5 @@ class UiControllerCache @AssistedInject internal constructor(
             null
         }
 
-    private fun KClass<out Base>.uiControllerType() = UiControllerType.create(this)
+    private fun Base.uiControllerType() = UiControllerType.create(javaClass.kotlin)
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerModule.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
+import dagger.multibindings.Multibinds
 import org.cru.godtools.base.tool.ui.controller.AnimationController
 import org.cru.godtools.base.tool.ui.controller.BaseController
 import org.cru.godtools.base.tool.ui.controller.ButtonController
@@ -28,6 +29,9 @@ import org.cru.godtools.xml.model.Video
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class UiControllerModule {
+    @Multibinds
+    abstract fun variationResolvers(): Set<VariationResolver>
+
     @Binds
     @IntoMap
     @UiControllerType(Animation::class)

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
@@ -7,8 +7,11 @@ import org.cru.godtools.xml.model.Base
 @MapKey(unwrapValue = false)
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class UiControllerType(val value: KClass<out Base>) {
+annotation class UiControllerType(val value: KClass<out Base>, val variation: Int = DEFAULT_VARIATION) {
     companion object {
-        fun create(value: KClass<out Base>) = UiControllerTypeCreator.createUiControllerType(value.java)
+        const val DEFAULT_VARIATION = 1
+
+        fun create(value: KClass<out Base>, variation: Int = DEFAULT_VARIATION) =
+            UiControllerTypeCreator.createUiControllerType(value.java, variation)
     }
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
@@ -4,7 +4,11 @@ import dagger.MapKey
 import kotlin.reflect.KClass
 import org.cru.godtools.xml.model.Base
 
-@MapKey
+@MapKey(unwrapValue = false)
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class UiControllerType(val value: KClass<out Base>)
+annotation class UiControllerType(val value: KClass<out Base>) {
+    companion object {
+        fun create(value: KClass<out Base>) = UiControllerTypeCreator.createUiControllerType(value.java)
+    }
+}

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/VariationResolver.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/cache/VariationResolver.kt
@@ -1,0 +1,7 @@
+package org.cru.godtools.base.tool.ui.controller.cache
+
+import org.cru.godtools.xml.model.Base
+
+fun interface VariationResolver {
+    fun resolve(model: Base): Int?
+}

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/ParentControllerTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/ParentControllerTest.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.view.children
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -43,8 +44,8 @@ class ParentControllerTest {
         context = ContextThemeWrapper(activity, R.style.Theme_AppCompat)
         contentContainer = LinearLayout(context)
         cache = mock {
-            on { acquire(Text::class) } doAnswer { mock { on { root } doReturn TextView(context) } }
-            on { acquire(Image::class) } doAnswer { mock { on { root } doReturn ImageView(context) } }
+            on { acquire(any<Text>()) } doAnswer { mock { on { root } doReturn TextView(context) } }
+            on { acquire(any<Image>()) } doAnswer { mock { on { root } doReturn ImageView(context) } }
         }
         controller = ConcreteParentController(contentContainer, cache)
     }

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCacheTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCacheTest.kt
@@ -33,7 +33,8 @@ class UiControllerCacheTest {
         parent = mock(defaultAnswer = RETURNS_DEEP_STUBS)
         parentController = mock()
         imageFactory = mock { on { create(parent, parentController) } doAnswer { mock() } }
-        cache = UiControllerCache(parent, parentController, mapOf(Image::class.java to imageFactory))
+        cache =
+            UiControllerCache(parent, parentController, mapOf(UiControllerType.create(Image::class) to imageFactory))
     }
 
     // region acquire()

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCacheTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCacheTest.kt
@@ -40,9 +40,10 @@ class UiControllerCacheTest {
     // region acquire()
     @Test
     fun testAcquireReusesReleased() {
+        val model = mock<Image>()
         val image = mock<BaseController<Image>>()
-        cache.release(Image::class, image)
-        val image2 = cache.acquire(Image::class)
+        cache.release(model, image)
+        val image2 = cache.acquire(model)
         assertSame(image, image2)
     }
     // endregion acquire()
@@ -50,13 +51,14 @@ class UiControllerCacheTest {
     // region createController()
     @Test
     fun testCreateController() {
-        val controller = cache.acquire(Image::class)
+        val model = mock<Image>()
+        val controller = cache.acquire(model)
         assertNotNull(controller)
         verify(imageFactory).create(parent, parentController)
         verifyNoMoreInteractions(imageFactory)
         clearInvocations(imageFactory)
 
-        val controller2 = cache.acquire(Image::class)
+        val controller2 = cache.acquire(model)
         assertNotNull(controller2)
         assertNotSame(controller, controller2)
         verify(imageFactory).create(parent, parentController)
@@ -66,7 +68,7 @@ class UiControllerCacheTest {
     @Test(expected = IllegalArgumentException::class)
     fun testCreateControllerFactoryMissingDebug() {
         parent.context.applicationInfo.flags = ApplicationInfo.FLAG_DEBUGGABLE
-        cache.acquire(Text::class)
+        cache.acquire(mock<Text>())
     }
 
     @Test
@@ -75,7 +77,7 @@ class UiControllerCacheTest {
         Timber.plant(tree)
 
         try {
-            val controller = cache.acquire(Text::class)
+            val controller = cache.acquire(mock<Text>())
             assertNull(controller)
             verifyNoInteractions(imageFactory)
             verify(tree).e(any<IllegalArgumentException>(), any(), anyVararg())

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerTypeTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerTypeTest.kt
@@ -1,0 +1,17 @@
+package org.cru.godtools.base.tool.ui.controller.cache
+
+import org.cru.godtools.xml.model.Image
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UiControllerTypeTest {
+    @Test
+    @UiControllerType(Image::class)
+    fun testUiControllerTypeAnnotation() {
+        val expected = this::testUiControllerTypeAnnotation.annotations.first { it is UiControllerType }
+        val autoAnnotation = UiControllerType.create(Image::class)
+
+        assertEquals(expected, autoAnnotation)
+        assertEquals(expected.hashCode(), autoAnnotation.hashCode())
+    }
+}

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerTypeTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/cache/UiControllerTypeTest.kt
@@ -6,10 +6,10 @@ import org.junit.Test
 
 class UiControllerTypeTest {
     @Test
-    @UiControllerType(Image::class)
+    @UiControllerType(Image::class, 13)
     fun testUiControllerTypeAnnotation() {
         val expected = this::testUiControllerTypeAnnotation.annotations.first { it is UiControllerType }
-        val autoAnnotation = UiControllerType.create(Image::class)
+        val autoAnnotation = UiControllerType.create(Image::class, 13)
 
         assertEquals(expected, autoAnnotation)
         assertEquals(expected.hashCode(), autoAnnotation.hashCode())


### PR DESCRIPTION
When rendering an outlined button it has different base styles automatically applied to it. This means it is hard to switch a button view between normal and outlined mode. To accommodate for this difference we will have 2 different `ButtonControllers`, one for normal buttons and one for outlined buttons.

This PR introduces the framework to define a `VariationResolver` that will allow us to define the 2 button variations we support.

Long term this can also be used if we need to support a different video platform via the `video` element