### PR TITLE
GT-1363 Separate Dispatcher logic from ShortcutManager

### DIFF
--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -110,30 +110,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     // region Events
     @AnyThread
     @Subscribe
-    fun onToolUpdate(event: ToolUpdateEvent) {
-        // Could change which tools are visible or the label for tools
-        updateShortcutsActor.trySend(Unit)
-        updatePendingShortcutsActor.trySend(Unit)
-    }
-
-    @AnyThread
-    @Subscribe
-    fun onAttachmentUpdate(event: AttachmentUpdateEvent) {
-        // Handles potential icon image changes.
-        updateShortcutsActor.trySend(Unit)
-        updatePendingShortcutsActor.trySend(Unit)
-    }
-
-    @AnyThread
-    @Subscribe
-    fun onTranslationUpdate(event: TranslationUpdateEvent) {
-        // Could change which tools are available or the label for tools
-        updateShortcutsActor.trySend(Unit)
-        updatePendingShortcutsActor.trySend(Unit)
-    }
-
-    @AnyThread
-    @Subscribe
     fun onToolUsed(event: ToolUsedEvent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             shortcutManager?.reportShortcutUsed(event.toolCode.toolShortcutId)
@@ -340,6 +316,43 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
             .setLongLabel(label)
             .setIcon(icon)
             .build()
+    }
+
+    @Singleton
+    class Dispatcher @Inject constructor(
+        eventBus: EventBus,
+        private val shortcutManager: GodToolsShortcutManager
+    ) {
+        // region Events
+        init {
+            // register event listeners
+            eventBus.register(this)
+        }
+
+        @AnyThread
+        @Subscribe
+        fun onToolUpdate(event: ToolUpdateEvent) {
+            // Could change which tools are visible or the label for tools
+            shortcutManager.updateShortcutsActor.trySend(Unit)
+            shortcutManager.updatePendingShortcutsActor.trySend(Unit)
+        }
+
+        @AnyThread
+        @Subscribe
+        fun onAttachmentUpdate(event: AttachmentUpdateEvent) {
+            // Handles potential icon image changes.
+            shortcutManager.updateShortcutsActor.trySend(Unit)
+            shortcutManager.updatePendingShortcutsActor.trySend(Unit)
+        }
+
+        @AnyThread
+        @Subscribe
+        fun onTranslationUpdate(event: TranslationUpdateEvent) {
+            // Could change which tools are available or the label for tools
+            shortcutManager.updateShortcutsActor.trySend(Unit)
+            shortcutManager.updatePendingShortcutsActor.trySend(Unit)
+        }
+        // endregion Events
     }
 }
 

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/ShortcutModule.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/ShortcutModule.kt
@@ -16,7 +16,7 @@ abstract class ShortcutModule {
     @Binds
     @IntoSet
     @EagerSingleton(threadMode = EagerSingleton.ThreadMode.ASYNC)
-    abstract fun shortcutManagerEagerSingleton(shortcutManager: GodToolsShortcutManager): Any
+    abstract fun shortcutManagerEagerSingleton(dispatcher: GodToolsShortcutManager.Dispatcher): Any
 
     companion object {
         @IntoSet

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -1,0 +1,74 @@
+package org.cru.godtools.shortcuts
+
+import java.util.Locale
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.cru.godtools.base.Settings
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GodToolsShortcutManagerDispatcherTest {
+    private lateinit var settings: Settings
+    private lateinit var shortcutManager: GodToolsShortcutManager
+    private val coroutineScope = TestCoroutineScope(SupervisorJob()).apply { pauseDispatcher() }
+
+    private val primaryLanguageFlow = MutableSharedFlow<Locale>(extraBufferCapacity = 20)
+    private val parallelLanguageFlow = MutableSharedFlow<Locale?>(extraBufferCapacity = 20)
+
+    private lateinit var dispatcher: GodToolsShortcutManager.Dispatcher
+
+    @Before
+    fun setup() {
+        shortcutManager = mock()
+        settings = mock {
+            on { primaryLanguageFlow } doReturn primaryLanguageFlow
+            on { parallelLanguageFlow } doReturn parallelLanguageFlow
+        }
+
+        dispatcher = GodToolsShortcutManager.Dispatcher(shortcutManager, mock(), settings, coroutineScope)
+    }
+
+    @After
+    fun cleanup() {
+        dispatcher.shutdown()
+        coroutineScope.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun verifyUpdatePendingToolShortcuts() {
+        // update doesn't trigger before requested
+        coroutineScope.advanceUntilIdle()
+        coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
+        verifyNoInteractions(shortcutManager)
+
+        // trigger update
+        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        verifyNoInteractions(shortcutManager)
+        coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
+        verifyBlocking(shortcutManager) { updatePendingShortcuts() }
+        verifyNoMoreInteractions(shortcutManager)
+        clearInvocations(shortcutManager)
+
+        // trigger multiple updates simultaneously, it should conflate to a single update
+        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        coroutineScope.advanceTimeBy(1)
+        verifyNoInteractions(shortcutManager)
+        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
+        verifyBlocking(shortcutManager) { updatePendingShortcuts() }
+        verifyNoMoreInteractions(shortcutManager)
+        coroutineScope.advanceUntilIdle()
+        verifyNoMoreInteractions(shortcutManager)
+    }
+}

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -25,14 +25,11 @@ import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ToolFileManager
 import org.cru.godtools.model.Tool
 import org.greenrobot.eventbus.EventBus
-import org.hamcrest.Matchers.greaterThanOrEqualTo
-import org.hamcrest.Matchers.lessThan
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,12 +48,14 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Config.NEWEST_SDK
+import org.robolectric.annotation.Config.OLDEST_SDK
 
 private const val ACTION_INSTALL_SHORTCUT = "com.android.launcher.action.INSTALL_SHORTCUT"
 private const val INSTALL_SHORTCUT_PERMISSION = "com.android.launcher.permission.INSTALL_SHORTCUT"
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [24, 25, 28])
+@Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.N, Build.VERSION_CODES.N_MR1, NEWEST_SDK])
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsShortcutManagerTest {
     private lateinit var app: Application
@@ -172,9 +171,8 @@ class GodToolsShortcutManagerTest {
 
     // region Update Existing Shortcuts
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsOnPrimaryLanguageUpdate() {
-        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
-
         whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
         assertUpdateExistingShortcutsInitialUpdate()
 
@@ -186,9 +184,8 @@ class GodToolsShortcutManagerTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsOnParallelLanguageUpdate() {
-        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
-
         whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
         assertUpdateExistingShortcutsInitialUpdate()
 
@@ -200,9 +197,8 @@ class GodToolsShortcutManagerTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsAggregateMultiple() = runBlockingTest {
-        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
-
         whenever(dao.get(Tool::class.java)).thenReturn(emptyList())
         assertUpdateExistingShortcutsInitialUpdate()
 
@@ -222,8 +218,8 @@ class GodToolsShortcutManagerTest {
     }
 
     @Test
+    @Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.N])
     fun verifyUpdateExistingShortcutsNotAvailableForOldSdks() {
-        assumeThat(Build.VERSION.SDK_INT, lessThan(Build.VERSION_CODES.N_MR1))
         coroutineScope.advanceUntilIdle()
         assertTrue(
             "Ensure actor can still accept requests, even though they are no-ops",
@@ -234,9 +230,8 @@ class GodToolsShortcutManagerTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun testUpdateDynamicShortcutsDoesntInterceptChildCancelledException() {
-        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
-
         dao.stub { on { get(any<Query<Tool>>()) } doReturn emptyList() }
         ioDispatcher.pauseDispatcher()
         coroutineScope.resumeDispatcher()
@@ -259,9 +254,8 @@ class GodToolsShortcutManagerTest {
 
     // region Instant App
     @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateDynamicShortcutsOnInstantAppIsANoop() {
-        assumeThat(Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.N_MR1))
-
         // Instant Apps don't have access to the system ShortcutManager
         whenever(app.getSystemService<ShortcutManager>()).thenReturn(null)
         coroutineScope.resumeDispatcher()


### PR DESCRIPTION
This splits some of the ShortcutManager functionality to make it easier to test certain behaviors. This is in preparation for Kotlin Coroutines 1.6.0 which changes how coroutines tests run