### PR TITLE
cleanup

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsActionEvent.kt
@@ -15,7 +15,7 @@ open class AnalyticsActionEvent(
     systems: Collection<AnalyticsSystem>? = null
 ) : AnalyticsBaseEvent(locale, systems) {
     companion object {
-        fun String.sanitizeAdobeNameForFirebase(): String = replace(Regex("[ \\-.]"), "_").toLowerCase(Locale.ROOT)
+        fun String.sanitizeAdobeNameForFirebase(): String = replace(Regex("[ \\-.]"), "_").lowercase(Locale.ROOT)
     }
 
     constructor(action: String, label: String? = null, locale: Locale? = null, system: AnalyticsSystem) :

--- a/library/model/build.gradle
+++ b/library/model/build.gradle
@@ -1,3 +1,11 @@
+android {
+    lintOptions {
+        // HACK: disable the NullSafeMutableLiveData check because it throws an error until lifecycle 2.4.0-alpha02
+        //       relevant bug: https://issuetracker.google.com/issues/183696616
+        disable "NullSafeMutableLiveData"
+    }
+}
+
 dependencies {
     implementation project(':library:base')
 

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -111,24 +111,24 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     @Subscribe
     fun onToolUpdate(event: ToolUpdateEvent) {
         // Could change which tools are visible or the label for tools
-        updateShortcutsActor.offer(Unit)
-        updatePendingShortcutsActor.offer(Unit)
+        updateShortcutsActor.trySend(Unit)
+        updatePendingShortcutsActor.trySend(Unit)
     }
 
     @AnyThread
     @Subscribe
     fun onAttachmentUpdate(event: AttachmentUpdateEvent) {
         // Handles potential icon image changes.
-        updateShortcutsActor.offer(Unit)
-        updatePendingShortcutsActor.offer(Unit)
+        updateShortcutsActor.trySend(Unit)
+        updatePendingShortcutsActor.trySend(Unit)
     }
 
     @AnyThread
     @Subscribe
     fun onTranslationUpdate(event: TranslationUpdateEvent) {
         // Could change which tools are available or the label for tools
-        updateShortcutsActor.offer(Unit)
-        updatePendingShortcutsActor.offer(Unit)
+        updateShortcutsActor.trySend(Unit)
+        updatePendingShortcutsActor.trySend(Unit)
     }
 
     @AnyThread
@@ -143,8 +143,8 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         when (key) {
             // primary/parallel language preferences changed. key=null when preferences are cleared
             Settings.PREF_PRIMARY_LANGUAGE, Settings.PREF_PARALLEL_LANGUAGE, null -> {
-                updateShortcutsActor.offer(Unit)
-                updatePendingShortcutsActor.offer(Unit)
+                updateShortcutsActor.trySend(Unit)
+                updatePendingShortcutsActor.trySend(Unit)
             }
         }
     }
@@ -221,7 +221,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
     init {
         // launch an initial update
-        updateShortcutsActor.offer(Unit)
+        updateShortcutsActor.trySend(Unit)
     }
 
     @AnyThread

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -141,7 +141,7 @@ class GodToolsShortcutManagerTest {
         verifyZeroInteractions(dao)
 
         // trigger update
-        assertTrue(shortcutManager.updatePendingShortcutsActor.offer(Unit))
+        assertTrue(shortcutManager.updatePendingShortcutsActor.trySend(Unit).isSuccess)
         verifyZeroInteractions(dao)
         coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
         verify(dao).find<Tool>("kgp")
@@ -149,10 +149,10 @@ class GodToolsShortcutManagerTest {
         clearInvocations(dao)
 
         // trigger multiple updates simultaneously, it should conflate to a single update
-        assertTrue(shortcutManager.updatePendingShortcutsActor.offer(Unit))
+        assertTrue(shortcutManager.updatePendingShortcutsActor.trySend(Unit).isSuccess)
         coroutineScope.advanceTimeBy(1)
         verifyZeroInteractions(dao)
-        assertTrue(shortcutManager.updatePendingShortcutsActor.offer(Unit))
+        assertTrue(shortcutManager.updatePendingShortcutsActor.trySend(Unit).isSuccess)
         coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
         verify(dao).find<Tool>("kgp")
         verifyNoMoreInteractions(dao)
@@ -176,10 +176,10 @@ class GodToolsShortcutManagerTest {
         clearInvocations(dao)
 
         // trigger multiple updates simultaneously, it should aggregate to a single update
-        assertTrue(shortcutManager.updateShortcutsActor.offer(Unit))
+        assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
         coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
-        assertTrue(shortcutManager.updateShortcutsActor.offer(Unit))
-        assertTrue(shortcutManager.updateShortcutsActor.offer(Unit))
+        assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
         coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
         verifyZeroInteractions(dao)
         coroutineScope.advanceUntilIdle()
@@ -192,7 +192,7 @@ class GodToolsShortcutManagerTest {
         coroutineScope.advanceUntilIdle()
         assertTrue(
             "Ensure actor can still accept requests, even though they are no-ops",
-            shortcutManager.updateShortcutsActor.offer(Unit)
+            shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess
         )
         coroutineScope.advanceUntilIdle()
         verifyZeroInteractions(dao)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -451,7 +451,7 @@ class TractActivity :
         val tool = manifest.code ?: return null
         val locale = manifest.locale ?: return null
         return URI_SHARE_BASE.buildUpon()
-            .appendEncodedPath(locale.toLanguageTag().toLowerCase(Locale.ENGLISH))
+            .appendEncodedPath(locale.toLanguageTag().lowercase(Locale.ENGLISH))
             .appendPath(tool)
             .apply { if (pager.currentItem > 0) appendPath(pager.currentItem.toString()) }
             .appendQueryParameter("icid", "gtshare")


### PR DESCRIPTION
- use trySend instead of the deprecated offer method
- use new lowercase method
- disable a lint check that crashes until lifecycle 2.4.0-alpha02
