### PR TITLE
GT-1044 Fix ShortcutManager crash on Instant App

### DIFF
--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -209,4 +209,19 @@ class GodToolsShortcutManagerTest {
         }
     }
     // endregion Update Existing Shortcuts
+
+    // region Instant App
+    @Test
+    fun verifyUpdateDynamicShortcutsOnInstantAppIsANoop() {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
+
+        // Instant Apps don't have access to the system ShortcutManager
+        whenever(app.getSystemService<ShortcutManager>()).thenReturn(null)
+        coroutineScope.resumeDispatcher()
+        clearInvocations(dao)
+
+        coroutineScope.launch { shortcutManager.updateDynamicShortcuts(emptyMap()) }
+        verifyZeroInteractions(dao)
+    }
+    // endregion Instant App
 }


### PR DESCRIPTION
Instant Apps don't have access to the ShortcutManager system service. This led to a crash where updating dynamic shortcuts would utilize `ShortcutManagerCompat` which assumes the `ShortcutManager` is available on newer versions of Android. This led to an NPE.

we now only attempt to update dynamic shortcuts if we have an actual `ShortcutManager`