### PR TITLE
Allow model to define default text-colors

### DIFF
--- a/ui/article-renderer/src/main/res/layout/list_item_category.xml
+++ b/ui/article-renderer/src/main/res/layout/list_item_category.xml
@@ -7,7 +7,6 @@
         <import type="androidx.databinding.ObservableField" />
         <import type="org.cru.godtools.article.ui.categories.CategorySelectedListener" />
         <import type="org.cru.godtools.tool.model.Manifest" />
-        <import type="org.cru.godtools.tool.model.ManifestKt" />
 
         <variable name="callbacks" type="ObservableField&lt;CategorySelectedListener&gt;" />
         <variable name="category" type="org.cru.godtools.tool.model.Category" />
@@ -37,7 +36,6 @@
             android:lines="2"
             android:text="@{category.label}"
             android:textSize="@{@dimen/categories_list_label_text_size, default=@dimen/categories_list_label_text_size}"
-            app:defaultTextColor="@{ManifestKt.getCategoryLabelColor(category.getManifest())}"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="About God" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
@@ -5,7 +5,6 @@ import android.graphics.Typeface
 import android.util.TypedValue
 import android.view.Gravity
 import android.widget.TextView
-import androidx.annotation.ColorInt
 import androidx.databinding.BindingAdapter
 import com.squareup.picasso.Picasso
 import org.ccci.gto.android.common.picasso.widget.TextViewDrawableEndTarget
@@ -16,15 +15,15 @@ import org.cru.godtools.base.tool.ui.util.getTypeface
 import org.cru.godtools.base.toolFileManager
 import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.Text
-import org.cru.godtools.tool.model.defaultTextColor
 import org.cru.godtools.tool.model.gravity
 import org.cru.godtools.tool.model.textAlign
+import org.cru.godtools.tool.model.textColor
 import org.cru.godtools.tool.model.textScale
 import splitties.bitflags.minusFlag
 import splitties.bitflags.withFlag
 
-@BindingAdapter("android:text", "android:textSize", "defaultTextColor", requireAll = false)
-fun TextView.bindTextNode(text: Text?, textSize: Float?, @ColorInt defaultTextColor: Int?) {
+@BindingAdapter("android:text", "android:textSize", requireAll = false)
+fun TextView.bindTextNode(text: Text?, textSize: Float?) {
     this.text = text?.text
     setTypeface(text?.manifest?.getTypeface(context), text?.typefaceStyle ?: Typeface.NORMAL)
     paintFlags = paintFlags.let {
@@ -34,8 +33,7 @@ fun TextView.bindTextNode(text: Text?, textSize: Float?, @ColorInt defaultTextCo
     val size = text.textScale * (textSize ?: context.resources.getDimension(R.dimen.tool_content_text_size_base))
     setTextSize(TypedValue.COMPLEX_UNIT_PX, size.toFloat())
 
-    val defColor = defaultTextColor ?: text.defaultTextColor
-    setTextColor(text?.getTextColor(defColor) ?: defColor)
+    setTextColor(text.textColor)
 
     // set the alignment for the text
     gravity = (gravity and Gravity.VERTICAL_GRAVITY_MASK) or text.textAlign.gravity

--- a/ui/base-tool/src/main/res/layout/tool_content_button.xml
+++ b/ui/base-tool/src/main/res/layout/tool_content_button.xml
@@ -17,6 +17,5 @@
         android:onClick="@{() -> controller.click()}"
         android:saveEnabled="false"
         android:text="@{model.text}"
-        app:backgroundColor="@{ButtonKt.getButtonColor(model)}"
-        app:defaultTextColor="@{ButtonKt.getTextColor(model)}" />
+        app:backgroundColor="@{ButtonKt.getButtonColor(model)}" />
 </layout>

--- a/ui/base-tool/src/main/res/layout/tool_content_button_outlined.xml
+++ b/ui/base-tool/src/main/res/layout/tool_content_button_outlined.xml
@@ -18,7 +18,6 @@
         android:onClick="@{() -> controller.click()}"
         android:saveEnabled="false"
         android:text="@{model.text}"
-        app:defaultTextColor="@{ButtonKt.getButtonColor(model)}"
         app:rippleColor="@{ButtonKt.getButtonColor(model)}"
         app:strokeColor="@{ButtonKt.getButtonColor(model)}" />
 </layout>

--- a/ui/base-tool/src/main/res/layout/tool_content_link.xml
+++ b/ui/base-tool/src/main/res/layout/tool_content_link.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout>
     <data>
-        <import type="org.cru.godtools.tool.model.BaseKt" />
-        <import type="org.cru.godtools.tool.model.StylesKt" />
-
         <variable name="controller" type="org.cru.godtools.base.tool.ui.controller.LinkController" />
         <variable name="model" type="org.cru.godtools.tool.model.Link" />
     </data>
@@ -18,6 +15,5 @@
         android:minHeight="32dp"
         android:saveEnabled="false"
         android:onClick="@{() -> controller.click(model)}"
-        android:text="@{model.text}"
-        app:defaultTextColor="@{StylesKt.getPrimaryColor(BaseKt.getStylesParent(model))}" />
+        android:text="@{model.text}" />
 </layout>

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/TextViewAdaptersTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/databinding/TextViewAdaptersTest.kt
@@ -14,7 +14,6 @@ import kotlin.random.Random
 import org.cru.godtools.base.tool.R
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Text
-import org.cru.godtools.tool.model.defaultTextColor
 import org.cru.godtools.tool.model.gravity
 import org.cru.godtools.tool.model.textColor
 import org.junit.Assert.assertEquals
@@ -50,7 +49,7 @@ class TextViewAdaptersTest {
             textAlign = Text.Align.CENTER,
             textStyles = setOf(Text.Style.BOLD, Text.Style.ITALIC, Text.Style.UNDERLINE)
         )
-        view.bindTextNode(text, null, null)
+        view.bindTextNode(text, null)
         assertEquals("text", view.text)
         assertEquals(Color.RED, view.textColors.defaultColor)
         assertEquals(Text.Align.CENTER.gravity, view.gravity and Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK)
@@ -63,9 +62,9 @@ class TextViewAdaptersTest {
     fun verifyBindTextNodeDefaults() {
         val baseTextSize = Random.nextFloat() * 30
         val text = Text(Manifest(), text = "text", textScale = 1.5, textColor = null, textAlign = Text.Align.END)
-        view.bindTextNode(text, baseTextSize, Color.GREEN)
+        view.bindTextNode(text, baseTextSize)
         assertEquals("text", view.text)
-        assertEquals(Color.GREEN, view.textColors.defaultColor)
+        assertEquals(text.textColor, view.textColors.defaultColor)
         assertEquals(Text.Align.END.gravity, view.gravity and Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK)
         assertEquals(1.5f * baseTextSize, view.textSize, 0.001f)
         assertEquals(NORMAL, view.typeface?.style ?: NORMAL)
@@ -75,35 +74,32 @@ class TextViewAdaptersTest {
     @Test
     fun verifyBindTextNodeTextColor() {
         with(Text(Manifest())) {
-            view.bindTextNode(this, null, null)
-            assertEquals(defaultTextColor, view.textColors.defaultColor)
+            view.bindTextNode(this, null)
+            assertEquals(textColor, view.textColors.defaultColor)
         }
 
-        view.bindTextNode(Text(Manifest(), textColor = Color.GREEN), null, Color.RED)
+        view.bindTextNode(Text(Manifest(), textColor = Color.GREEN), null)
         assertEquals(Color.GREEN, view.textColors.defaultColor)
 
-        view.bindTextNode(null, null, Color.BLUE)
-        assertEquals(Color.BLUE, view.textColors.defaultColor)
-
-        view.bindTextNode(null, null, null)
-        assertEquals((null as Text?).defaultTextColor, view.textColors.defaultColor)
+        view.bindTextNode(null, null)
+        assertEquals((null as Text?).textColor, view.textColors.defaultColor)
     }
 
     @Test
     fun verifyBindTextNodeTextStyles() {
-        view.bindTextNode(Text(Manifest()), null, null)
+        view.bindTextNode(Text(Manifest()), null)
         assertEquals(NORMAL, view.typeface?.style ?: NORMAL)
 
-        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.UNDERLINE)), null, null)
+        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.UNDERLINE)), null)
         assertEquals(NORMAL, view.typeface?.style ?: NORMAL)
 
-        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.BOLD)), null, null)
+        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.BOLD)), null)
         assertEquals(BOLD, view.typeface.style)
 
