### PR TITLE
GT-1083 Fix buttons using EventBus in lessons

### DIFF
--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
@@ -38,11 +38,6 @@ abstract class BaseController<T : Base> protected constructor(
         fun create(parent: ViewGroup, parentController: BaseController<*>): U
     }
 
-    protected open val dao: GodToolsDao
-        get() {
-            checkNotNull(parentController) { "No GodToolsDao found in controller ancestors" }
-            return parentController.dao
-        }
     @VisibleForTesting(otherwise = PROTECTED)
     open val eventBus: EventBus
         get() {
@@ -123,11 +118,11 @@ abstract class BaseController<T : Base> protected constructor(
         parentController?.showTip(tip)
     }
 
-    protected fun isTipComplete(tipId: String?): LiveData<Boolean> {
+    protected fun GodToolsDao.isTipComplete(tipId: String?): LiveData<Boolean> {
         val manifest = model?.manifest
         return when {
             manifest == null || tipId == null -> ImmutableLiveData(false)
-            else -> dao.findLiveData<TrainingTip>(manifest.code, manifest.locale, tipId).map { it?.isCompleted == true }
+            else -> findLiveData<TrainingTip>(manifest.code, manifest.locale, tipId).map { it?.isCompleted == true }
                 .distinctUntilChanged()
         }
     }

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/BaseController.kt
@@ -32,18 +32,18 @@ import org.keynote.godtools.android.db.GodToolsDao
 abstract class BaseController<T : Base> protected constructor(
     private val modelClass: KClass<T>,
     val root: View,
-    private val parentController: BaseController<*>? = null
+    private val parentController: BaseController<*>? = null,
+    eventBus: EventBus? = null
 ) : Observer<T?> {
     interface Factory<U : BaseController<*>> {
         fun create(parent: ViewGroup, parentController: BaseController<*>): U
     }
 
+    private val _eventBus = eventBus
     @VisibleForTesting(otherwise = PROTECTED)
-    open val eventBus: EventBus
-        get() {
-            checkNotNull(parentController) { "No EventBus found in controller ancestors" }
-            return parentController.eventBus
-        }
+    val eventBus: EventBus
+        get() = _eventBus ?: parentController?.eventBus ?: error("No EventBus found in controller hierarchy")
+
     open val lifecycleOwner: LifecycleOwner? get() = parentController?.lifecycleOwner
 
     var model: T? = null

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ButtonController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ButtonController.kt
@@ -14,11 +14,13 @@ import org.cru.godtools.base.ui.util.openUrl
 import org.cru.godtools.xml.model.AnalyticsEvent.Trigger
 import org.cru.godtools.xml.model.Base
 import org.cru.godtools.xml.model.Button
+import org.greenrobot.eventbus.EventBus
 
 internal sealed class ButtonController<T : ViewDataBinding>(
     private val binding: T,
-    parentController: BaseController<*>
-) : BaseController<Button>(Button::class, binding.root, parentController) {
+    parentController: BaseController<*>,
+    eventBus: EventBus
+) : BaseController<Button>(Button::class, binding.root, parentController, eventBus) {
     init {
         binding.setVariable(BR.controller, this)
     }
@@ -42,10 +44,12 @@ internal sealed class ButtonController<T : ViewDataBinding>(
 
 internal class ContainedButtonController @AssistedInject internal constructor(
     @Assisted parent: ViewGroup,
-    @Assisted parentController: BaseController<*>
+    @Assisted parentController: BaseController<*>,
+    eventBus: EventBus
 ) : ButtonController<ToolContentButtonBinding>(
     ToolContentButtonBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-    parentController
+    parentController,
+    eventBus
 ) {
     @AssistedFactory
     interface Factory : BaseController.Factory<ContainedButtonController>
@@ -56,10 +60,12 @@ internal class ContainedButtonController @AssistedInject internal constructor(
 
 internal class OutlinedButtonController @AssistedInject internal constructor(
     @Assisted parent: ViewGroup,
-    @Assisted parentController: BaseController<*>
+    @Assisted parentController: BaseController<*>,
+    eventBus: EventBus
 ) : ButtonController<ToolContentButtonOutlinedBinding>(
     ToolContentButtonOutlinedBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-    parentController
+    parentController,
+    eventBus
 ) {
     @AssistedFactory
     interface Factory : BaseController.Factory<OutlinedButtonController>

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ParentController.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/ui/controller/ParentController.kt
@@ -9,13 +9,15 @@ import org.cru.godtools.base.model.Event
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
 import org.cru.godtools.xml.model.Content
 import org.cru.godtools.xml.model.Parent
+import org.greenrobot.eventbus.EventBus
 
 abstract class ParentController<T> protected constructor(
     clazz: KClass<T>,
     root: View,
     parentController: BaseController<*>? = null,
-    cacheFactory: UiControllerCache.Factory
-) : BaseController<T>(clazz, root, parentController) where T : Parent {
+    cacheFactory: UiControllerCache.Factory,
+    eventBus: EventBus? = null
+) : BaseController<T>(clazz, root, parentController, eventBus) where T : Parent {
     // region Lifecycle
     @CallSuper
     override fun onBind() {

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/controller/LessonPageController.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/controller/LessonPageController.kt
@@ -7,11 +7,13 @@ import org.cru.godtools.base.tool.ui.controller.ParentController
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
 import org.cru.godtools.tool.lesson.databinding.LessonPageBinding
 import org.cru.godtools.xml.model.lesson.LessonPage
+import org.greenrobot.eventbus.EventBus
 
 class LessonPageController @AssistedInject constructor(
     @Assisted private val binding: LessonPageBinding,
-    cacheFactory: UiControllerCache.Factory
-) : ParentController<LessonPage>(LessonPage::class, binding.root, cacheFactory = cacheFactory) {
+    cacheFactory: UiControllerCache.Factory,
+    eventBus: EventBus
+) : ParentController<LessonPage>(LessonPage::class, binding.root, cacheFactory = cacheFactory, eventBus = eventBus) {
     @AssistedFactory
     interface Factory {
         fun create(binding: LessonPageBinding): LessonPageController

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ModalController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/ModalController.kt
@@ -11,9 +11,9 @@ import org.greenrobot.eventbus.EventBus
 
 class ModalController @AssistedInject internal constructor(
     @Assisted private val binding: TractContentModalBinding,
-    override val eventBus: EventBus,
+    eventBus: EventBus,
     cacheFactory: UiControllerCache.Factory
-) : ParentController<Modal>(Modal::class, binding.root, cacheFactory = cacheFactory) {
+) : ParentController<Modal>(Modal::class, binding.root, cacheFactory = cacheFactory, eventBus = eventBus) {
     @AssistedFactory
     interface Factory {
         fun create(binding: TractContentModalBinding): ModalController

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -31,7 +31,7 @@ import org.keynote.godtools.android.db.GodToolsDao
 class PageController @AssistedInject internal constructor(
     @Assisted private val binding: TractPageBinding,
     @Assisted baseLifecycleOwner: LifecycleOwner?,
-    override val dao: GodToolsDao,
+    private val dao: GodToolsDao,
     override val eventBus: EventBus,
     private val settings: Settings,
     heroControllerFactory: HeroController.Factory,
@@ -80,8 +80,8 @@ class PageController @AssistedInject internal constructor(
     override fun onBind() {
         super.onBind()
         binding.page = model
-        binding.isHeaderTipComplete = isTipComplete(model?.header?.tip?.id)
-        binding.isCallToActionTipComplete = isTipComplete(model?.callToAction?.tip?.id)
+        binding.isHeaderTipComplete = dao.isTipComplete(model?.header?.tip?.id)
+        binding.isCallToActionTipComplete = dao.isTipComplete(model?.callToAction?.tip?.id)
         heroController.model = model?.hero
         updateVisibleCards()
     }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -32,11 +32,11 @@ class PageController @AssistedInject internal constructor(
     @Assisted private val binding: TractPageBinding,
     @Assisted baseLifecycleOwner: LifecycleOwner?,
     private val dao: GodToolsDao,
-    override val eventBus: EventBus,
+    eventBus: EventBus,
     private val settings: Settings,
     heroControllerFactory: HeroController.Factory,
     private val cardControllerFactory: CardController.Factory
-) : BaseController<TractPage>(TractPage::class, binding.root),
+) : BaseController<TractPage>(TractPage::class, binding.root, eventBus = eventBus),
     CardController.Callbacks,
     PageContentLayout.OnActiveCardListener {
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
@@ -8,13 +8,23 @@ import dagger.assisted.AssistedInject
 import org.cru.godtools.base.tool.ui.controller.BaseController
 import org.cru.godtools.tract.databinding.TractContentInlineTipBinding
 import org.cru.godtools.xml.model.tips.InlineTip
+import org.keynote.godtools.android.db.GodToolsDao
 
 internal class InlineTipController private constructor(
     private val binding: TractContentInlineTipBinding,
-    parentController: BaseController<*>
+    parentController: BaseController<*>,
+    private val dao: GodToolsDao
 ) : BaseController<InlineTip>(InlineTip::class, binding.root, parentController) {
-    @AssistedInject internal constructor(@Assisted parent: ViewGroup, @Assisted parentController: BaseController<*>) :
-        this(TractContentInlineTipBinding.inflate(LayoutInflater.from(parent.context), parent, false), parentController)
+    @AssistedInject
+    internal constructor(
+        @Assisted parent: ViewGroup,
+        @Assisted parentController: BaseController<*>,
+        dao: GodToolsDao
+    ) : this(
+        TractContentInlineTipBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+        parentController,
+        dao
+    )
 
     @AssistedFactory
     interface Factory : BaseController.Factory<InlineTipController>
@@ -28,6 +38,6 @@ internal class InlineTipController private constructor(
     public override fun onBind() {
         super.onBind()
         binding.model = model
-        binding.isCompleted = isTipComplete(model?.id)
+        binding.isCompleted = dao.isTipComplete(model?.id)
     }
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/TipPageController.kt
@@ -12,9 +12,9 @@ import org.greenrobot.eventbus.EventBus
 
 class TipPageController @AssistedInject internal constructor(
     @Assisted private val binding: TractTipPageBinding,
-    override val eventBus: EventBus,
+    eventBus: EventBus,
     cacheFactory: UiControllerCache.Factory
-) : ParentController<TipPage>(TipPage::class, binding.root, cacheFactory = cacheFactory) {
+) : ParentController<TipPage>(TipPage::class, binding.root, cacheFactory = cacheFactory, eventBus = eventBus) {
     @AssistedFactory
     interface Factory {
         fun create(binding: TractTipPageBinding): TipPageController


### PR DESCRIPTION
Buttons inside lessons didn't have access to EventBus to trigger the appropriate EventBus events.

Long term I'm moving towards Dagger directly injecting controller dependencies where they are used instead of relying on them being in the base controller for the current hierarchy.