### PR TITLE
Rename FileManager to FileSystem

### DIFF
--- a/app/src/main/java/org/cru/godtools/databinding/PicassoImageViewBindingAdapter.kt
+++ b/app/src/main/java/org/cru/godtools/databinding/PicassoImageViewBindingAdapter.kt
@@ -4,11 +4,11 @@ import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import org.ccci.gto.android.common.picasso.view.PicassoImageView
 import org.ccci.gto.android.common.picasso.view.SimplePicassoImageView
-import org.cru.godtools.base.toolFileManager
+import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.model.Attachment
 
 @BindingAdapter("android:src")
 internal fun SimplePicassoImageView.bindAttachment(attachment: Attachment?) = setPicassoAttachment(attachment)
 
 private fun <T> T.setPicassoAttachment(attachment: Attachment?) where T : ImageView, T : PicassoImageView =
-    setPicassoFile(attachment?.takeIf { it.isDownloaded }?.getFileBlocking(context.toolFileManager))
+    setPicassoFile(attachment?.takeIf { it.isDownloaded }?.getFileBlocking(context.toolFileSystem))

--- a/library/base/build.gradle.kts
+++ b/library/base/build.gradle.kts
@@ -3,8 +3,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.kotlin.coroutines)
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.livedata.ktx)
 
