### PR TITLE
GT-1048 GT-1060 Card background images

### DIFF
--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/model/view/ManifestViewUtils.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/model/view/ManifestViewUtils.kt
@@ -1,16 +1,7 @@
 package org.cru.godtools.base.tool.model.view
 
 import android.content.Context
-import org.cru.godtools.base.tool.widget.ScaledPicassoImageView
 import org.cru.godtools.base.ui.util.getTypeface
 import org.cru.godtools.xml.model.Manifest
-import org.cru.godtools.xml.model.backgroundImageGravity
-import org.cru.godtools.xml.model.backgroundImageScaleType
 
 fun Manifest.getTypeface(context: Context) = context.getTypeface(locale)
-
-fun ScaledPicassoImageView.bindBackgroundImage(manifest: Manifest?) = bindBackgroundImage(
-    manifest?.backgroundImage,
-    manifest.backgroundImageScaleType,
-    manifest.backgroundImageGravity
-)

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/model/view/ResourceViewUtils.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/model/view/ResourceViewUtils.kt
@@ -1,9 +1,6 @@
 package org.cru.godtools.base.tool.model.view
 
-import android.view.Gravity
 import android.view.View
-import android.widget.FrameLayout
-import android.widget.RelativeLayout
 import jp.wasabeef.picasso.transformations.CropTransformation.GravityHorizontal
 import jp.wasabeef.picasso.transformations.CropTransformation.GravityVertical
 import org.ccci.gto.android.common.picasso.view.PicassoImageView
@@ -45,48 +42,4 @@ fun ScaledPicassoImageView.bindBackgroundImage(resource: Resource?, scale: Image
         }
     )
     toggleBatchUpdates(false)
-
-    // update layout params
-    view.layoutParams = view.layoutParams.apply {
-        when (this) {
-            is FrameLayout.LayoutParams -> {
-                val horizontal = when {
-                    gravity.isStart -> Gravity.START
-                    gravity.isEnd -> Gravity.END
-                    gravity.isCenterX -> Gravity.CENTER_HORIZONTAL
-                    else -> Gravity.NO_GRAVITY
-                }
-                val vertical = when {
-                    gravity.isTop -> Gravity.TOP
-                    gravity.isBottom -> Gravity.BOTTOM
-                    gravity.isCenterY -> Gravity.CENTER_VERTICAL
-                    else -> Gravity.NO_GRAVITY
-                }
-                this.gravity = horizontal.or(vertical)
-            }
-            is RelativeLayout.LayoutParams -> {
-                // set default layout for background image first
-                addRule(RelativeLayout.ALIGN_PARENT_START, 0)
-                addRule(RelativeLayout.ALIGN_PARENT_END, 0)
-                addRule(RelativeLayout.CENTER_HORIZONTAL, 0)
-                addRule(RelativeLayout.ALIGN_PARENT_TOP, 0)
-                addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 0)
-                addRule(RelativeLayout.CENTER_VERTICAL, 0)
-
-                // update gravity (X-Axis)
-                when {
-                    gravity.isStart -> addRule(RelativeLayout.ALIGN_PARENT_START)
-                    gravity.isEnd -> addRule(RelativeLayout.ALIGN_PARENT_END)
-                    gravity.isCenterX -> addRule(RelativeLayout.CENTER_HORIZONTAL)
-                }
-
-                // update gravity (Y-Axis)
-                when {
-                    gravity.isTop -> addRule(RelativeLayout.ALIGN_PARENT_TOP)
-                    gravity.isBottom -> addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
-                    gravity.isCenterY -> addRule(RelativeLayout.CENTER_VERTICAL)
-                }
-            }
-        }
-    }
 }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/widget/SimpleScaledPicassoImageView.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/widget/SimpleScaledPicassoImageView.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.base.tool.widget
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import jp.wasabeef.picasso.transformations.CropTransformation.GravityHorizontal
 import jp.wasabeef.picasso.transformations.CropTransformation.GravityVertical
