### PR TITLE
GT-1275 Fix multiselect layout when rendering a single column

### DIFF
--- a/ui/base-tool/src/main/res/layout/tool_content_multiselect_option.xml
+++ b/ui/base-tool/src/main/res/layout/tool_content_multiselect_option.xml
@@ -16,7 +16,7 @@
         android:layout_height="wrap_content"
         android:clipToPadding="false"
         android:padding="8dp"
-        app:layout_constraintWidth_percent="@{(float) 1 / (model != null ? model.multiselect.columns : 1)}">
+        app:layout_constraintWidth_percent="@{(float) 1 / (model != null ? model.multiselect.columns : 1), default=1}">
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"


### PR DESCRIPTION
when the multiselect option is created the `layout_constraintWidth_percentage` wouldn't initially be set. This would cause all options to be rendered in a single row.

Once databinding runs it would attempt to set the percentage to 100%, but would short-circuit because the unset internal value is 100%. This would result in the view not being re-laid out.