### PR TITLE
Update-cru_appname-Value

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
@@ -28,7 +28,7 @@ import org.greenrobot.eventbus.ThreadMode
 
 /* Value constants */
 private const val USER_PROP_APP_NAME = "cru_appname"
-private const val VALUE_APP_NAME_GODTOOLS = "GodTools"
+private const val VALUE_APP_NAME_GODTOOLS = "GodTools App"
 
 private const val USER_PROP_APP_TYPE = "godtools_app_type"
 private const val VALUE_APP_TYPE_INSTANT = "instant"


### PR DESCRIPTION
The analytics team requested we update this value to be the same across all platforms/apps. So it should always be "app name + App".