### PR TITLE
GT-1306 Remove unnecessary onUpdateActiveManifest() lifecycle event

### DIFF
--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -34,12 +34,7 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
         processIntent(intent)
 
         // finish now if this activity is in an invalid state
-        if (!validStartState()) {
-            finish()
-            return
-        }
-
-        startLoaders()
+        if (!validStartState()) finish()
     }
     // endregion Lifecycle
 
@@ -86,10 +81,6 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
     }
 
     private fun validStartState() = !requireTool || hasTool()
-
-    private fun startLoaders() {
-        dataModel.manifest.observe(this) { onUpdateActiveManifest() }
-    }
 
     // region Up Navigation
     override fun buildParentIntentExtras(): Bundle {

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -102,9 +102,6 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         }
         else -> super.onOptionsItemSelected(item)
     }
-
-    @CallSuper
-    protected open fun onUpdateActiveManifest() = Unit
     // endregion Lifecycle
 
     /**

--- a/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/java/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -62,6 +62,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         super.onCreate(savedInstanceState)
         isConnected.observe(this) { if (it) syncTools() }
         setupStatusBar()
+        setupFeatureDiscovery()
         eventBus.register(this, this)
     }
 
@@ -265,6 +266,10 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
 
     // region Feature Discovery
     private var featureDiscovery: TapTargetView? = null
+
+    private fun setupFeatureDiscovery() {
+        shareMenuItemVisible.observe(this) { showNextFeatureDiscovery() }
+    }
 
     override fun showNextFeatureDiscovery() {
         if (!settings.isFeatureDiscovered(FEATURE_TOOL_SHARE) && canShowFeatureDiscovery(FEATURE_TOOL_SHARE)) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -162,12 +162,6 @@ class TractActivity :
 
     override fun onDismissTip() = trackTractPage()
 
-    @CallSuper
-    override fun onUpdateActiveManifest() {
-        super.onUpdateActiveManifest()
-        showNextFeatureDiscovery()
-    }
-
     override fun onContentEvent(event: Event) {
         checkForPageEvent(event)
         propagateEventToPage(event)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -100,7 +100,6 @@ class TractActivity :
         // track this view
         if (savedInstanceState == null) dataModel.tool.value?.let { trackToolOpen(it) }
 
-        setupDataModel()
         setupActiveTranslationManagement()
         attachLiveSharePublishExitBehavior()
         startLiveShareSubscriberIfNecessary(savedInstanceState)
@@ -238,9 +237,6 @@ class TractActivity :
     // region Data Model
     private val dataModel: TractActivityDataModel by viewModels()
     private val toolState: ToolStateHolder by viewModels()
-    private fun setupDataModel() {
-        dataModel.activeManifest.observe(this) { onUpdateActiveManifest() }
-    }
     // endregion Data Model
 
     // region UI


### PR DESCRIPTION
The last thing we were using `onUpdateActiveManifest()` for was to trigger feature discovery for the share menu. This refactors the logic to more directly monitor share menu visibility to trigger feature discovery.