### PR TITLE
Use coroutines Flow to monitor for primary/parallel language changes

### DIFF
--- a/library/base/build.gradle
+++ b/library/base/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     implementation "org.ccci.gto.android:gto-support-androidx-lifecycle:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-compat:${deps.gtoSupport}"
+    implementation "org.ccci.gto.android:gto-support-kotlin-coroutines:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-okta:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-util:${deps.gtoSupport}"
 

--- a/library/base/src/main/java/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.kt
@@ -209,12 +209,4 @@ class Settings @Inject internal constructor(
         trackFirstLaunchVersion()
     }
     // endregion Launch tracking
-
-    fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        prefs.registerOnSharedPreferenceChangeListener(listener)
-    }
-
-    fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        prefs.unregisterOnSharedPreferenceChangeListener(listener)
-    }
 }

--- a/library/base/src/main/java/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.kt
@@ -13,9 +13,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.androidx.lifecycle.getBooleanLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.getIntLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.getStringLiveData
+import org.ccci.gto.android.common.kotlin.coroutines.getStringFlow
 import org.ccci.gto.android.common.okta.oidc.clients.sessions.oktaUserId
 import org.ccci.gto.android.common.util.toLocale
 
@@ -74,6 +77,9 @@ class Settings @Inject internal constructor(
         prefs.getStringLiveData(PREF_PRIMARY_LANGUAGE, defaultLanguage.toLanguageTag()).distinctUntilChanged()
             .map { it?.toLocale() ?: defaultLanguage.also { primaryLanguage = it } }
     }
+    val primaryLanguageFlow
+        get() = prefs.getStringFlow(PREF_PRIMARY_LANGUAGE, defaultLanguage.toLanguageTag()).distinctUntilChanged()
+            .map { it?.toLocale() ?: defaultLanguage.also { primaryLanguage = it } }
 
     var parallelLanguage
         get() = prefs.getString(PREF_PARALLEL_LANGUAGE, null)?.toLocale()
@@ -86,6 +92,9 @@ class Settings @Inject internal constructor(
         prefs.getStringLiveData(PREF_PARALLEL_LANGUAGE, null).distinctUntilChanged()
             .map { it?.toLocale() }
     }
+    val parallelLanguageFlow
+        get() = prefs.getStringFlow(PREF_PARALLEL_LANGUAGE, null).distinctUntilChanged()
+            .map { it?.toLocale() }
 
     fun isLanguageProtected(locale: Locale) = when (locale) {
         defaultLanguage -> true

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -22,11 +22,14 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import com.squareup.picasso.Picasso
 import java.util.EnumSet
+import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.find
 import org.ccci.gto.android.common.testing.timber.ExceptionRaisingTree
@@ -67,6 +70,9 @@ class GodToolsShortcutManagerTest {
     private val coroutineScope = TestCoroutineScope(SupervisorJob()).apply { pauseDispatcher() }
     private val ioDispatcher = TestCoroutineDispatcher()
 
+    private val primaryLanguageFlow = MutableSharedFlow<Locale>(extraBufferCapacity = 20)
+    private val parallelLanguageFlow = MutableSharedFlow<Locale?>(extraBufferCapacity = 20)
+
     private lateinit var shortcutManager: GodToolsShortcutManager
 
     @Before
@@ -91,7 +97,10 @@ class GodToolsShortcutManagerTest {
         eventBus = mock()
         fileManager = mock()
         picasso = mock()
-        settings = mock()
+        settings = mock {
+            on { primaryLanguageFlow } doReturn primaryLanguageFlow
+            on { parallelLanguageFlow } doReturn parallelLanguageFlow
+        }
 
         shortcutManager =
             GodToolsShortcutManager(app, dao, eventBus, fileManager, picasso, settings, coroutineScope, ioDispatcher)
@@ -163,23 +172,49 @@ class GodToolsShortcutManagerTest {
 
     // region Update Existing Shortcuts
     @Test
-    fun verifyUpdateExistingShortcuts() {
+    fun verifyUpdateExistingShortcutsOnPrimaryLanguageUpdate() {
         assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
 
         whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
+        assertUpdateExistingShortcutsInitialUpdate()
 
-        // ensure update shortcuts is initially delayed
-        coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
+        // trigger a primary language update
+        assertTrue(primaryLanguageFlow.tryEmit(Locale.ENGLISH))
         verifyZeroInteractions(dao)
-        coroutineScope.advanceTimeBy(1)
+        coroutineScope.advanceUntilIdle()
         verify(dao).get(Tool::class.java)
-        clearInvocations(dao)
+    }
+
+    @Test
+    fun verifyUpdateExistingShortcutsOnParallelLanguageUpdate() {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
+
+        whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
+        assertUpdateExistingShortcutsInitialUpdate()
+
+        // trigger a primary language update
+        assertTrue(parallelLanguageFlow.tryEmit(null))
+        verifyZeroInteractions(dao)
+        coroutineScope.advanceUntilIdle()
+        verify(dao).get(Tool::class.java)
+    }
+
+    @Test
+    fun verifyUpdateExistingShortcutsAggregateMultiple() = runBlockingTest {
+        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
+
+        whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
+        assertUpdateExistingShortcutsInitialUpdate()
 
         // trigger multiple updates simultaneously, it should aggregate to a single update
         assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(primaryLanguageFlow.tryEmit(Locale.ENGLISH))
+        assertTrue(parallelLanguageFlow.tryEmit(null))
         coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
         assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
         assertTrue(shortcutManager.updateShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(primaryLanguageFlow.tryEmit(Locale.ENGLISH))
+        assertTrue(parallelLanguageFlow.tryEmit(null))
         coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
         verifyZeroInteractions(dao)
         coroutineScope.advanceUntilIdle()
@@ -210,6 +245,15 @@ class GodToolsShortcutManagerTest {
             coroutineScope.launch { shortcutManager.updateDynamicShortcuts(emptyMap()) }.cancel()
             ioDispatcher.resumeDispatcher()
         }
+    }
+
+    private fun assertUpdateExistingShortcutsInitialUpdate() {
+        // ensure update shortcuts is initially delayed
+        coroutineScope.advanceTimeBy(DELAY_UPDATE_SHORTCUTS - 1)
+        verifyZeroInteractions(dao)
+        coroutineScope.advanceTimeBy(1)
+        verify(dao).get(Tool::class.java)
+        clearInvocations(dao)
     }
     // endregion Update Existing Shortcuts
 


### PR DESCRIPTION
- expose the primary and parallel languages as coroutine flows
- update the GodToolsShortcutManager to monitor primary & parallel language changes via coroutine flows
- remove unused register/unregister listener methods