@@ -26,5 +27,10 @@ class SimpleScaledPicassoImageView @JvmOverloads constructor(
 
     override fun setGravityVertical(gravity: GravityVertical) {
         helper.gravityVertical = gravity
+    }
+
+    override fun setImageDrawable(drawable: Drawable?) {
+        super.setImageDrawable(drawable)
+        helper.onSetImageDrawable()
     }
 }

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/widget/ScaledPicassoImageViewTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/widget/ScaledPicassoImageViewTest.kt
@@ -1,0 +1,157 @@
+package org.cru.godtools.base.tool.widget
+
+import android.graphics.Matrix
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.stub
+import com.nhaarman.mockitokotlin2.verify
+import jp.wasabeef.picasso.transformations.CropTransformation.GravityHorizontal
+import jp.wasabeef.picasso.transformations.CropTransformation.GravityVertical
+import org.cru.godtools.xml.model.ImageScaleType
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScaledPicassoImageViewTest {
+    private lateinit var drawable: Drawable
+    private lateinit var view: ImageView
+
+    private lateinit var helper: ScaledPicassoImageView.ScaleHelper
+
+    @Before
+    fun setup() {
+        drawable = mock()
+        view = mock {
+            on { context } doReturn ApplicationProvider.getApplicationContext()
+            on { isInEditMode } doReturn true
+            on { drawable } doReturn drawable
+        }
+        helper = ScaledPicassoImageView.ScaleHelper(view, null, 0, 0)
+    }
+
+    // region scaleType = MATRIX
+    @Test
+    fun testScaleTypeMatrixFit() {
+        view.stub { on { scaleType } doReturn ImageView.ScaleType.MATRIX }
+        helper.scaleType = ImageScaleType.FIT
+        helper.gravityVertical = GravityVertical.CENTER
+        helper.gravityHorizontal = GravityHorizontal.CENTER
+        stubDrawableDimensions(20, 20)
+        stubViewDimensions(40, 70)
+
+        helper.onSetImageDrawable()
+        argumentCaptor<Matrix> {
+            verify(view).imageMatrix = capture()
+            assertEquals(
+                Matrix().apply {
+                    setScale(2f, 2f)
+                    postTranslate(0f, 15f)
+                },
+                firstValue
+            )
+        }
+    }
+
+    @Test
+    fun testScaleTypeMatrixFitTopLeft() {
+        view.stub { on { scaleType } doReturn ImageView.ScaleType.MATRIX }
+        helper.scaleType = ImageScaleType.FIT
+        helper.gravityVertical = GravityVertical.TOP
+        helper.gravityHorizontal = GravityHorizontal.LEFT
+        stubDrawableDimensions(20, 20)
+        stubViewDimensions(40, 70)
+
+        helper.onSetImageDrawable()
+        argumentCaptor<Matrix> {
+            verify(view).imageMatrix = capture()
+            assertEquals(Matrix().apply { setScale(2f, 2f) }, firstValue)
+        }
+    }
+
+    @Test
+    fun testScaleTypeMatrixFillTopRight() {
+        view.stub { on { scaleType } doReturn ImageView.ScaleType.MATRIX }
+        helper.scaleType = ImageScaleType.FILL
+        helper.gravityVertical = GravityVertical.TOP
+        helper.gravityHorizontal = GravityHorizontal.RIGHT
+        stubDrawableDimensions(20, 20)
+        stubViewDimensions(40, 80)
+
+        helper.onSetImageDrawable()
+        argumentCaptor<Matrix> {
+            verify(view).imageMatrix = capture()
+            assertEquals(
+                Matrix().apply {
+                    setScale(4f, 4f)
+                    postTranslate(-40f, 0f)
+                },
+                firstValue
+            )
+        }
+    }
+
+    @Test
+    fun testScaleTypeMatrixFillXBottom() {
+        view.stub { on { scaleType } doReturn ImageView.ScaleType.MATRIX }
+        helper.scaleType = ImageScaleType.FILL_X
+        helper.gravityVertical = GravityVertical.BOTTOM
+        stubDrawableDimensions(20, 20)
+        stubViewDimensions(40, 80)
+
+        helper.onSetImageDrawable()
+        argumentCaptor<Matrix> {
+            verify(view).imageMatrix = capture()
+            assertEquals(
+                Matrix().apply {
+                    setScale(2f, 2f)
+                    postTranslate(0f, 40f)
+                },
+                firstValue
+            )
+        }
+    }
+
+    @Test
+    fun testScaleTypeMatrixFillYLeft() {
+        view.stub { on { scaleType } doReturn ImageView.ScaleType.MATRIX }
+        helper.scaleType = ImageScaleType.FILL_Y
+        helper.gravityHorizontal = GravityHorizontal.LEFT
+        stubDrawableDimensions(20, 20)
+        stubViewDimensions(70, 40)
+
+        helper.onSetImageDrawable()
+        argumentCaptor<Matrix> {
+            verify(view).imageMatrix = capture()
+            assertEquals(Matrix().apply { setScale(2f, 2f) }, firstValue)
+        }
+    }
+    // endregion scaleType = MATRIX
+
+    private fun stubDrawableDimensions(width: Int = 0, height: Int = 0) = drawable.stub {
+        on { intrinsicWidth } doReturn width
+        on { intrinsicHeight } doReturn height
+    }
+
+    private fun stubViewDimensions(
+        width: Int = 0,
+        height: Int = 0,
+        paddingLeft: Int = 0,
+        paddingTop: Int = 0,
+        paddingRight: Int = 0,
+        paddingBottom: Int = 0
+    ) = view.stub {
+        on { this.width } doReturn width
+        on { this.height } doReturn height
+        on { this.paddingLeft } doReturn paddingLeft
+        on { this.paddingTop } doReturn paddingTop
+        on { this.paddingRight } doReturn paddingRight
+        on { this.paddingBottom } doReturn paddingBottom
+    }
+}

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -39,7 +39,6 @@ import org.cru.godtools.base.URI_SHARE_BASE
 import org.cru.godtools.base.model.Event
 import org.cru.godtools.base.tool.EXTRA_SHOW_TIPS
 import org.cru.godtools.base.tool.activity.BaseToolActivity
