### PR TITLE
cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -193,7 +193,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-recyclerview-advrecyclerview:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.google.firebase:firebase-crashlytics:${deps.firebase.crashlytics}"
     implementation "com.google.firebase:firebase-inappmessaging-display:${deps.firebase.inAppMessaging}"

--- a/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.kt
+++ b/app/src/main/java/org/keynote/godtools/android/activity/MainActivity.kt
@@ -141,7 +141,7 @@ class MainActivity :
         bottomNav.menu.findItem(R.id.action_lessons)?.let { lessons ->
             dataModel.lessons.observe(this@MainActivity) { lessons.isVisible = !it.isNullOrEmpty() }
         }
-        bottomNav.setOnNavigationItemSelectedListener {
+        bottomNav.setOnItemSelectedListener {
             Page.findPage(it.itemId)?.let { showPage(it) }
             true
         }

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
@@ -36,7 +36,7 @@ private const val STATUS_NON_ORGANIC = "Non-organic"
 class AppsFlyerAnalyticsService @VisibleForTesting internal constructor(
     private val app: Application,
     eventBus: EventBus,
-    private val deepLinkResolvers: Set<@JvmSuppressWildcards AppsFlyerDeepLinkResolver>,
+    private val deepLinkResolvers: Set<AppsFlyerDeepLinkResolver>,
     private val appsFlyer: AppsFlyerLib
 ) : Application.ActivityLifecycleCallbacks {
     @Inject

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
@@ -18,6 +18,7 @@ import org.cru.godtools.analytics.BuildConfig
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
+import org.cru.godtools.base.HOST_GET_GODTOOLSAPP_COM
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -103,7 +104,7 @@ class AppsFlyerAnalyticsService @VisibleForTesting internal constructor(
     init {
         appsFlyer.apply {
             if (BuildConfig.DEBUG) setLogLevel(AFLogger.LogLevel.DEBUG)
-            setOneLinkCustomDomain("get.godtoolsapp.com")
+            setOneLinkCustomDomain(HOST_GET_GODTOOLSAPP_COM)
             init(BuildConfig.APPSFLYER_DEV_KEY, conversionListener, app)
             start(app)
         }

--- a/library/base/src/main/java/org/cru/godtools/base/Constants.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Constants.kt
@@ -7,4 +7,6 @@ const val EXTRA_TOOL = "tool"
 const val EXTRA_LANGUAGE = "language"
 const val EXTRA_LANGUAGES = "languages"
 
-val URI_SHARE_BASE: Uri = Uri.parse("https://knowgod.com/")
+const val HOST_KNOWGOD_COM = "knowgod.com"
+
+val URI_SHARE_BASE: Uri = Uri.parse("https://$HOST_KNOWGOD_COM/")

--- a/library/base/src/main/java/org/cru/godtools/base/Constants.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Constants.kt
@@ -7,6 +7,7 @@ const val EXTRA_TOOL = "tool"
 const val EXTRA_LANGUAGE = "language"
 const val EXTRA_LANGUAGES = "languages"
 
+const val HOST_GODTOOLSAPP_COM = "godtoolsapp.com"
 const val HOST_GET_GODTOOLSAPP_COM = "get.godtoolsapp.com"
 const val HOST_KNOWGOD_COM = "knowgod.com"
 

--- a/library/base/src/main/java/org/cru/godtools/base/Constants.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Constants.kt
@@ -7,6 +7,7 @@ const val EXTRA_TOOL = "tool"
 const val EXTRA_LANGUAGE = "language"
 const val EXTRA_LANGUAGES = "languages"
 
+const val HOST_GET_GODTOOLSAPP_COM = "get.godtoolsapp.com"
 const val HOST_KNOWGOD_COM = "knowgod.com"
 
 val URI_SHARE_BASE: Uri = Uri.parse("https://$HOST_KNOWGOD_COM/")

--- a/ui/article-aem-renderer/build.gradle
+++ b/ui/article-aem-renderer/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-okhttp3:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.github.Karumi:WeakDelegate:${deps.weakdelegate}"
     implementation "com.google.dagger:dagger:${deps.dagger}"

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -27,6 +27,7 @@ import org.cru.godtools.article.aem.fragment.AemArticleFragment
 import org.cru.godtools.article.aem.model.Article
 import org.cru.godtools.article.aem.service.AemArticleManager
 import org.cru.godtools.article.aem.util.removeExtension
+import org.cru.godtools.base.HOST_GODTOOLSAPP_COM
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivity
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
@@ -106,7 +107,7 @@ class AemArticleActivity :
     private fun Intent?.isValidDeepLink() =
         this != null && action == Intent.ACTION_VIEW && data?.isValidDeepLink() == true
     private fun Uri.isValidDeepLink() =
-        (scheme == "http" || scheme == "https") && host == "godtoolsapp.com" && path == "/article/aem"
+        (scheme == "http" || scheme == "https") && host == HOST_GODTOOLSAPP_COM && path == "/article/aem"
     // endregion Intent parsing
 
     private val articleDataModel: AemArticleViewModel by viewModels()

--- a/ui/article-renderer/build.gradle
+++ b/ui/article-renderer/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-recyclerview:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.google.dagger:dagger:${deps.dagger}"
     implementation "com.google.dagger:hilt-android:${deps.dagger}"

--- a/ui/base-tool/build.gradle
+++ b/ui/base-tool/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     api "org.ccci.gto.android:gto-support-picasso:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.airbnb.android:lottie:${deps.lottie}"
     api "com.getkeepsafe.taptargetview:taptargetview:${deps.taptargetview}"

--- a/ui/lesson-renderer/build.gradle
+++ b/ui/lesson-renderer/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-material-components:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-recyclerview:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.google.android.material:material:${deps.materialDesign}"
     implementation "com.google.dagger:hilt-android:${deps.dagger}"

--- a/ui/tract-renderer/build.gradle
+++ b/ui/tract-renderer/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
     api "org.ccci.gto.android:gto-support-viewpager:${deps.gtoSupport}"
 
-    implementation "org.cru.godtools.kotlin:godtools-tool-parser:${deps.godtoolsToolParser}"
+    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
 
     implementation "com.airbnb.android:lottie:${deps.lottie}"
     implementation 'com.duolingo.open:rtl-viewpager:2.0.0'

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -204,7 +204,7 @@ class TractActivity :
     private fun processIntent(intent: Intent?, savedInstanceState: Bundle?) {
         val data = intent?.data
         val extras = intent?.extras
-        if (intent?.action == Intent.ACTION_VIEW && data?.isTractDeepLink(this) == true) {
+        if (intent?.action == Intent.ACTION_VIEW && data?.isTractDeepLink() == true) {
             dataModel.tool.value = data.deepLinkTool
             val (primary, parallel) = data.deepLinkLanguages
             dataModel.primaryLocales.value = primary

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/appsflyer/TractAppsFlyerDeepLinkResolver.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/analytics/appsflyer/TractAppsFlyerDeepLinkResolver.kt
@@ -9,7 +9,7 @@ import org.cru.godtools.tract.util.isTractDeepLink
 
 object TractAppsFlyerDeepLinkResolver : AppsFlyerDeepLinkResolver {
     override fun resolve(context: Context, uri: Uri?, data: Map<String, String?>) = when {
-        uri?.isTractDeepLink(context) == true -> Intent(Intent.ACTION_VIEW, uri, context, TractActivity::class.java)
+        uri?.isTractDeepLink() == true -> Intent(Intent.ACTION_VIEW, uri, context, TractActivity::class.java)
         else -> null
     }
 }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/util/DeepLinkUtils.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/util/DeepLinkUtils.kt
@@ -1,12 +1,7 @@
 package org.cru.godtools.tract.util
 
-import android.content.Context
 import android.net.Uri
-import org.cru.godtools.tract.R
+import org.cru.godtools.base.HOST_KNOWGOD_COM
 
-internal fun Uri.isTractDeepLink(context: Context) = ("http".equals(scheme, true) || "https".equals(scheme, true)) &&
-    isTractDeepLinkHost(context) && pathSegments.size >= 2
-
-private fun Uri.isTractDeepLinkHost(context: Context) =
-    context.getString(R.string.tract_deeplink_host_1).equals(host, true) ||
-        context.getString(R.string.tract_deeplink_host_2).equals(host, true)
+internal fun Uri.isTractDeepLink() = ("http".equals(scheme, true) || "https".equals(scheme, true)) &&
+    host.equals(HOST_KNOWGOD_COM, true) && pathSegments.size >= 2

--- a/ui/tract-renderer/src/main/res/values/deeplinks_tract.xml
+++ b/ui/tract-renderer/src/main/res/values/deeplinks_tract.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="tract_deeplink_host_1" translatable="false">www.knowgod.com</string>
-    <string name="tract_deeplink_host_2" translatable="false">knowgod.com</string>
-</resources>

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/util/DeepLinkUtilsTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/util/DeepLinkUtilsTest.kt
@@ -1,34 +1,23 @@
 package org.cru.godtools.tract.util
 
-import android.app.Activity
-import android.content.Context
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class DeepLinkUtilsTest {
-    lateinit var context: Context
-
-    @Before
-    fun setup() {
-        context = Robolectric.buildActivity(Activity::class.java).get()
-    }
-
     @Test
     fun verifyIsTractDeepLink() {
-        assertFalse(Uri.parse("wss://knowgod.com/en/kgp").isTractDeepLink(context))
-        assertFalse(Uri.parse("https://example.com/en/kgp").isTractDeepLink(context))
-        assertFalse(Uri.parse("https://knowgod.com/en").isTractDeepLink(context))
-        assertTrue(Uri.parse("http://knowgod.com/en/kgp").isTractDeepLink(context))
-        assertTrue(Uri.parse("https://knowgod.com/en/kgp").isTractDeepLink(context))
-        assertTrue(Uri.parse("https://www.knowgod.com/en/kgp").isTractDeepLink(context))
-        assertTrue(Uri.parse("https://knowgod.com/en/fourlaws").isTractDeepLink(context))
-        assertTrue(Uri.parse("https://knowgod.com/en/kgp/2").isTractDeepLink(context))
+        assertFalse(Uri.parse("wss://knowgod.com/en/kgp").isTractDeepLink())
+        assertFalse(Uri.parse("https://example.com/en/kgp").isTractDeepLink())
+        assertFalse(Uri.parse("https://knowgod.com/en").isTractDeepLink())
+        assertTrue(Uri.parse("http://knowgod.com/en/kgp").isTractDeepLink())
+        assertTrue(Uri.parse("https://knowgod.com/en/kgp").isTractDeepLink())
+        assertFalse(Uri.parse("https://www.knowgod.com/en/kgp").isTractDeepLink())
+        assertTrue(Uri.parse("https://knowgod.com/en/fourlaws").isTractDeepLink())
+        assertTrue(Uri.parse("https://knowgod.com/en/kgp/2").isTractDeepLink())
     }
 }


### PR DESCRIPTION
- update the shared parser dependency
- move away from deprecated method
- remove unnecessary JvmSuppressWildcards annotation from a non-dagger constructor
- create a constant for the knowgod.com domain
- make the get.godtoolsapp.com hostname a constant
- make a constant for godtoolsapp.com
