### PR TITLE
GT-1062 don't perform language splits, just install all languages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,9 +128,13 @@ android {
             buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools\""
         }
     }
+    bundle {
+        language.enableSplit = false
+    }
     dynamicFeatures = [
             ':feature:bundledcontent',
     ]
+
     sourceSets {
         qa {
             java.srcDir 'src/debug/java'


### PR DESCRIPTION
android app bundles allows the play store to install only the resources that a user's device needs. This is normally a good thing.

but in GodTools we occasionally use a language that isn't the device language, this means it needs access to language resources that might not be installed. The `language.enableSplits` setting should force the play store to always install all the languages.

I believe this will fix the split language issue, but I won't know for sure until we get this change into a version uploaded to the play store.