-import org.cru.godtools.base.tool.model.view.bindBackgroundImage
 import org.cru.godtools.tract.PARAM_LIVE_SHARE_STREAM
 import org.cru.godtools.tract.PARAM_PARALLEL_LANGUAGE
 import org.cru.godtools.tract.PARAM_PRIMARY_LANGUAGE
@@ -286,6 +285,7 @@ class TractActivity :
     override val activeDownloadProgressLiveData get() = dataModel.downloadProgress
 
     private fun setupBinding() {
+        binding.manifest = dataModel.activeManifest
         binding.activeLocale = dataModel.activeLocale
         binding.visibleLocales = dataModel.visibleLocales
     }
@@ -297,10 +297,7 @@ class TractActivity :
     }
 
     private fun setupBackground() {
-        dataModel.activeManifest.observe(this) {
-            window.decorView.setBackgroundColor(it.backgroundColor)
-            binding.backgroundImage.bindBackgroundImage(it)
-        }
+        dataModel.activeManifest.observe(this) { window.decorView.setBackgroundColor(it.backgroundColor) }
     }
 
     // region Language Toggle

--- a/ui/tract-renderer/src/main/res/layout/tract_activity.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_activity.xml
@@ -9,7 +9,10 @@
         <import type="java.util.Locale" />
         <import type="org.cru.godtools.base.tool.activity.BaseToolActivity.ToolState" />
         <import type="org.cru.godtools.download.manager.DownloadProgress" />
+        <import type="org.cru.godtools.xml.model.Manifest" />
+        <import type="org.cru.godtools.xml.model.ManifestKt" />
 
+        <variable name="manifest" type="LiveData&lt;Manifest&gt;" />
         <variable name="activeLocale" type="LiveData&lt;Locale&gt;" />
         <variable name="progress" type="LiveData&lt;DownloadProgress&gt;" />
         <variable name="toolState" type="LiveData&lt;ToolState&gt;" />
@@ -35,7 +38,7 @@
             app:progress="@{progress}"
             app:toolState="@{toolState}" />
 
-        <RelativeLayout
+        <FrameLayout
             android:id="@+id/mainContent"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -47,13 +50,16 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:adjustViewBounds="true"
