### PR TITLE
cleanup

### DIFF
--- a/feature/bundledcontent/build.gradle
+++ b/feature/bundledcontent/build.gradle
@@ -1,12 +1,9 @@
 dependencies {
     implementation project(':library:initial-content')
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${deps.kotlinCoroutines}"
-
     implementation "org.ccci.gto.android:gto-support-dagger:${deps.gtoSupport}"
 
     implementation "com.google.dagger:dagger:${deps.dagger}"
-    implementation "com.google.dagger:hilt-android:${deps.dagger}"
 
     kapt "com.google.dagger:dagger-compiler:${deps.dagger}"
 }

--- a/feature/bundledcontent/src/main/AndroidManifest.xml
+++ b/feature/bundledcontent/src/main/AndroidManifest.xml
@@ -7,8 +7,7 @@
         dist:title="@string/feature_bundled_content">
         <dist:delivery>
             <dist:install-time>
-                <!-- TODO: enable this when we upgrade to Android Studio 4.2 -->
-<!--                <dist:removable value="true" />-->
+                <dist:removable value="true" />
             </dist:install-time>
         </dist:delivery>
         <dist:fusing dist:include="true" />

--- a/library/base/src/main/java/org/cru/godtools/base/util/LocaleUtils.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/util/LocaleUtils.kt
@@ -41,4 +41,4 @@ private fun Context.getLanguageNameStringRes(locale: Locale) =
     }
 
 private val Locale.languageNameStringRes
-    get() = "$STRING_RES_LANGUAGE_NAME_PREFIX${toString().toLowerCase(Locale.ENGLISH)}"
+    get() = "$STRING_RES_LANGUAGE_NAME_PREFIX${toString().lowercase(Locale.ENGLISH)}"

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.actor
-import kotlinx.coroutines.channels.receiveOrNull
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -403,11 +402,11 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     @VisibleForTesting
     @OptIn(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
     internal val cleanupActor = coroutineScope.actor<RunCleanup>(capacity = Channel.CONFLATED) {
-        withTimeoutOrNull(CLEANUP_DELAY_INITIAL) { channel.receiveOrNull() }
+        withTimeoutOrNull(CLEANUP_DELAY_INITIAL) { channel.receiveCatching() }
         while (!channel.isClosedForReceive) {
             detectMissingFiles()
             cleanFilesystem()
-            withTimeoutOrNull(CLEANUP_DELAY) { channel.receiveOrNull() }
+            withTimeoutOrNull(CLEANUP_DELAY) { channel.receiveCatching() }
         }
     }
 


### PR DESCRIPTION
- make the bundled content feature removable
- use lowercase instead of toLowercase
- use receiveCatching instead of deprecated receiveOrNull
- remove some unnecessary dependencies from the bundled content feature
