### PR TITLE
cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ subprojects {
                 compileOnly "androidx.annotation:annotation:${deps.androidX.annotation}"
                 compileOnly "com.google.code.findbugs:jsr305:${deps.findbugs}"
 
-                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${deps.kotlin}"
+                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${deps.kotlin}"
 
                 implementation "com.jakewharton.timber:timber:${deps.timber}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -159,9 +159,6 @@ allprojects {
             force "com.google.code.findbugs:jsr305:${deps.findbugs}"
             force "junit:junit:${deps.junit}"
 
-            // force the correct version of transitive coroutine libraries
-            force "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${deps.kotlinCoroutines}"
-
             // XXX: Force a version of picasso that uses AndroidX.
             //      This can be removed once FIAM doesn't depend on Picasso 2.71828
             force "com.squareup.picasso:picasso:${deps.picasso}"

--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,6 @@ allprojects {
             force "io.grpc:grpc-stub:${deps.grpc}"
 
             dependencySubstitution {
-                substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') with module("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${deps.kotlin}")
-
                 // use the new condensed version of hamcrest
                 substitute module('org.hamcrest:hamcrest-core') with module("org.hamcrest:hamcrest:${deps.hamcrest}")
                 substitute module('org.hamcrest:hamcrest-library') with module("org.hamcrest:hamcrest:${deps.hamcrest}")
@@ -243,11 +241,11 @@ subprojects {
                 }
 
                 compileOptions {
-                    sourceCompatibility JavaVersion.VERSION_1_8
-                    targetCompatibility JavaVersion.VERSION_1_8
+                    sourceCompatibility JavaVersion.VERSION_11
+                    targetCompatibility JavaVersion.VERSION_11
                 }
                 kotlinOptions {
-                    jvmTarget = JavaVersion.VERSION_1_8.toString()
+                    jvmTarget = JavaVersion.VERSION_11.toString()
                     freeCompilerArgs += '-Xjvm-default=all'
                 }
                 lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -175,10 +175,6 @@ allprojects {
 
                 // use regular moshi library instead of moshi-kotlin, any Kotlin moshi models should use moshi-kotlin-codegen instead
                 substitute module('com.squareup.moshi:moshi-kotlin') with module("com.squareup.moshi:moshi:${deps.moshi}")
-
-                // HACK: Okta changed the artifact name of their OIDC library when moving it to Maven Central,
-                //       this is a temporary substitution until gto-support is updated.
-                substitute module('com.okta.android:oidc-androidx') with module("com.okta.android:okta-oidc-android:${deps.okta}")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,13 @@ allprojects {
         }
         google()
         mavenCentral()
-        jcenter()
+        jcenter {
+            content {
+                includeModule 'com.duolingo.open', 'rtl-viewpager'
+                includeModule 'com.pierfrancescosoffritti.androidyoutubeplayer', 'core'
+                includeModule 'com.sergivonavi', 'materialbanner'
+            }
+        }
     }
 
     configurations.all { configuration ->

--- a/build.gradle
+++ b/build.gradle
@@ -151,9 +151,6 @@ allprojects {
 
     configurations.all { configuration ->
         configuration.resolutionStrategy {
-            force "androidx.annotation:annotation:${deps.androidX.annotation}"
-            force "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
-            force "androidx.fragment:fragment:${deps.androidX.fragment}"
             force "com.google.code.findbugs:jsr305:${deps.findbugs}"
             force "junit:junit:${deps.junit}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ buildscript {
                 fragment          : '1.3.6',
                 hilt              : '1.0.0',
                 lifecycle         : '2.3.1',
-                loader            : '1.1.0',
                 recyclerView      : '1.2.1',
                 room              : '2.3.0',
                 swipeRefreshLayout: '1.1.0',
@@ -155,7 +154,6 @@ allprojects {
             force "androidx.annotation:annotation:${deps.androidX.annotation}"
             force "androidx.appcompat:appcompat:${deps.androidX.appCompat}"
             force "androidx.fragment:fragment:${deps.androidX.fragment}"
-            force "androidx.loader:loader:${deps.androidX.loader}"
             force "com.google.code.findbugs:jsr305:${deps.findbugs}"
             force "junit:junit:${deps.junit}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,7 @@ allprojects {
             //      Remove this override once FIAM depends on v1.30.0+ of grpc
             //      https://github.com/grpc/grpc-java/pull/6912
             //      https://jira.cru.org/projects/GT/issues/GT-1122
+            //      https://github.com/firebase/firebase-android-sdk/issues/2642
             force "io.grpc:grpc-okhttp:${deps.grpc}"
             force "io.grpc:grpc-protobuf-lite:${deps.grpc}"
             force "io.grpc:grpc-stub:${deps.grpc}"

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/dagger/PicassoProvider.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/dagger/PicassoProvider.kt
@@ -1,0 +1,16 @@
+package org.cru.godtools.base.tool.dagger
+
+import android.content.Context
+import com.squareup.picasso.Picasso
+import dagger.hilt.EntryPoint
+import dagger.hilt.EntryPoints
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+internal interface PicassoProvider {
+    val picasso: Picasso
+}
+
+internal val Context.picasso get() = EntryPoints.get(applicationContext, PicassoProvider::class.java).picasso

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
@@ -6,11 +6,11 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
-import com.squareup.picasso.Picasso
 import org.ccci.gto.android.common.picasso.widget.TextViewDrawableEndTarget
 import org.ccci.gto.android.common.picasso.widget.TextViewDrawableStartTarget
 import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.R
+import org.cru.godtools.base.tool.dagger.picasso
 import org.cru.godtools.base.tool.ui.util.getTypeface
 import org.cru.godtools.base.toolFileManager
 import org.cru.godtools.tool.model.Resource
@@ -45,13 +45,12 @@ fun TextView.bindDrawableStartResource(resource: Resource?, drawableStartSize: I
     val file = resource?.localName?.let { context.toolFileManager.getFileBlocking(it) }
     val imageSize = dpToPixelSize(drawableStartSize, resources)
     if (file != null) {
-        // TODO: figure out how to provide Picasso Singleton from Dagger
-        Picasso.get().load(file)
+        context.picasso.load(file)
             .resize(imageSize, imageSize)
             .centerInside()
             .into(target)
     } else {
-        Picasso.get().cancelRequest(target)
+        context.picasso.cancelRequest(target)
         target.updateDrawable(null)
     }
 }
@@ -62,13 +61,12 @@ fun TextView.bindDrawableEndResource(resource: Resource?, drawableEndSize: Int) 
     val file = resource?.localName?.let { context.toolFileManager.getFileBlocking(it) }
     val imageSize = dpToPixelSize(drawableEndSize, resources)
     if (file != null) {
-        // TODO: figure out how to provide Picasso Singleton from Dagger
-        Picasso.get().load(file)
+        context.picasso.load(file)
             .resize(imageSize, imageSize)
             .centerInside()
             .into(target)
     } else {
-        Picasso.get().cancelRequest(target)
+        context.picasso.cancelRequest(target)
         target.updateDrawable(null)
     }
 }


### PR DESCRIPTION
- create a PicassoProvider that allows access to Picasso from the Dagger object graph
- use java 11 source level which is now supported with AGP 7