-                android:cropToPadding="false" />
+                android:cropToPadding="false"
+                app:gravity="@{ManifestKt.getBackgroundImageGravity(manifest)}"
+                app:picassoFile="@{manifest.backgroundImage}"
+                app:scaleType="@{ManifestKt.getBackgroundImageScaleType(manifest)}" />
 
             <org.cru.godtools.tract.widget.HackyRtlViewPager
                 android:id="@+id/pages"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
-        </RelativeLayout>
+        </FrameLayout>
 
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"

--- a/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
@@ -98,26 +98,20 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <FrameLayout
+                <org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
+                    android:id="@+id/background_image"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:adjustViewBounds="true"
+                    android:cropToPadding="false"
+                    android:scaleType="matrix"
+                    app:gravity="@{CardKt.getBackgroundImageGravity(model)}"
                     app:layout_constraintBottom_toBottomOf="@id/content_scroll_view"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/content_scroll_view">
-
-                    <!-- We need the FrameLayout parent to handle image alignment when the image doesn't fill the entire background -->
-                    <org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
-                        android:id="@+id/background_image"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:adjustViewBounds="true"
-                        android:cropToPadding="false"
-                        android:scaleType="matrix"
-                        app:gravity="@{CardKt.getBackgroundImageGravity(model)}"
-                        app:picassoFile="@{model.backgroundImage}"
-                        app:scaleType="@{CardKt.getBackgroundImageScaleType(model)}" />
-                </FrameLayout>
+                    app:layout_constraintTop_toTopOf="@id/content_scroll_view"
+                    app:picassoFile="@{model.backgroundImage}"
+                    app:scaleType="@{CardKt.getBackgroundImageScaleType(model)}" />
 
                 <org.ccci.gto.android.common.widget.HackyNestedScrollView
                     android:id="@+id/content_scroll_view"

--- a/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
@@ -110,9 +110,10 @@
                     <org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
                         android:id="@+id/background_image"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="match_parent"
                         android:adjustViewBounds="true"
                         android:cropToPadding="false"
+                        android:scaleType="matrix"
                         app:gravity="@{CardKt.getBackgroundImageGravity(model)}"
                         app:picassoFile="@{model.backgroundImage}"
                         app:scaleType="@{CardKt.getBackgroundImageScaleType(model)}" />

--- a/ui/tract-renderer/src/main/res/layout/tract_page.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_page.xml
@@ -20,19 +20,17 @@
         <variable name="isCallToActionTipComplete" type="LiveData&lt;Boolean&gt;" />
     </data>
 
-    <RelativeLayout
-        android:id="@+id/pageView"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@{TractPageKt.getBackgroundColor(page)}">
 
         <org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
-            android:id="@+id/background_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:adjustViewBounds="true"
             android:cropToPadding="false"
             android:layoutDirection="@{BaseKt.getLayoutDirection(page)}"
+            android:scaleType="matrix"
             app:gravity="@{TractPageKt.getBackgroundImageGravity(page)}"
             app:picassoFile="@{page.backgroundImage}"
             app:scaleType="@{TractPageKt.getBackgroundImageScaleType(page)}"
@@ -113,5 +111,5 @@
                 app:visibleIf="@{enableTips &amp;&amp; page.callToAction.tip != null}"
                 tools:src="@drawable/ic_tips_tip" />
         </org.cru.godtools.tract.widget.PageContentLayout>
-    </RelativeLayout>
+    </FrameLayout>
 </layout>

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/databinding/TractActivityBindingTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/databinding/TractActivityBindingTest.kt
@@ -7,16 +7,21 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.EnumSet
+import org.ccci.gto.android.common.testing.picasso.PicassoSingletonRule
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.cru.godtools.tract.R
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class TractActivityBindingTest {
+    @get:Rule
+    val picassoSingletonRule = PicassoSingletonRule()
+
     private lateinit var binding: TractActivityBinding
 
     @Before


### PR DESCRIPTION
utilize a matrix scale type to position/scale background images for tools, pages, and cards.

I'm not totally happy with how I had to write tests, but I'm not sure of a better way to programmatically test how an ImageView renders a drawable without needing to run an emulator.

Instead I'm testing to make sure that the Matrix transform is generated in an expected manner based upon the drawable and image size