### PR TITLE
cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.GodTools.AppBar">
+        android:theme="@style/Theme.GodTools">
         <activity
             android:name="org.keynote.godtools.android.activity.MainActivity"
             android:launchMode="singleTask"

--- a/ui/article-aem-renderer/src/main/AndroidManifest.xml
+++ b/ui/article-aem-renderer/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
             android:name=".ui.AemArticleActivity"
             android:parentActivityName="org.cru.godtools.article.ui.ArticlesActivity"
             android:screenOrientation="user"
-            android:theme="@style/Theme.GodTools.Tool.AppBar">
+            android:theme="@style/Theme.GodTools.Tool">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleViewModel.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleViewModel.kt
@@ -39,7 +39,7 @@ internal class AemArticleViewModel @Inject constructor(
         val context = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ->
                 ContextThemeWrapper(activity.applicationContext, activity.theme)
-            else -> ContextThemeWrapper(activity.applicationContext, R.style.Theme_GodTools_Tool_AppBar)
+            else -> ContextThemeWrapper(activity.applicationContext, R.style.Theme_GodTools_Tool)
         }
 
         webView = WebView(context).apply {

--- a/ui/article-renderer/src/main/AndroidManifest.xml
+++ b/ui/article-renderer/src/main/AndroidManifest.xml
@@ -6,6 +6,6 @@
             android:name=".ui.ArticlesActivity"
             android:parentActivityName="org.keynote.godtools.android.activity.MainActivity"
             android:screenOrientation="@integer/default_screen_orientation"
-            android:theme="@style/Theme.GodTools.Tool.AppBar" />
+            android:theme="@style/Theme.GodTools.Tool" />
     </application>
 </manifest>

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.base.tool.activity
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -119,12 +118,10 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     private fun setupStatusBar() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.apply {
-                addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-                activeManifestLiveData.observe(this@BaseToolActivity) {
-                    statusBarColor = it.navBarColor.toHslColor().darken(0.12f).toColorInt()
-                }
+        window.apply {
+            addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            activeManifestLiveData.observe(this@BaseToolActivity) {
+                statusBarColor = it.navBarColor.toHslColor().darken(0.12f).toColorInt()
             }
         }
     }

--- a/ui/base-tool/src/main/res/values/styles.xml
+++ b/ui/base-tool/src/main/res/values/styles.xml
@@ -5,14 +5,7 @@
         <item name="materialButtonOutlinedStyle">@style/Widget.GodTools.Tool.Content.Button.OutlinedButton</item>
     </style>
 
-    <style name="Theme.GodTools.Tool.AppBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionModeOverlay">true</item>
-    </style>
-
-    <style name="Theme.GodTools.Tool.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
+    <style name="Theme.GodTools.Tool.NoAppBar">
+        <item name="windowActionModeOverlay">false</item>
     </style>
 </resources>

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/activity/BaseActivity.kt
@@ -209,7 +209,6 @@ abstract class BaseActivity<B : ViewBinding> protected constructor(@LayoutRes pr
     // endregion Up Navigation
 
     companion object {
-        @JvmStatic
         fun buildExtras(context: Context) = Bundle().apply {
             if (context is Activity) putParcelable(EXTRA_LAUNCHING_COMPONENT, context.componentName)
         }

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/util/WebUrlLauncher.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/util/WebUrlLauncher.kt
@@ -6,6 +6,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.net.Uri
 import android.widget.Toast
+import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.ContextCompat
 import org.cru.godtools.base.ui.R
@@ -15,8 +16,12 @@ fun Context.openUrl(url: Uri) = try {
     CustomTabsIntent.Builder()
         .setShowTitle(false)
         .setUrlBarHidingEnabled(true)
-        // XXX: we use gt_blue_dark to force white text & action buttons for now
-        .setToolbarColor(ContextCompat.getColor(this, R.color.gt_blue_dark))
+        .setDefaultColorSchemeParams(
+            CustomTabColorSchemeParams.Builder()
+                // XXX: we use gt_blue_dark to force white text & action buttons for now
+                .setToolbarColor(ContextCompat.getColor(this, R.color.gt_blue_dark))
+                .build()
+        )
         .setInstantAppsEnabled(true)
         .build().launchUrl(this, url)
     true

--- a/ui/base/src/main/java/org/cru/godtools/base/ui/util/WebUrlLauncher.kt
+++ b/ui/base/src/main/java/org/cru/godtools/base/ui/util/WebUrlLauncher.kt
@@ -1,5 +1,3 @@
-@file:JvmName("WebUrlLauncher")
-
 package org.cru.godtools.base.ui.util
 
 import android.content.ActivityNotFoundException

--- a/ui/base/src/main/res/values/styles.xml
+++ b/ui/base/src/main/res/values/styles.xml
@@ -3,11 +3,13 @@
     <style name="Base"/>
 
     <!-- GodTools theme -->
-    <style name="Theme.GodTools" parent="Theme.MaterialComponents.Light">
+    <style name="Theme.GodTools" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/gt_blue</item>
         <item name="colorPrimaryDark">@color/gt_blue_dark</item>
         <item name="colorAccent">@color/gt_blue</item>
         <item name="android:windowBackground">@color/white</item>
+
+        <item name="windowActionModeOverlay">true</item>
 
         <item name="actionBarTheme">@style/ThemeOverlay.GodTools.Toolbar.AppBar</item>
         <item name="actionBarStyle">@style/Widget.GodTools.ActionBar.Solid</item>
@@ -17,9 +19,7 @@
         <item name="toolbarStyle">@style/Widget.GodTools.Toolbar.AppBar</item>
     </style>
 
-    <style name="Theme.GodTools.AppBar">
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowActionModeOverlay">true</item>
+    <style name="Theme.GodTools.NoAppBar">
+        <item name="windowActionModeOverlay">false</item>
     </style>
 </resources>

--- a/ui/lesson-renderer/src/main/res/values/styles.xml
+++ b/ui/lesson-renderer/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 <resources>
     <dimen name="lesson_content_horiz_margin">16dp</dimen>
 
-    <style name="Theme.GodTools.Tool.Activity.Lesson" parent="Theme.GodTools.Tool.AppBar">
+    <style name="Theme.GodTools.Tool.Activity.Lesson" parent="Theme.GodTools.Tool">
         <item name="materialButtonStyle">@style/Widget.GodTools.Tool.Lesson.Content.Button</item>
         <item name="materialButtonOutlinedStyle">@style/Widget.GodTools.Tool.Lesson.Content.Button.OutlinedButton</item>
 

--- a/ui/tract-renderer/src/main/res/values/styles.xml
+++ b/ui/tract-renderer/src/main/res/values/styles.xml
@@ -7,5 +7,5 @@
 
     <dimen name="tract_content_margin_horizontal">16dp</dimen>
 
-    <style name="Theme.GodTools.Tract.Activity.Tract" parent="Theme.GodTools.Tool.AppBar" />
+    <style name="Theme.GodTools.Tract.Activity.Tract" parent="Theme.GodTools.Tool" />
 </resources>

--- a/ui/tract-renderer/src/main/res/values/styles_modal.xml
+++ b/ui/tract-renderer/src/main/res/values/styles_modal.xml
@@ -2,7 +2,7 @@
 <resources>
     <dimen name="tract_content_modal_title_text_size">48sp</dimen>
 
-    <style name="Theme.GodTools.Tract.Activity.Modal" parent="Theme.GodTools.Tool.NoActionBar">
+    <style name="Theme.GodTools.Tract.Activity.Modal" parent="Theme.GodTools.Tool.NoAppBar">
         <item name="android:fitsSystemWindows">false</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/ui/tutorial-renderer/src/main/res/values/styles.xml
+++ b/ui/tutorial-renderer/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.GodTools.Activity.Tutorial" parent="Theme.GodTools.AppBar">
+    <style name="Theme.GodTools.Activity.Tutorial" parent="Theme.GodTools">
         <item name="actionMenuTextColor">@color/gt_blue</item>
         <item name="colorControlNormal">@color/gt_blue</item>
 


### PR DESCRIPTION
- remove unnecessary JvmStatic annotation
- move away from deprecated setToolbarColor method
- remove unnecessary JvmName annotation
- remove unnecessary SDK version check
