### PR TITLE
GT-1108 use HackyDrawerLayout to workaround a framework crash relating to MotionEvents

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,6 +176,7 @@ dependencies {
     implementation "androidx.work:work-runtime:${deps.androidX.work}"
 
     implementation "org.ccci.gto.android:gto-support-androidx-databinding:${deps.gtoSupport}"
+    implementation "org.ccci.gto.android:gto-support-androidx-drawerlayout:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-androidx-fragment:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-androidx-lifecycle:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-androidx-viewpager2:${deps.gtoSupport}"

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -9,7 +9,7 @@
         <variable name="selectedPage" type="LiveData&lt;org.cru.godtools.ui.dashboard.Page&gt;" />
     </data>
 
-    <androidx.drawerlayout.widget.DrawerLayout
+    <org.ccci.gto.android.common.androidx.drawerlayout.widget.HackyDrawerLayout
         android:id="@+id/drawer_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -60,5 +60,5 @@
             android:layout_height="match_parent"
             android:layout_gravity="start"
             app:menu="@menu/activity_generic_left_menu" />
-    </androidx.drawerlayout.widget.DrawerLayout>
+    </org.ccci.gto.android.common.androidx.drawerlayout.widget.HackyDrawerLayout>
 </layout>

--- a/app/src/main/res/layout/activity_generic_fragment_with_nav_drawer.xml
+++ b/app/src/main/res/layout/activity_generic_fragment_with_nav_drawer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.ccci.gto.android.common.androidx.drawerlayout.widget.HackyDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
@@ -17,4 +17,4 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         app:menu="@menu/activity_generic_left_menu" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</org.ccci.gto.android.common.androidx.drawerlayout.widget.HackyDrawerLayout>


### PR DESCRIPTION
Depends on:
- [x] https://github.com/CruGlobal/android-gto-support/pull/780