### PR TITLE
Revert "Update Gradle Wrapper from 6.8.3 to 7.0"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=81003f83b0056d20eedf48cddd4f52a9813163d4ba185bcf8abd34b8eeea4cbd
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionSha256Sum=9af5c8e7e2cd1a3b0f694a4ac262b9f38c75262e74a9e8b5101af302a6beadd7
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reverts CruGlobal/godtools-android#1641

firebase app distribution doesn't currently support gradle 7. https://github.com/firebase/firebase-android-sdk/issues/2580