### PR TITLE
GT-1189 Support providing lesson feedback

### DIFF
--- a/library/base/src/main/java/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/java/org/cru/godtools/base/Settings.kt
@@ -49,6 +49,7 @@ class Settings @Inject internal constructor(
         const val FEATURE_TOOL_OPENED = "toolOpened"
         const val FEATURE_TOOL_SHARE = "toolShare"
         const val FEATURE_TOOL_FAVORITE = "toolFavorite"
+        const val FEATURE_LESSON_FEEDBACK = "lessonFeedback."
         const val FEATURE_TRACT_CARD_SWIPED = "tractCardSwiped"
         const val FEATURE_TRACT_CARD_CLICKED = "tractCardClicked"
         const val FEATURE_TUTORIAL_ONBOARDING = "tutorialOnboarding"

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -247,7 +247,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         val manifest = activeManifest ?: return
         if (manifest.code != event.tool || manifest.locale != event.locale) return
 
-        manifest.checkForEvent(event)
+        checkForManifestEvent(manifest, event)
         if (isFinishing) return
         onContentEvent(event)
     }
@@ -255,8 +255,8 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     @MainThread
     protected open fun onContentEvent(event: Event) = Unit
 
-    private fun Manifest.checkForEvent(event: Event) {
-        if (event.id in dismissListeners) {
+    protected open fun checkForManifestEvent(manifest: Manifest, event: Event) {
+        if (event.id in manifest.dismissListeners) {
             finish()
             return
         }

--- a/ui/lesson-renderer/build.gradle
+++ b/ui/lesson-renderer/build.gradle
@@ -10,9 +10,11 @@ dependencies {
     api project(":ui:base-tool")
 
     implementation "androidx.activity:activity-ktx:${deps.androidX.activity}"
+    implementation "androidx.fragment:fragment-ktx:${deps.androidX.fragment}"
     implementation "androidx.viewpager2:viewpager2:${deps.androidX.viewPager2}"
 
     implementation "org.ccci.gto.android:gto-support-androidx-databinding:${deps.gtoSupport}"
+    implementation "org.ccci.gto.android:gto-support-androidx-fragment:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-androidx-lifecycle:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-androidx-viewpager2:${deps.gtoSupport}"
     implementation "org.ccci.gto.android:gto-support-eventbus:${deps.gtoSupport}"

--- a/ui/lesson-renderer/build.gradle
+++ b/ui/lesson-renderer/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     implementation "com.google.android.material:material:${deps.materialDesign}"
     implementation "com.google.dagger:hilt-android:${deps.dagger}"
+    implementation "com.louiscad.splitties:splitties-fragmentargs:${deps.splitties}"
 
     kapt "com.google.dagger:dagger-compiler:${deps.dagger}"
     kapt "com.google.dagger:hilt-compiler:${deps.dagger}"

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/analytics/model/LessonFeedbackAnalyticsEvent.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/analytics/model/LessonFeedbackAnalyticsEvent.kt
@@ -1,0 +1,24 @@
+package org.cru.godtools.tool.lesson.analytics.model
+
+import android.os.Bundle
+import java.util.Locale
+import org.cru.godtools.analytics.model.AnalyticsActionEvent
+import org.cru.godtools.analytics.model.AnalyticsSystem
+
+private const val ACTION_LESSON_FEEDBACK = "lesson_feedback"
+
+internal class LessonFeedbackAnalyticsEvent(lesson: String, locale: Locale, private val args: Bundle) :
+    AnalyticsActionEvent(ACTION_LESSON_FEEDBACK, locale = locale, systems = setOf(AnalyticsSystem.FIREBASE)) {
+    companion object {
+        const val PARAM_HELPFUL = "helpful"
+        const val PARAM_READINESS = "readiness"
+        const val PARAM_PAGE_REACHED = "page_reached"
+
+        const val VALUE_HELPFUL_YES = "yes"
+        const val VALUE_HELPFUL_NO = "no"
+    }
+
+    override val appSection = lesson
+
+    override val firebaseParams get() = Bundle().apply { putAll(args) }
+}

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -2,9 +2,14 @@ package org.cru.godtools.tool.lesson.ui
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.switchMap
 import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import dagger.hilt.android.AndroidEntryPoint
@@ -15,6 +20,8 @@ import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.lifecycle.SetLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.viewpager2.widget.whileMaintainingVisibleCurrentItem
+import org.cru.godtools.base.Settings
+import org.cru.godtools.base.Settings.Companion.FEATURE_LESSON_FEEDBACK
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivity
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivityDataModel
 import org.cru.godtools.base.tool.model.Event
@@ -24,6 +31,7 @@ import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.tool.lesson.R
 import org.cru.godtools.tool.lesson.analytics.model.LessonPageAnalyticsScreenEvent
 import org.cru.godtools.tool.lesson.databinding.LessonActivityBinding
+import org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackDialogFragment
 import org.cru.godtools.tool.lesson.util.isLessonDeepLink
 import org.cru.godtools.tool.lesson.util.lessonDeepLinkCode
 import org.cru.godtools.tool.lesson.util.lessonDeepLinkLocale
@@ -43,6 +51,11 @@ class LessonActivity :
     private val toolState: ToolStateHolder by viewModels()
 
     // region Lifecycle
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setupFeedbackDialog()
+    }
+
     override fun onBindingChanged() {
         super.onBindingChanged()
         binding.setupPages()
@@ -52,6 +65,11 @@ class LessonActivity :
     override fun onResume() {
         super.onResume()
         trackPageInAnalytics()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        android.R.id.home -> showFeedbackDialogIfNecessary() || super.onOptionsItemSelected(item)
+        else -> super.onOptionsItemSelected(item)
     }
 
     override fun onContentEvent(event: Event) {
@@ -124,6 +142,7 @@ class LessonActivity :
             override fun onPageSelected(position: Int) {
                 updateProgressIndicator(position = position)
                 trackPageInAnalytics(dataModel.pages.value?.getOrNull(position))
+                dataModel.pageReached.value = maxOf(position, dataModel.pageReached.value ?: 0)
             }
         })
     }
@@ -146,7 +165,33 @@ class LessonActivity :
         binding.pages.currentItem += 1
     }
     // endregion Pages
+
+    // region Feedback
+    private fun setupFeedbackDialog() {
+        supportFragmentManager.setFragmentResultListener(LessonFeedbackDialogFragment.RESULT_DISMISSED, this) { _, _ ->
+            settings.setFeatureDiscovered(FEATURE_LESSON_FEEDBACK + tool)
+            finish()
+        }
+        onBackPressedDispatcher.addCallback(
+            object : OnBackPressedCallback(false) {
+                override fun handleOnBackPressed() {
+                    showFeedbackDialogIfNecessary()
+                }
+            }.also { cb -> dataModel.showFeedback.observe(this) { cb.isEnabled = it } }
+        )
+    }
+
+    private fun showFeedbackDialogIfNecessary() = if (dataModel.showFeedback.value == true) {
+        LessonFeedbackDialogFragment(tool, locale, dataModel.pageReached.value ?: 0).show(supportFragmentManager, null)
+        true
+    } else false
+    // endregion Feedback
     // endregion UI
+
+    override fun checkForManifestEvent(manifest: Manifest, event: Event) {
+        if (event.id in manifest.dismissListeners && showFeedbackDialogIfNecessary()) return
+        super.checkForManifestEvent(manifest, event)
+    }
 
     private fun trackPageInAnalytics(page: LessonPage? = dataModel.pages.value?.getOrNull(binding.pages.currentItem)) {
         page?.let { eventBus.post(LessonPageAnalyticsScreenEvent(page)) }
@@ -157,11 +202,19 @@ class LessonActivity :
 class LessonActivityDataModel @Inject constructor(
     manifestManager: ManifestManager,
     dao: GodToolsDao,
-    downloadManager: GodToolsDownloadManager
+    downloadManager: GodToolsDownloadManager,
+    settings: Settings,
+    savedState: SavedStateHandle
 ) : BaseSingleToolActivityDataModel(manifestManager, dao, downloadManager) {
     val visiblePages = SetLiveData<String>(synchronous = true)
 
     val pages = manifest.combineWith(visiblePages) { manifest, visible ->
         manifest?.lessonPages.orEmpty().filter { !it.isHidden || it.id in visible }
     }.distinctUntilChanged()
+
+    val pageReached = savedState.getLiveData("pageReached", 0)
+    val showFeedback = toolCode
+        .switchMap { settings.isFeatureDiscoveredLiveData(FEATURE_LESSON_FEEDBACK + it) }
+        .combineWith(pageReached) { discovered, page -> !discovered && page > 3 }
+        .distinctUntilChanged()
 }

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -169,7 +169,6 @@ class LessonActivity :
     // region Feedback
     private fun setupFeedbackDialog() {
         supportFragmentManager.setFragmentResultListener(LessonFeedbackDialogFragment.RESULT_DISMISSED, this) { _, _ ->
-            settings.setFeatureDiscovered(FEATURE_LESSON_FEEDBACK + tool)
             finish()
         }
         onBackPressedDispatcher.addCallback(

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
@@ -3,29 +3,52 @@ package org.cru.godtools.tool.lesson.ui.feedback
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
+import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.DataBindingDialogFragment
 import org.cru.godtools.tool.lesson.R
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.PARAM_HELPFUL
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.PARAM_PAGE_REACHED
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.PARAM_READINESS
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.VALUE_HELPFUL_NO
+import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.VALUE_HELPFUL_YES
 import org.cru.godtools.tool.lesson.databinding.LessonFeedbackDialogBinding
+import org.greenrobot.eventbus.EventBus
+import splitties.fragmentargs.arg
 
 @AndroidEntryPoint
-class LessonFeedbackDialogFragment :
+class LessonFeedbackDialogFragment() :
     DataBindingDialogFragment<LessonFeedbackDialogBinding>(R.layout.lesson_feedback_dialog) {
     companion object {
         const val RESULT_DISMISSED = "org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackDialogFragment_DISMISSED"
     }
 
+    constructor(lesson: String, locale: Locale, pageReached: Int) : this() {
+        this.lesson = lesson
+        this.locale = locale
+        this.pageReached = pageReached
+    }
+
+    private var lesson: String by arg()
+    private var locale: Locale by arg()
+    private var pageReached: Int by arg()
+
+    @Inject
+    internal lateinit var eventBus: EventBus
     private val viewModel by viewModels<LessonFeedbackViewModel>()
 
     // region Lifecycle
     override fun onCreateDialog(savedInstanceState: Bundle?) = MaterialAlertDialogBuilder(requireContext())
         .setTitle(R.string.lesson_feedback_title)
-        .setPositiveButton(R.string.lesson_feedback_action_submit, null)
+        .setPositiveButton(R.string.lesson_feedback_action_submit) { _, _ -> sendFeedback() }
         .setNegativeButton(R.string.lesson_feedback_action_cancel, null)
         .create()
 
@@ -38,9 +61,22 @@ class LessonFeedbackDialogFragment :
         setFragmentResult(RESULT_DISMISSED, Bundle.EMPTY)
     }
     // endregion Lifecycle
+
+    private fun sendFeedback() {
+        val args = bundleOf(
+            PARAM_PAGE_REACHED to pageReached,
+            PARAM_HELPFUL to when (viewModel.helpful.value) {
+                R.id.yes -> VALUE_HELPFUL_YES
+                R.id.no -> VALUE_HELPFUL_NO
+                else -> null
+            },
+            PARAM_READINESS to viewModel.readiness.value?.toInt()
+        )
+        eventBus.post(LessonFeedbackAnalyticsEvent(lesson, locale, args))
+    }
 }
 
-class LessonFeedbackViewModel(private val savedState: SavedStateHandle) : ViewModel() {
+class LessonFeedbackViewModel(savedState: SavedStateHandle) : ViewModel() {
     val helpful = savedState.getLiveData("helpful", View.NO_ID)
     val readiness = savedState.getLiveData("readiness", 1f)
 }

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.DataBindingDialogFragment
+import org.cru.godtools.base.Settings
 import org.cru.godtools.tool.lesson.R
 import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent
 import org.cru.godtools.tool.lesson.analytics.model.LessonFeedbackAnalyticsEvent.Companion.PARAM_HELPFUL
@@ -43,6 +44,8 @@ class LessonFeedbackDialogFragment() :
 
     @Inject
     internal lateinit var eventBus: EventBus
+    @Inject
+    internal lateinit var settings: Settings
     private val viewModel by viewModels<LessonFeedbackViewModel>()
 
     // region Lifecycle
@@ -58,6 +61,7 @@ class LessonFeedbackDialogFragment() :
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
+        settings.setFeatureDiscovered(Settings.FEATURE_LESSON_FEEDBACK + lesson)
         setFragmentResult(RESULT_DISMISSED, Bundle.EMPTY)
     }
     // endregion Lifecycle

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogFragment.kt
@@ -1,0 +1,46 @@
+package org.cru.godtools.tool.lesson.ui.feedback
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dagger.hilt.android.AndroidEntryPoint
+import org.ccci.gto.android.common.androidx.fragment.app.DataBindingDialogFragment
+import org.cru.godtools.tool.lesson.R
+import org.cru.godtools.tool.lesson.databinding.LessonFeedbackDialogBinding
+
+@AndroidEntryPoint
+class LessonFeedbackDialogFragment :
+    DataBindingDialogFragment<LessonFeedbackDialogBinding>(R.layout.lesson_feedback_dialog) {
+    companion object {
+        const val RESULT_DISMISSED = "org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackDialogFragment_DISMISSED"
+    }
+
+    private val viewModel by viewModels<LessonFeedbackViewModel>()
+
+    // region Lifecycle
+    override fun onCreateDialog(savedInstanceState: Bundle?) = MaterialAlertDialogBuilder(requireContext())
+        .setTitle(R.string.lesson_feedback_title)
+        .setPositiveButton(R.string.lesson_feedback_action_submit, null)
+        .setNegativeButton(R.string.lesson_feedback_action_cancel, null)
+        .create()
+
+    override fun onBindingCreated(binding: LessonFeedbackDialogBinding) {
+        binding.viewModel = viewModel
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        setFragmentResult(RESULT_DISMISSED, Bundle.EMPTY)
+    }
+    // endregion Lifecycle
+}
+
+class LessonFeedbackViewModel(private val savedState: SavedStateHandle) : ViewModel() {
+    val helpful = savedState.getLiveData("helpful", View.NO_ID)
+    val readiness = savedState.getLiveData("readiness", 1f)
+}

--- a/ui/lesson-renderer/src/main/res/layout/lesson_feedback_dialog.xml
+++ b/ui/lesson-renderer/src/main/res/layout/lesson_feedback_dialog.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable name="viewModel" type="org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackViewModel" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="?attr/dialogPreferredPadding"
+        android:paddingRight="?attr/dialogPreferredPadding">
+
+        <TextView
+            style="?attr/materialAlertDialogBodyTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/lesson_feedback_question_helpful" />
+
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/toggleButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            app:checkedButtonId="@={viewModel.helpful}"
+            app:singleSelection="true">
+
+            <Button
+                android:id="@+id/yes"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/lesson_feedback_question_helpful_yes" />
+
+            <Button
+                android:id="@+id/no"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/lesson_feedback_question_helpful_no" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+
+        <TextView
+            style="?attr/materialAlertDialogBodyTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/lesson_feedback_question_readiness" />
+
+        <com.google.android.material.slider.Slider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stepSize="1"
+            android:valueFrom="1"
+            android:valueTo="10"
+            app:tickVisible="false"
+            app:value="@={viewModel.readiness}" />
+    </LinearLayout>
+</layout>

--- a/ui/lesson-renderer/src/main/res/layout/lesson_feedback_dialog.xml
+++ b/ui/lesson-renderer/src/main/res/layout/lesson_feedback_dialog.xml
@@ -17,6 +17,7 @@
             style="?attr/materialAlertDialogBodyTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
             android:text="@string/lesson_feedback_question_helpful" />
 
         <com.google.android.material.button.MaterialButtonToggleGroup
@@ -48,6 +49,7 @@
             style="?attr/materialAlertDialogBodyTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
             android:text="@string/lesson_feedback_question_readiness" />
 
         <com.google.android.material.slider.Slider

--- a/ui/lesson-renderer/src/main/res/values/strings_lesson_feedback.xml
+++ b/ui/lesson-renderer/src/main/res/values/strings_lesson_feedback.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="lesson_feedback_title">Review</string>
+    <string name="lesson_feedback_question_helpful">Was this lesson helpful for you?</string>
+    <string name="lesson_feedback_question_helpful_yes">Yes</string>
+    <string name="lesson_feedback_question_helpful_no">No</string>
+    <string name="lesson_feedback_question_readiness">On a scale of 1-10 ready do you feel to share your faith?</string>
+    <string name="lesson_feedback_action_submit">Send feedback</string>
+    <string name="lesson_feedback_action_cancel">Skip</string>
+</resources>


### PR DESCRIPTION
- create a lesson feedback dialog fragment
- submit the lesson feedback via an AnalyticsEvent
- track lesson feedback using the feature discovery subsystem
- make it possible to override the checkForManifestEvent behavior
- show the lesson feedback dialog fragment when finishing a lesson
- mark the lesson feedback as discovered when dismissing the dialog
