### PR TITLE
Switch from onActivityResult to new ActivityResultContract API

### DIFF
--- a/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/TutorialActivityResultContract.kt
+++ b/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/TutorialActivityResultContract.kt
@@ -1,0 +1,11 @@
+package org.cru.godtools.tutorial
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import org.cru.godtools.tutorial.activity.buildTutorialActivityIntent
+
+class TutorialActivityResultContract : ActivityResultContract<PageSet, Int>() {
+    override fun createIntent(context: Context, input: PageSet) = context.buildTutorialActivityIntent(pageSet = input)
+    override fun parseResult(resultCode: Int, intent: Intent?) = resultCode
+}


### PR DESCRIPTION
- create a Tutorial AcitvityResultContract for launching tutorials expecting results
- update ToolDetailsFragment to use tutorial ActivityResultContract
- use the ActivityResultContract for launching the tutorial activity
