### PR TITLE
Revert "disable Timber lint checks until it is updated for AGP 7.0.0"

### DIFF
--- a/analysis/lint/lint.xml
+++ b/analysis/lint/lint.xml
@@ -6,14 +6,4 @@
     <!-- enable a few additional lint checks -->
 <!--    <issue id="SyntheticAccessor" severity="warning" />-->
 <!--    <issue id="UnusedIds" severity="warning" />-->
-
-    <!-- HACK: disable Timber lint checks until https://github.com/JakeWharton/timber/issues/408 is fixed -->
-    <issue id="LogNotTimber" severity="ignore" />
-    <issue id="StringFormatInTimber" severity="ignore" />
-    <issue id="ThrowableNotAtBeginning" severity="ignore" />
-    <issue id="BinaryOperationInTimber" severity="ignore" />
-    <issue id="TimberArgCount" severity="ignore" />
-    <issue id="TimberArgTypes" severity="ignore" />
-    <issue id="TimberTagLength" severity="ignore" />
-    <issue id="TimberExceptionLogging" severity="ignore" />
 </lint>


### PR DESCRIPTION
This reverts commit 0fc01925b91a5eb2c8b12061fb7f5e575cadf4a6.