-        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.ITALIC)), null, null)
+        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.ITALIC)), null)
         assertEquals(ITALIC, view.typeface.style)
 
-        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.BOLD, Text.Style.ITALIC)), null, null)
+        view.bindTextNode(Text(Manifest(), textStyles = setOf(Text.Style.BOLD, Text.Style.ITALIC)), null)
         assertEquals(BOLD_ITALIC, view.typeface.style)
     }
 }

--- a/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_content_card.xml
@@ -51,7 +51,6 @@
                     android:layout_marginBottom="12dp"
                     android:text="@{model.label}"
                     android:textSize="@{@dimen/tract_card_label_text_size, default=@dimen/tract_card_label_text_size}"
-                    app:defaultTextColor="@{StylesKt.getPrimaryColor(model)}"
                     app:layout_constraintEnd_toStartOf="@id/tipsIndicator"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"

--- a/ui/tract-renderer/src/main/res/layout/tract_page_hero.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_page_hero.xml
@@ -4,8 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-        <import type="org.cru.godtools.tool.model.StylesKt" />
-
         <variable name="model" type="org.cru.godtools.tool.model.tract.Hero" />
     </data>
 
@@ -27,7 +25,6 @@
             android:text="@{model.heading}"
             android:textIsSelectable="true"
             android:textSize="@{@dimen/tract_hero_heading_text_size, default=@dimen/tract_hero_heading_text_size}"
-            app:defaultTextColor="@{StylesKt.getPrimaryColor(model.stylesParent)}"
             app:visibleIf="@{model.heading != null}"
             tools:text="Knowing God Personally" />
 


### PR DESCRIPTION
- The category label should automatically resolve the correct label color
- no need to define a default text color for buttons, the model correctly represents this already
- no need to define a default color for links
- no need to define the default text color for card labels
- no need to define a default color for the hero heading
- remove defaultTextColor parameter from the bindTextNode method

Dependent on:
- [x] https://github.com/CruGlobal/kotlin-mpp-godtools-tool-parser/pull/66