### PR TITLE
Revert "temporarily use the snapshot build of the vanniktech jacoco plugin"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,25 +308,6 @@ subprojects {
 junitJacoco {
     jacocoVersion = deps.jacoco
     includeNoLocationClasses = true
-    excludes += [
-            // DataBinding generated classes
-            '**/DataBinderMapperImpl.java',
-            '**/*BindingImpl.*',
-            '**/databinding/*Binding.*',
-
-            // EventBus generated Indexes
-            '**/*EventBusIndex.*',
-
-            // Hilt generated classes
-            '**/hilt_aggregated_deps/**/*',
-            '**/Hilt_*',
-            '**/*_HiltModules.*',
-            '**/*_HiltModules$*',
-
-            // Room generated classes
-            '**/*_Impl.*',
-            '**/*_Impl$*'
-    ]
 }
 allprojects {
     afterEvaluate {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,22 +1,3 @@
-pluginManagement {
-    repositories {
-        maven {
-            setUrl("https://jitpack.io")
-            content { includeGroupByRegex("com\\.github\\..*") }
-        }
-        gradlePluginPortal()
-    }
-    resolutionStrategy {
-        eachPlugin {
-            // HACK: use the master-SNAPSHOT version until 0.17.0 is released. This provides a better mechanism to
-            //       modify excluded classes.
-            //       see: https://github.com/vanniktech/gradle-android-junit-jacoco-plugin/pull/173
-            if (requested.id.id == "com.vanniktech.android.junit.jacoco") {
-                useModule("com.github.vanniktech:gradle-android-junit-jacoco-plugin:master-SNAPSHOT")
-            }
-        }
-    }
-}
 rootProject.name = "godtools"
 enableFeaturePreview("VERSION_CATALOGS")
 


### PR DESCRIPTION
This reverts commit 881dd2a8d361dfc02526b40ff300166409a152ee.

This is dependent on v0.17.0+ of the vanniktech jacoco plugin being released