@@ -15,7 +13,10 @@ dependencies {
 
     implementation(libs.dagger)
     implementation(libs.hilt)
+    implementation(libs.kotlin.coroutines)
 
     kapt(libs.dagger.compiler)
     kapt(libs.hilt.compiler)
+
+    testImplementation(libs.kotlin.coroutines.test)
 }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileManager.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileManager.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.base
 
 import android.content.Context
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.InputStream
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,7 +10,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-abstract class FileManager(protected val context: Context, private val dirName: String) {
+open class FileManager(context: Context, dirName: String) {
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private val dirTask = coroutineScope.async { File(context.filesDir, dirName) }
@@ -24,7 +23,6 @@ abstract class FileManager(protected val context: Context, private val dirName: 
         withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }
     suspend fun getFile(filename: String) = File(dirTask.await(), filename)
 
-    @Throws(FileNotFoundException::class)
     suspend fun getInputStream(filename: String): InputStream =
         withContext(Dispatchers.IO) { getFile(filename).inputStream() }
 

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-open class FileManager(context: Context, dirName: String) {
+open class FileSystem(context: Context, dirName: String) {
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private val dirTask = coroutineScope.async { File(context.filesDir, dirName) }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -16,7 +16,7 @@ open class FileSystem(context: Context, dirName: String) {
     private val dirTask = coroutineScope.async { File(context.filesDir, dirName) }
     private val dirCreated = coroutineScope.async { dirTask.await().run { (exists() || mkdirs()) && isDirectory } }
 
-    suspend fun createDir() = dirCreated.await()
+    suspend fun exists() = dirCreated.await()
     suspend fun getDir() = dirTask.await()
 
     suspend fun createTmpFile(prefix: String, suffix: String? = null): File =

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -21,10 +21,10 @@ open class FileSystem(context: Context, dirName: String) {
 
     suspend fun createTmpFile(prefix: String, suffix: String? = null): File =
         withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }
-    suspend fun getFile(filename: String) = File(dirTask.await(), filename)
+    suspend fun file(filename: String) = File(dirTask.await(), filename)
 
     suspend fun getInputStream(filename: String): InputStream =
-        withContext(Dispatchers.IO) { getFile(filename).inputStream() }
+        withContext(Dispatchers.IO) { file(filename).inputStream() }
 
     private val dir by lazy { runBlocking { dirTask.await() } }
     fun getFileBlocking(filename: String) = File(dir, filename)

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -23,7 +23,7 @@ open class FileSystem(context: Context, dirName: String) {
         withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }
     suspend fun file(filename: String) = File(dirTask.await(), filename)
 
-    suspend fun getInputStream(filename: String): InputStream =
+    suspend fun openInputStream(filename: String): InputStream =
         withContext(Dispatchers.IO) { file(filename).inputStream() }
 
     private val dir by lazy { runBlocking { dirTask.await() } }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -17,7 +17,7 @@ open class FileSystem(context: Context, dirName: String) {
     private val dirCreated = coroutineScope.async { dirTask.await().run { (exists() || mkdirs()) && isDirectory } }
 
     suspend fun exists() = dirCreated.await()
-    suspend fun getDir() = dirTask.await()
+    suspend fun rootDir() = dirTask.await()
 
     suspend fun createTmpFile(prefix: String, suffix: String? = null): File =
         withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/ToolFileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/ToolFileSystem.kt
@@ -10,14 +10,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ToolFileManager @Inject internal constructor(@ApplicationContext context: Context) :
-    FileManager(context, "resources") {
+class ToolFileSystem @Inject internal constructor(@ApplicationContext context: Context) :
+    FileSystem(context, "resources") {
     @EntryPoint
     @InstallIn(SingletonComponent::class)
     internal interface Provider {
-        val fileManager: ToolFileManager
+        val fileSystem: ToolFileSystem
     }
 }
 
-val Context.toolFileManager
-    get() = EntryPoints.get(applicationContext, ToolFileManager.Provider::class.java).fileManager
+val Context.toolFileSystem
+    get() = EntryPoints.get(applicationContext, ToolFileSystem.Provider::class.java).fileSystem

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileManagerTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileManagerTest.kt
@@ -21,7 +21,7 @@ class FileManagerTest {
         context = mock {
             on { filesDir } doReturn rootDir
         }
-        fileManager = object : FileManager(context, "resources") {}
+        fileManager = FileManager(context, "resources")
     }
 
     @Test

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.base
 
 import android.content.Context
 import java.io.File
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -10,25 +10,23 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-class FileManagerTest {
+class FileSystemTest {
     private lateinit var context: Context
     private val rootDir = File.createTempFile("abc", null).parentFile!!
 
-    private lateinit var fileManager: FileManager
+    private lateinit var fileSystem: FileSystem
 
     @Before
     fun setup() {
         context = mock {
             on { filesDir } doReturn rootDir
         }
-        fileManager = FileManager(context, "resources")
+        fileSystem = FileSystem(context, "resources")
     }
 
     @Test
-    fun testCreateDir() {
-        runBlocking {
-            assertTrue(fileManager.createDir())
-            assertEquals(File(rootDir, "resources"), fileManager.getDir())
-        }
+    fun testCreateDir() = runBlockingTest {
+        assertTrue(fileSystem.createDir())
+        assertEquals(File(rootDir, "resources"), fileSystem.getDir())
     }
 }

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
@@ -25,8 +25,8 @@ class FileSystemTest {
     }
 
     @Test
-    fun testCreateDir() = runBlockingTest {
-        assertTrue(fileSystem.createDir())
+    fun testExists() = runBlockingTest {
+        assertTrue(fileSystem.exists())
         assertEquals(File(rootDir, "resources"), fileSystem.getDir())
     }
 }

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
@@ -27,6 +27,6 @@ class FileSystemTest {
     @Test
     fun testExists() = runBlockingTest {
         assertTrue(fileSystem.exists())
-        assertEquals(File(rootDir, "resources"), fileSystem.getDir())
+        assertEquals(File(rootDir, "resources"), fileSystem.rootDir())
     }
 }

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -43,7 +43,7 @@ import org.ccci.gto.android.common.kotlin.coroutines.withLock
 import org.cru.godtools.api.AttachmentsApi
 import org.cru.godtools.api.TranslationsApi
 import org.cru.godtools.base.Settings
-import org.cru.godtools.base.ToolFileManager
+import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.LocalFile
@@ -101,7 +101,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     private val attachmentsApi: AttachmentsApi,
     private val dao: GodToolsDao,
     private val eventBus: EventBus,
-    private val fileManager: ToolFileManager,
+    private val fs: ToolFileSystem,
     private val settings: Settings,
     private val translationsApi: TranslationsApi,
     private val coroutineScope: CoroutineScope,
@@ -112,14 +112,14 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
         attachmentsApi: AttachmentsApi,
         dao: GodToolsDao,
         eventBus: EventBus,
-        fileManager: ToolFileManager,
+        fs: ToolFileSystem,
         settings: Settings,
         translationsApi: TranslationsApi
     ) : this(
         attachmentsApi,
         dao,
         eventBus,
-        fileManager,
+        fs,
         settings,
         translationsApi,
         CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -217,7 +217,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun downloadAttachment(attachmentId: Long) {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
 
         attachmentsMutex.withLock(attachmentId) {
             val attachment: Attachment = dao.find(attachmentId) ?: return
@@ -252,7 +252,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     }
 
     suspend fun importAttachment(attachmentId: Long, data: InputStream) {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
 
         attachmentsMutex.withLock(attachmentId) {
             val attachment: Attachment = dao.find(attachmentId) ?: return
@@ -302,7 +302,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun downloadLatestPublishedTranslation(key: TranslationKey) {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
 
         translationsMutex.withLock(key) {
             dao.getLatestTranslation(key.tool, key.locale, true)?.takeUnless { it.isDownloaded }?.let { trans ->
@@ -321,7 +321,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     }
 
     suspend fun importTranslation(translation: Translation, zipStream: InputStream, size: Long) {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
 
         val key = TranslationKey(translation)
         translationsMutex.withLock(TranslationKey(translation)) {
@@ -412,16 +412,16 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun detectMissingFiles() {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
 
         filesystemMutex.write.withLock {
             withContext(ioDispatcher) {
                 // get the set of all downloaded files
-                val files = fileManager.getDir().listFiles()?.filterTo(mutableSetOf()) { it.isFile }.orEmpty()
+                val files = fs.getDir().listFiles()?.filterTo(mutableSetOf()) { it.isFile }.orEmpty()
 
                 // check for missing files
                 Query.select<LocalFile>().get(dao)
-                    .filterNot { files.contains(it.getFile(fileManager)) }
+                    .filterNot { files.contains(it.getFile(fs)) }
                     .forEach { dao.delete(it) }
             }
         }
@@ -429,7 +429,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun cleanFilesystem() {
-        if (!fileManager.createDir()) return
+        if (!fs.createDir()) return
         filesystemMutex.write.withLock {
             withContext(ioDispatcher) {
                 // remove any TranslationFiles for translations that are no longer downloaded
@@ -452,11 +452,11 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
                     .get(dao)
                     .forEach {
                         dao.delete(it)
-                        it.getFile(fileManager).delete()
+                        it.getFile(fs).delete()
                     }
 
                 // delete any orphaned files
-                fileManager.getDir().listFiles()
+                fs.getDir().listFiles()
                     ?.filter { dao.find<LocalFile>(it.name) == null }
                     ?.forEach { it.delete() }
             }
@@ -480,6 +480,6 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @WorkerThread
     private suspend fun InputStream.copyTo(localFile: LocalFile) {
-        withContext(Dispatchers.IO) { localFile.getFile(fileManager).outputStream().use { copyTo(it) } }
+        withContext(Dispatchers.IO) { localFile.getFile(fs).outputStream().use { copyTo(it) } }
     }
 }

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -217,7 +217,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun downloadAttachment(attachmentId: Long) {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         attachmentsMutex.withLock(attachmentId) {
             val attachment: Attachment = dao.find(attachmentId) ?: return
@@ -252,7 +252,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     }
 
     suspend fun importAttachment(attachmentId: Long, data: InputStream) {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         attachmentsMutex.withLock(attachmentId) {
             val attachment: Attachment = dao.find(attachmentId) ?: return
@@ -302,7 +302,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun downloadLatestPublishedTranslation(key: TranslationKey) {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         translationsMutex.withLock(key) {
             dao.getLatestTranslation(key.tool, key.locale, true)?.takeUnless { it.isDownloaded }?.let { trans ->
@@ -321,7 +321,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     }
 
     suspend fun importTranslation(translation: Translation, zipStream: InputStream, size: Long) {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         val key = TranslationKey(translation)
         translationsMutex.withLock(TranslationKey(translation)) {
@@ -412,7 +412,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun detectMissingFiles() {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         filesystemMutex.write.withLock {
             withContext(ioDispatcher) {
@@ -429,7 +429,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun cleanFilesystem() {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
         filesystemMutex.write.withLock {
             withContext(ioDispatcher) {
                 // remove any TranslationFiles for translations that are no longer downloaded

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -417,7 +417,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
         filesystemMutex.write.withLock {
             withContext(ioDispatcher) {
                 // get the set of all downloaded files
-                val files = fs.getDir().listFiles()?.filterTo(mutableSetOf()) { it.isFile }.orEmpty()
+                val files = fs.rootDir().listFiles()?.filterTo(mutableSetOf()) { it.isFile }.orEmpty()
 
                 // check for missing files
                 Query.select<LocalFile>().get(dao)
@@ -456,7 +456,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
                     }
 
                 // delete any orphaned files
-                fs.getDir().listFiles()
+                fs.rootDir().listFiles()
                     ?.filter { dao.find<LocalFile>(it.name) == null }
                     ?.forEach { it.delete() }
             }

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -108,7 +108,7 @@ class GodToolsDownloadManagerTest {
         }
         eventBus = mock()
         fs = mock {
-            onBlocking { getDir() } doReturn resourcesDir
+            onBlocking { rootDir() } doReturn resourcesDir
             onBlocking { exists() } doReturn true
         }
         observer = mock()
@@ -567,14 +567,14 @@ class GodToolsDownloadManagerTest {
     private fun assertCleanupActorRan(times: Int = 1) {
         inOrder(dao, fs) {
             repeat(times) {
-                runBlocking { verify(fs).getDir() }
+                runBlocking { verify(fs).rootDir() }
                 verify(dao).get(argThat<Query<*>> { table.type == LocalFile::class.java })
                 verify(dao).get(argThat<Query<*>> { table.type == TranslationFile::class.java })
                 verify(dao).get(argThat<Query<*>> { table.type == LocalFile::class.java })
-                runBlocking { verify(fs).getDir() }
+                runBlocking { verify(fs).rootDir() }
             }
             verify(dao, never()).get(any<Query<*>>())
-            runBlocking { verify(fs, never()).getDir() }
+            runBlocking { verify(fs, never()).rootDir() }
         }
     }
 
@@ -584,7 +584,7 @@ class GodToolsDownloadManagerTest {
         val missingFile = getTmpFile()
         whenever(dao.get(any<Query<LocalFile>>())).thenReturn(listOf(LocalFile(file.name), LocalFile(missingFile.name)))
         fs.stub {
-            onBlocking { getDir() } doReturn file.parentFile!!
+            onBlocking { rootDir() } doReturn file.parentFile!!
             onBlocking { getFile(any()) } doAnswer { File(file.parentFile, it.getArgument(0)) }
         }
 

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -389,7 +389,7 @@ class GodToolsDownloadManagerTest {
         verify(dao, never()).updateOrInsert(any())
         verify(dao, never()).update(any(), anyVararg<String>())
         verify(eventBus, never()).post(any())
-        verifyBlocking(fs, never()) { getFile(any()) }
+        verifyBlocking(fs, never()) { file(any()) }
         assertTrue(attachment.isDownloaded)
     }
 
@@ -405,7 +405,7 @@ class GodToolsDownloadManagerTest {
         runBlocking { testData.inputStream().use { downloadManager.importAttachment(attachment.id, it) } }
         verify(dao).update(attachment, AttachmentTable.COLUMN_DOWNLOADED)
         verify(eventBus).post(AttachmentUpdateEvent)
-        verifyBlocking(fs, never()) { getFile(any()) }
+        verifyBlocking(fs, never()) { file(any()) }
         verify(dao, never()).updateOrInsert(any())
         assertTrue(attachment.isDownloaded)
     }
@@ -429,9 +429,9 @@ class GodToolsDownloadManagerTest {
             on { getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true) } doReturn translation
         }
         fs.stub {
-            onBlocking { getFile("a.txt") } doReturn files[0]
-            onBlocking { getFile("b.txt") } doReturn files[1]
-            onBlocking { getFile("c.txt") } doReturn files[2]
+            onBlocking { file("a.txt") } doReturn files[0]
+            onBlocking { file("b.txt") } doReturn files[1]
+            onBlocking { file("c.txt") } doReturn files[2]
         }
         val response: ResponseBody = mock { on { byteStream() } doReturn getInputStreamForResource("abc.zip") }
         translationsApi.stub {
@@ -464,9 +464,9 @@ class GodToolsDownloadManagerTest {
         val files = Array(3) { getTmpFile() }
         downloadManager.getDownloadProgressLiveData(TOOL, Locale.FRENCH).observeForever(observer)
         fs.stub {
-            onBlocking { getFile("a.txt") } doReturn files[0]
-            onBlocking { getFile("b.txt") } doReturn files[1]
-            onBlocking { getFile("c.txt") } doReturn files[2]
+            onBlocking { file("a.txt") } doReturn files[0]
+            onBlocking { file("b.txt") } doReturn files[1]
+            onBlocking { file("c.txt") } doReturn files[2]
         }
 
         runBlocking { downloadManager.importTranslation(translation, getInputStreamForResource("abc.zip"), -1) }
@@ -585,7 +585,7 @@ class GodToolsDownloadManagerTest {
         whenever(dao.get(any<Query<LocalFile>>())).thenReturn(listOf(LocalFile(file.name), LocalFile(missingFile.name)))
         fs.stub {
             onBlocking { rootDir() } doReturn file.parentFile!!
-            onBlocking { getFile(any()) } doAnswer { File(file.parentFile, it.getArgument(0)) }
+            onBlocking { file(any()) } doAnswer { File(file.parentFile, it.getArgument(0)) }
         }
 
         runBlocking { downloadManager.detectMissingFiles() }
@@ -606,8 +606,8 @@ class GodToolsDownloadManagerTest {
             on { find<LocalFile>(keep.name) } doReturn keepLocalFile
         }
         fs.stub {
-            onBlocking { getFile(keep.name) } doReturn keep
-            onBlocking { getFile(orphan.name) } doReturn orphan
+            onBlocking { file(keep.name) } doReturn keep
+            onBlocking { file(orphan.name) } doReturn orphan
         }
 
         assertThat(resourcesDir.listFiles()!!.toSet(), hasItem(orphan))

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -109,7 +109,7 @@ class GodToolsDownloadManagerTest {
         eventBus = mock()
         fs = mock {
             onBlocking { getDir() } doReturn resourcesDir
-            onBlocking { createDir() } doReturn true
+            onBlocking { exists() } doReturn true
         }
         observer = mock()
         settings = mock()
@@ -365,7 +365,7 @@ class GodToolsDownloadManagerTest {
     fun verifyImportAttachmentUnableToCreateResourcesDir() {
         whenever(dao.find<Attachment>(attachment.id)).thenReturn(attachment)
         fs.stub {
-            onBlocking { createDir() } doReturn false
+            onBlocking { exists() } doReturn false
             onBlocking { attachment.getFile(this) } doReturn file
         }
 

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Attachment.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Attachment.kt
@@ -32,6 +32,6 @@ class Attachment : Base() {
             "$sha256.$extension"
         }
 
-    suspend fun getFile(fs: FileSystem) = localFilename?.let { fs.getFile(it) }
+    suspend fun getFile(fs: FileSystem) = localFilename?.let { fs.file(it) }
     fun getFileBlocking(fs: FileSystem) = localFilename?.let { fs.getFileBlocking(it) }
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Attachment.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Attachment.kt
@@ -3,7 +3,7 @@ package org.cru.godtools.model
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
-import org.cru.godtools.base.FileManager
+import org.cru.godtools.base.FileSystem
 
 private const val JSON_API_TYPE = "attachment"
 private const val JSON_RESOURCE = "resource"
@@ -32,6 +32,6 @@ class Attachment : Base() {
             "$sha256.$extension"
         }
 
-    suspend fun getFile(manager: FileManager) = localFilename?.let { manager.getFile(it) }
-    fun getFileBlocking(manager: FileManager) = localFilename?.let { manager.getFileBlocking(it) }
+    suspend fun getFile(fs: FileSystem) = localFilename?.let { fs.getFile(it) }
+    fun getFileBlocking(fs: FileSystem) = localFilename?.let { fs.getFileBlocking(it) }
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/LocalFile.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/LocalFile.kt
@@ -3,5 +3,5 @@ package org.cru.godtools.model
 import org.cru.godtools.base.FileSystem
 
 data class LocalFile(val filename: String) {
-    suspend fun getFile(fs: FileSystem) = fs.getFile(filename)
+    suspend fun getFile(fs: FileSystem) = fs.file(filename)
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/LocalFile.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/LocalFile.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.model
 
-import org.cru.godtools.base.FileManager
+import org.cru.godtools.base.FileSystem
 
 data class LocalFile(val filename: String) {
-    suspend fun getFile(fileManager: FileManager) = fileManager.getFile(filename)
+    suspend fun getFile(fs: FileSystem) = fs.getFile(filename)
 }

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
@@ -27,6 +27,6 @@ class Resource(@field:PrimaryKey val uri: Uri) {
         return localFileName == null || dateDownloaded == null
     }
 
-    suspend fun getLocalFile(fs: FileSystem) = localFileName?.let { fs.getFile(it) }
+    suspend fun getLocalFile(fs: FileSystem) = localFileName?.let { fs.file(it) }
     suspend fun getInputStream(fs: FileSystem) = getLocalFile(fs)?.inputStream()
 }

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/model/Resource.kt
@@ -5,7 +5,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.util.Date
 import okhttp3.MediaType
-import org.cru.godtools.base.FileManager
+import org.cru.godtools.base.FileSystem
 
 @Entity(tableName = Resource.TABLE_NAME)
 class Resource(@field:PrimaryKey val uri: Uri) {
@@ -27,6 +27,6 @@ class Resource(@field:PrimaryKey val uri: Uri) {
         return localFileName == null || dateDownloaded == null
     }
 
-    suspend fun getLocalFile(fileManager: FileManager) = localFileName?.let { fileManager.getFile(it) }
-    suspend fun getInputStream(fileManager: FileManager) = getLocalFile(fileManager)?.inputStream()
+    suspend fun getLocalFile(fs: FileSystem) = localFileName?.let { fs.getFile(it) }
+    suspend fun getInputStream(fs: FileSystem) = getLocalFile(fs)?.inputStream()
 }

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -282,7 +282,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
                 .mapNotNullTo(mutableSetOf()) { it.getLocalFile(fs) }
 
             // delete any files not referenced
-            fs.getDir().listFiles()
+            fs.rootDir().listFiles()
                 ?.filterNot { it in valid }
                 ?.forEach { it.delete() }
         }

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -242,7 +242,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
             }
 
             // rename temporary file based on digest
-            val dedup = digest?.let { fs.getFile("${it.digest().toHexString()}.bin") }
+            val dedup = digest?.let { fs.file("${it.digest().toHexString()}.bin") }
             return when {
                 dedup == null -> tmpFile
                 dedup.exists() -> {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -223,7 +223,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
 
     @VisibleForTesting
     internal suspend fun InputStream.writeToDisk(): File? {
-        if (!fs.createDir()) return null
+        if (!fs.exists()) return null
 
         // create a MessageDigest to dedup files
         val digest = try {
@@ -273,7 +273,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
 
     @WorkerThread
     private suspend fun cleanOrphanedFiles() {
-        if (!fs.createDir()) return
+        if (!fs.exists()) return
 
         // lock the filesystem before removing any orphaned files
         filesystemMutex.write.withLock {

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.runBlocking
 import org.cru.godtools.article.aem.db.ResourceDao
 import org.cru.godtools.article.aem.model.Resource
 import org.cru.godtools.article.aem.service.AemArticleManager
-import org.cru.godtools.article.aem.util.AemFileManager
+import org.cru.godtools.article.aem.util.AemFileSystem
 import org.cru.godtools.base.ui.util.openUrl
 import timber.log.Timber
 
@@ -24,7 +24,7 @@ private const val TAG = "ArticleWebViewClient"
 
 internal class ArticleWebViewClient @Inject constructor(
     private val aemArticleManager: AemArticleManager,
-    private val aemFileManager: AemFileManager,
+    private val fs: AemFileSystem,
     private val resourceDao: ResourceDao
 ) : WebViewClient() {
     var activity: Activity? by weak()
@@ -70,7 +70,7 @@ internal class ArticleWebViewClient @Inject constructor(
 
     private fun Resource.getData() = runBlocking {
         try {
-            getInputStream(aemFileManager)
+            getInputStream(fs)
         } catch (e: FileNotFoundException) {
             // the file wasn't found in the local cache directory. log the error and clear the local file state so
             // it is downloaded again.

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/AemFileSystem.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/AemFileSystem.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.cru.godtools.base.FileManager
+import org.cru.godtools.base.FileSystem
 
 @Singleton
-class AemFileManager @Inject constructor(@ApplicationContext context: Context) : FileManager(context, "aem-resources")
+class AemFileSystem @Inject constructor(@ApplicationContext context: Context) : FileSystem(context, "aem-resources")

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -270,7 +270,7 @@ class AemArticleManagerTest {
 
     // region cleanupActor
     private fun setupCleanupActor() {
-        runBlocking { whenever(fs.createDir()) doReturn true }
+        runBlocking { whenever(fs.exists()) doReturn true }
     }
 
     @Test
@@ -311,7 +311,7 @@ class AemArticleManagerTest {
 
     private fun assertCleanupActorRan(mode: VerificationMode = times(1)) {
         val resourceDao = aemDb.resourceDao()
-        verifyBlocking(fs, mode) { createDir() }
+        verifyBlocking(fs, mode) { exists() }
         verifyBlocking(resourceDao, mode) { getAll() }
         verifyBlocking(fs, mode) { getDir() }
         verifyNoMoreInteractions(resourceDao, fs)

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -313,7 +313,7 @@ class AemArticleManagerTest {
         val resourceDao = aemDb.resourceDao()
         verifyBlocking(fs, mode) { exists() }
         verifyBlocking(resourceDao, mode) { getAll() }
-        verifyBlocking(fs, mode) { getDir() }
+        verifyBlocking(fs, mode) { rootDir() }
         verifyNoMoreInteractions(resourceDao, fs)
         clearInvocations(resourceDao, fs)
     }

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -204,7 +204,7 @@ class AemArticleManagerTest {
         verify(resourceDao).updateLocalFile(eq(uri), type.capture(), fileName.capture(), date.capture())
         assertEquals(mediaType, type.firstValue)
         assertThat(date.firstValue.time, allOf(greaterThanOrEqualTo(startTime), lessThanOrEqualTo(endTime)))
-        val file = runBlocking { fs.getFile(fileName.firstValue) }
+        val file = runBlocking { fs.file(fileName.firstValue) }
         assertArrayEquals(data.toByteArray(), file.readBytes())
     }
 

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -18,7 +18,7 @@ import okhttp3.ResponseBody
 import org.cru.godtools.article.aem.api.AemApi
 import org.cru.godtools.article.aem.db.ArticleRoomDatabase
 import org.cru.godtools.article.aem.model.Resource
-import org.cru.godtools.article.aem.util.AemFileManager
+import org.cru.godtools.article.aem.util.AemFileSystem
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.model.Translation
 import org.cru.godtools.tool.model.Manifest
@@ -67,7 +67,7 @@ class AemArticleManagerTest {
     private lateinit var aemDb: ArticleRoomDatabase
     private lateinit var api: AemApi
     private lateinit var dao: GodToolsDao
-    private lateinit var fileManager: AemFileManager
+    private lateinit var fs: AemFileSystem
     private lateinit var manifestManager: ManifestManager
     private lateinit var testScope: TestCoroutineScope
 
@@ -85,13 +85,13 @@ class AemArticleManagerTest {
         dao = mock {
             on { getAsFlow(QUERY_ARTICLE_TRANSLATIONS) } doReturn articleTranslationsChannel.consumeAsFlow()
         }
-        fileManager = spy(AemFileManager(mock { on { filesDir } doReturn testDir }))
+        fs = spy(AemFileSystem(mock { on { filesDir } doReturn testDir }))
         manifestManager = mock()
         testScope = TestCoroutineScope().apply { pauseDispatcher() }
 
         articleManager = mock(
             defaultAnswer = CALLS_REAL_METHODS,
-            useConstructor = UseConstructor.withArguments(aemDb, api, dao, fileManager, manifestManager, testScope)
+            useConstructor = UseConstructor.withArguments(aemDb, api, dao, fs, manifestManager, testScope)
         )
     }
 
@@ -204,7 +204,7 @@ class AemArticleManagerTest {
         verify(resourceDao).updateLocalFile(eq(uri), type.capture(), fileName.capture(), date.capture())
         assertEquals(mediaType, type.firstValue)
         assertThat(date.firstValue.time, allOf(greaterThanOrEqualTo(startTime), lessThanOrEqualTo(endTime)))
-        val file = runBlocking { fileManager.getFile(fileName.firstValue) }
+        val file = runBlocking { fs.getFile(fileName.firstValue) }
         assertArrayEquals(data.toByteArray(), file.readBytes())
     }
 
@@ -270,7 +270,7 @@ class AemArticleManagerTest {
 
     // region cleanupActor
     private fun setupCleanupActor() {
-        runBlocking { whenever(fileManager.createDir()) doReturn true }
+        runBlocking { whenever(fs.createDir()) doReturn true }
     }
 
     @Test
@@ -311,11 +311,11 @@ class AemArticleManagerTest {
 
     private fun assertCleanupActorRan(mode: VerificationMode = times(1)) {
         val resourceDao = aemDb.resourceDao()
-        verifyBlocking(fileManager, mode) { createDir() }
+        verifyBlocking(fs, mode) { createDir() }
         verifyBlocking(resourceDao, mode) { getAll() }
-        verifyBlocking(fileManager, mode) { getDir() }
-        verifyNoMoreInteractions(resourceDao, fileManager)
-        clearInvocations(resourceDao, fileManager)
+        verifyBlocking(fs, mode) { getDir() }
+        verifyNoMoreInteractions(resourceDao, fs)
+        clearInvocations(resourceDao, fs)
     }
     // endregion cleanupActor
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/BaseToolRendererModule.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/BaseToolRendererModule.kt
@@ -12,7 +12,7 @@ import dagger.multibindings.IntoSet
 import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.net.isConnectedLiveData
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton
-import org.cru.godtools.base.ToolFileManager
+import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.base.tool.service.ContentEventAnalyticsHandler
 import org.cru.godtools.tool.service.ManifestParser
 import org.cru.godtools.tool.xml.AndroidXmlPullParserFactory
@@ -36,8 +36,8 @@ abstract class BaseToolRendererModule {
 
         @Provides
         @Reusable
-        fun manifestParser(fileManager: ToolFileManager) = ManifestParser(object : AndroidXmlPullParserFactory() {
-            override suspend fun openFile(fileName: String) = fileManager.getInputStream(fileName).buffered()
+        fun manifestParser(fs: ToolFileSystem) = ManifestParser(object : AndroidXmlPullParserFactory() {
+            override suspend fun openFile(fileName: String) = fs.getInputStream(fileName).buffered()
         })
 
         @IntoSet

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/BaseToolRendererModule.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/BaseToolRendererModule.kt
@@ -37,7 +37,7 @@ abstract class BaseToolRendererModule {
         @Provides
         @Reusable
         fun manifestParser(fs: ToolFileSystem) = ManifestParser(object : AndroidXmlPullParserFactory() {
-            override suspend fun openFile(fileName: String) = fs.getInputStream(fileName).buffered()
+            override suspend fun openFile(fileName: String) = fs.openInputStream(fileName).buffered()
         })
 
         @IntoSet

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/LottieAnimationViewBindingAdapter.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/LottieAnimationViewBindingAdapter.kt
@@ -3,10 +3,10 @@ package org.cru.godtools.base.tool.databinding
 import androidx.databinding.BindingAdapter
 import com.airbnb.lottie.LottieAnimationView
 import org.ccci.gto.android.common.lottie.setAnimationFromFile
-import org.cru.godtools.base.toolFileManager
+import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.Resource
 
 @BindingAdapter("animation")
 internal fun LottieAnimationView.setAnimation(resource: Resource?) {
-    resource?.localName?.let { setAnimationFromFile(context.toolFileManager.getFileBlocking(it)) }
+    resource?.localName?.let { setAnimationFromFile(context.toolFileSystem.getFileBlocking(it)) }
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
@@ -7,14 +7,14 @@ import com.google.android.material.button.MaterialButton.ICON_GRAVITY_TEXT_START
 import org.ccci.gto.android.common.picasso.material.button.MaterialButtonIconTarget
 import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.dagger.picasso
-import org.cru.godtools.base.toolFileManager
+import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.Resource
 
 @BindingAdapter("icon", "iconSize")
 fun MaterialButton.bindIconResource(resource: Resource?, size: Int) {
     val target = MaterialButtonIconTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileManager.getFileBlocking(it) }
+    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
     val imageSize = dpToPixelSize(size, resources)
     if (file != null) {
         context.picasso.load(file)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
@@ -9,7 +9,7 @@ import org.ccci.gto.android.common.picasso.view.PicassoImageView
 import org.ccci.gto.android.common.picasso.view.SimplePicassoImageView
 import org.cru.godtools.base.tool.ui.util.layoutDirection
 import org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
-import org.cru.godtools.base.toolFileManager
+import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.ImageGravity
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Resource
@@ -49,4 +49,4 @@ internal fun SimpleScaledPicassoImageView.bindScaledResource(
 }
 
 private fun <T> T.setPicassoResource(resource: Resource?) where T : ImageView, T : PicassoImageView =
-    setPicassoFile(resource?.localName?.let { context.toolFileManager.getFileBlocking(it) })
+    setPicassoFile(resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) })

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
@@ -12,7 +12,7 @@ import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.R
 import org.cru.godtools.base.tool.dagger.picasso
 import org.cru.godtools.base.tool.ui.util.getTypeface
-import org.cru.godtools.base.toolFileManager
+import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.Resource
 import org.cru.godtools.tool.model.Text
 import org.cru.godtools.tool.model.gravity
@@ -42,7 +42,7 @@ fun TextView.bindTextNode(text: Text?, textSize: Float?) {
 @BindingAdapter("android:drawableStart", "drawableStartSize")
 fun TextView.bindDrawableStartResource(resource: Resource?, drawableStartSize: Int) {
     val target = TextViewDrawableStartTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileManager.getFileBlocking(it) }
+    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
     val imageSize = dpToPixelSize(drawableStartSize, resources)
     if (file != null) {
         context.picasso.load(file)
@@ -58,7 +58,7 @@ fun TextView.bindDrawableStartResource(resource: Resource?, drawableStartSize: I
 @BindingAdapter("android:drawableEnd", "drawableEndSize")
 fun TextView.bindDrawableEndResource(resource: Resource?, drawableEndSize: Int) {
     val target = TextViewDrawableEndTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileManager.getFileBlocking(it) }
+    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
     val imageSize = dpToPixelSize(drawableEndSize, resources)
     if (file != null) {
         context.picasso.load(file)

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -47,7 +47,7 @@ import org.ccci.gto.android.common.db.get
 import org.ccci.gto.android.common.picasso.getBitmap
 import org.ccci.gto.android.common.util.LocaleUtils
 import org.cru.godtools.base.Settings
-import org.cru.godtools.base.ToolFileManager
+import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.base.tool.SHORTCUT_LAUNCH
 import org.cru.godtools.base.tool.createTractActivityIntent
 import org.cru.godtools.base.ui.createArticlesIntent
@@ -75,7 +75,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     private val context: Context,
     private val dao: GodToolsDao,
     eventBus: EventBus,
-    private val fileManager: ToolFileManager,
+    private val fs: ToolFileSystem,
     private val picasso: Picasso,
     private val settings: Settings,
     private val coroutineScope: CoroutineScope,
@@ -86,14 +86,14 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         @ApplicationContext context: Context,
         dao: GodToolsDao,
         eventBus: EventBus,
-        fileManager: ToolFileManager,
+        fs: ToolFileSystem,
         picasso: Picasso,
         settings: Settings
     ) : this(
         context,
         dao,
         eventBus,
-        fileManager,
+        fs,
         picasso,
         settings,
         CoroutineScope(Dispatchers.Default + SupervisorJob())
@@ -260,7 +260,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         // create the icon bitmap
         val icon: IconCompat = tool.detailsBannerId
             ?.let { dao.find<Attachment>(it) }
-            ?.getFile(fileManager)
+            ?.getFile(fs)
             ?.let {
                 try {
                     picasso.load(it)

--- a/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/java/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -20,7 +20,6 @@ import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.find
 import org.ccci.gto.android.common.testing.timber.ExceptionRaisingTree
 import org.cru.godtools.base.Settings
-import org.cru.godtools.base.ToolFileManager
 import org.cru.godtools.model.Tool
 import org.greenrobot.eventbus.EventBus
 import org.junit.After
@@ -60,7 +59,6 @@ class GodToolsShortcutManagerTest {
 
     private lateinit var dao: GodToolsDao
     private lateinit var eventBus: EventBus
-    private lateinit var fileManager: ToolFileManager
     private lateinit var picasso: Picasso
     private lateinit var settings: Settings
     private val coroutineScope = TestCoroutineScope(SupervisorJob()).apply { pauseDispatcher() }
@@ -88,12 +86,11 @@ class GodToolsShortcutManagerTest {
         }
         dao = mock()
         eventBus = mock()
-        fileManager = mock()
         picasso = mock()
         settings = mock()
 
         shortcutManager =
-            GodToolsShortcutManager(app, dao, eventBus, fileManager, picasso, settings, coroutineScope, ioDispatcher)
+            GodToolsShortcutManager(app, dao, eventBus, mock(), picasso, settings, coroutineScope, ioDispatcher)
     }
 
     @After


### PR DESCRIPTION
- simplify the base FileManager class
- rename FileManager to FileSystem
