### PR TITLE
GT-1317 Fix AppsFlyer deep links when GodTools is already running

### DIFF
--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -25,6 +25,7 @@ android {
 
 dependencies {
     api(project(":library:base"))
+    implementation(project(":ui:base"))
 
     implementation(libs.kotlin.coroutines)
 

--- a/library/analytics/src/debug/AndroidManifest.xml
+++ b/library/analytics/src/debug/AndroidManifest.xml
@@ -1,12 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    package="org.cru.godtools.analytics">
 
     <application>
-        <!--suppress AndroidDomInspection -->
+        <!-- region AppsFlyer -->
         <activity
-            android:name="org.keynote.godtools.android.activity.MainActivity"
-            android:exported="true"
-            tools:ignore="MissingClass">
+            android:name=".appsflyer.AppsFlyerSpringboardActivity"
+            android:exported="true">
             <!-- AppsFlyer deep links -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -21,8 +20,9 @@
                 <!-- debug -->
                 <data android:pathPrefix="/lmlj" />
                 <!-- QA -->
-                <data android:pathPrefix="/07Ip" />
+                <data android:pathPrefix="/Ftl4" />
             </intent-filter>
         </activity>
+        <!-- endregion AppsFlyer -->
     </application>
 </manifest>

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerSpringboardActivity.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/appsflyer/AppsFlyerSpringboardActivity.kt
@@ -1,0 +1,13 @@
+package org.cru.godtools.analytics.appsflyer
+
+import android.app.Activity
+import android.os.Bundle
+import org.cru.godtools.base.ui.startDashboardActivity
+
+class AppsFlyerSpringboardActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startDashboardActivity()
+        finish()
+    }
+}

--- a/library/analytics/src/release/AndroidManifest.xml
+++ b/library/analytics/src/release/AndroidManifest.xml
@@ -1,13 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    package="org.cru.godtools.analytics">
 
     <application>
-        <!--suppress AndroidDomInspection -->
+        <!-- region AppsFlyer -->
         <activity
-            android:name="org.keynote.godtools.android.activity.MainActivity"
-            android:exported="true"
-            tools:ignore="MissingClass">
-            <!-- AppsFlyer deep links -->
+            android:name=".appsflyer.AppsFlyerSpringboardActivity"
+            android:exported="true">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
@@ -21,5 +19,6 @@
                 <data android:pathPrefix="/07Ip" />
             </intent-filter>
         </activity>
+        <!-- endregion AppsFlyer -->
     </application>
 </manifest>

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    api(project(":library:analytics"))
     api(project(":library:db"))
     api(project(":library:download-manager"))
     api(project(":library:sync"))

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 dependencies {
-    api(project(":library:analytics"))
+    api(project(":library:base"))
     implementation(project(":library:model"))
 
     api(libs.androidx.appcompat)

--- a/ui/tutorial-renderer/build.gradle.kts
+++ b/ui/tutorial-renderer/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":library:analytics"))
     implementation(project(":library:base"))
     implementation(project(":ui:base"))
 


### PR DESCRIPTION
AppsFlyer deep links are not being captured by MainActivity when we use the `singleTask` launch mode. This PR introduces an intermediary SpringBoard activity that will handle appsflyer deep links and not be affected by the MainActivity launch mode.