### PR TITLE
cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,12 +155,11 @@ configurations {
 
 dependencies {
     api project(':library:api')
-    implementation project(':library:base')
     api project(':library:db')
     api project(':library:download-manager')
+    implementation project(':library:base')
     implementation project(':library:model')
     implementation project(':library:sync')
-
     implementation project(':ui:article-renderer')
     implementation project(':ui:base')
     implementation project(':ui:cyoa-renderer')
@@ -169,71 +168,69 @@ dependencies {
     implementation project(':ui:tract-renderer')
     implementation project(':ui:tutorial-renderer')
 
-    implementation "androidx.constraintlayout:constraintlayout:${deps.androidX.constraintLayout}"
-    implementation "androidx.fragment:fragment-ktx:${deps.androidX.fragment}"
-    implementation "androidx.hilt:hilt-work:${deps.androidX.hilt}"
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.fragment.ktx
+    implementation libs.androidx.hilt.work
     implementation libs.androidx.lifecycle.livedata.ktx
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:${deps.androidX.swipeRefreshLayout}"
-    implementation "androidx.work:work-runtime:${deps.androidX.work}"
+    implementation libs.androidx.swiperefreshlayout
+    implementation libs.androidx.work
 
-    implementation libs.kotlin.coroutines.android
-
-    implementation "org.ccci.gto.android:gto-support-androidx-databinding:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-androidx-drawerlayout:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-androidx-fragment:${deps.gtoSupport}"
+    implementation libs.gtoSupport.androidx.databinding
+    implementation libs.gtoSupport.androidx.drawerlayout
+    implementation libs.gtoSupport.androidx.fragment
     implementation libs.gtoSupport.androidx.lifecycle
-    implementation "org.ccci.gto.android:gto-support-androidx-viewpager2:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-androidx-work:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-appcompat:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-base:${deps.gtoSupport}"
+    implementation libs.gtoSupport.androidx.viewpager2
+    implementation libs.gtoSupport.androidx.work
+    implementation libs.gtoSupport.appcompat
+    implementation libs.gtoSupport.base
     implementation libs.gtoSupport.compat
     implementation libs.gtoSupport.dagger
-    implementation "org.ccci.gto.android:gto-support-firebase-crashlytics:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-eventbus:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-material-components:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-napier:${deps.gtoSupport}"
+    implementation libs.gtoSupport.eventbus
+    implementation libs.gtoSupport.firebase.crashlytics
+    implementation libs.gtoSupport.materialComponents
+    implementation libs.gtoSupport.napier
     implementation libs.gtoSupport.okta
-    implementation "org.ccci.gto.android:gto-support-picasso:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-recyclerview:${deps.gtoSupport}"
-    implementation "org.ccci.gto.android:gto-support-recyclerview-advrecyclerview:${deps.gtoSupport}"
+    implementation libs.gtoSupport.picasso
+    implementation libs.gtoSupport.recyclerview
+    implementation libs.gtoSupport.recyclerview.advrecyclerview
     implementation libs.gtoSupport.util
 
-    implementation "org.cru.godtools.kotlin:parser:${deps.godtoolsToolParser}"
-
     implementation libs.firebase.crashlytics
-    implementation "com.google.firebase:firebase-inappmessaging-display:${deps.firebase.inAppMessaging}"
+    implementation libs.firebase.inappmessaging
     implementation libs.firebase.perf
 
     implementation libs.play.core
     implementation libs.play.instantapps
 
+    api libs.eventbus
+    implementation libs.advrecyclerview
+    implementation libs.godtoolsMpp.parser
+    implementation libs.hilt
+    implementation libs.kotlin.coroutines.android
     implementation libs.lottie
+    implementation libs.materialBanner
+    implementation libs.materialComponents
+    implementation libs.okta
+    implementation libs.splitties.fragmentargs
     implementation libs.taptargetview
     implementation libs.weakdelegate
-    implementation "com.google.android.material:material:${deps.materialDesign}"
-    implementation libs.hilt
-    implementation "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:${deps.advrecyclerview}"
-    implementation "com.louiscad.splitties:splitties-fragmentargs:${deps.splitties}"
-    implementation "com.okta.android:okta-oidc-android:${deps.okta}"
-    implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:${deps.youtubeplayer}"
-    implementation "com.sergivonavi:materialbanner:1.2.0"
-    api libs.eventbus
+    implementation libs.youtubePlayer
 
-    debugImplementation "org.ccci.gto.android:gto-support-facebook-flipper:${deps.gtoSupport}"
-    debugImplementation "org.ccci.gto.android:gto-support-leakcanary2:${deps.gtoSupport}"
-    debugImplementation "org.ccci.gto.android:gto-support-okhttp3:${deps.gtoSupport}"
     debugImplementation libs.firebase.crashlytics.ndk
     debugImplementation libs.facebook.flipper
     debugImplementation libs.facebook.flipper.plugins.network
     debugImplementation libs.facebook.soloader
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:${deps.leakcanary}"
+    debugImplementation libs.gtoSupport.facebook.flipper
+    debugImplementation libs.gtoSupport.leakcanary
+    debugImplementation libs.gtoSupport.okhttp3
+    debugImplementation libs.leakcanary
 
     kapt libs.dagger.compiler
+    kapt libs.eventbus.annotationProcessor
     kapt libs.hilt.compiler
-    kapt "org.greenrobot:eventbus-annotation-processor:${deps.eventbus}"
 
+    testImplementation libs.gtoSupport.testing.dagger
     testImplementation libs.hilt.testing
-    testImplementation "org.ccci.gto.android.testing:gto-support-dagger:${deps.gtoSupport}"
 
     kaptTest libs.hilt.compiler
 }

--- a/app/src/main/java/org/cru/godtools/dagger/features/FeaturesModule.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/features/FeaturesModule.kt
@@ -3,8 +3,8 @@ package org.cru.godtools.dagger.features
 import android.content.Context
 import dagger.Module
 import dagger.Provides
-import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
@@ -25,7 +25,7 @@ object FeaturesModule {
     fun provideBundledContentComponentProvider(
         @ApplicationContext context: Context
     ): FirstNonNullCachingProvider<SplitInstallComponent> {
-        val dependencies = EntryPoints.get(context, BundledContentFeatureDependencies::class.java)
+        val dependencies = EntryPointAccessors.fromApplication<BundledContentFeatureDependencies>(context)
         return FirstNonNullCachingProvider {
             getClassOrNull("org.cru.godtools.feature.bundledcontent.dagger.BundledContentFeatureComponentKt")
                 ?.getDeclaredMethodOrNull("create", BundledContentFeatureDependencies::class.java)

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
                 eventbus           : libs.versions.eventbus.get(),
                 findbugs           : '3.0.2',
                 godtoolsToolParser : libs.versions.godtoolsMpp.get(),
-                grpc               : '1.42.1',
                 gtoSupport         : libs.versions.gtoSupport.get(),
                 hamcrest           : '2.2',
                 jacoco             : '0.8.7',
@@ -131,15 +130,6 @@ allprojects {
             force "androidx.annotation:annotation:${libs.versions.androidx.annotation.get()}"
             force "androidx.lifecycle:lifecycle-viewmodel-ktx:${libs.versions.androidx.lifecycle.get()}"
             force "com.google.code.findbugs:jsr305:${deps.findbugs}"
-
-            // XXX: Force a newer version of grpc to work around an Android R+ crash with the FIAM library.
-            //      Remove this override once FIAM depends on v1.30.0+ of grpc
-            //      https://github.com/grpc/grpc-java/pull/6912
-            //      https://jira.cru.org/projects/GT/issues/GT-1122
-            //      https://github.com/firebase/firebase-android-sdk/issues/2642
-            force "io.grpc:grpc-okhttp:${deps.grpc}"
-            force "io.grpc:grpc-protobuf-lite:${deps.grpc}"
-            force "io.grpc:grpc-stub:${deps.grpc}"
 
             dependencySubstitution {
                 // use the new condensed version of hamcrest

--- a/build.gradle
+++ b/build.gradle
@@ -2,48 +2,6 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 buildscript {
     ext {
-        deps = [
-                circleindicator    : libs.versions.circleindicator.get(),
-                dagger             : libs.versions.dagger.get(),
-                eventbus           : libs.versions.eventbus.get(),
-                findbugs           : '3.0.2',
-                godtoolsToolParser : libs.versions.godtoolsMpp.get(),
-                gtoSupport         : libs.versions.gtoSupport.get(),
-                hamcrest           : '2.2',
-                jacoco             : '0.8.7',
-                junit              : '4.13.2',
-                kotlin             : '1.6.0',
-                lottie             : libs.versions.lottie.get(),
-                materialDesign     : libs.versions.materialComponents.get(),
-                mockito            : '4.1.0',
-                moshi              : '1.12.0',
-                okhttp3            : libs.versions.okhttp3.get(),
-                picasso            : libs.versions.picasso.get(),
-                retrofit2          : libs.versions.retrofit2.get(),
-                robolectric        : '4.7.2',
-                scarlet            : libs.versions.scarlet.get(),
-                splitties          : libs.versions.splitties.get(),
-                weakdelegate       : libs.versions.weakdelegate.get(),
-                youtubeplayer      : libs.versions.youtubePlayer.get(),
-        ]
-        deps.androidX = [
-                appCompat         : libs.versions.androidx.appcompat.get(),
-                archCore          : libs.versions.androidx.arch.get(),
-                cardView          : libs.versions.androidx.cardview.get(),
-                collection        : libs.versions.androidx.collection.get(),
-                concurrent        : '1.1.0',
-                constraintLayout  : libs.versions.androidx.constraintlayout.get(),
-                core              : libs.versions.androidx.core.get(),
-                fragment          : libs.versions.androidx.fragment.get(),
-                hilt              : libs.versions.androidx.hilt.get(),
-                lifecycle         : libs.versions.androidx.lifecycle.get(),
-                recyclerView      : libs.versions.androidx.recyclerview.get(),
-                swipeRefreshLayout: libs.versions.androidx.swiperefreshlayout.get(),
-                test              : '1.2.0',
-                testJUnit         : '1.1.3',
-                viewPager2        : libs.versions.androidx.viewpager2.get(),
-                work              : libs.versions.androidx.work.get(),
-        ]
         bundledContent = [
                 tools               : ['kgp', 'fourlaws', 'satisfied', 'teachmetoshare'],
                 attachments         : ['attr-banner', 'attr-banner-about'],
@@ -63,21 +21,21 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libs.android.gradle
-        classpath "com.google.dagger:hilt-android-gradle-plugin:${deps.dagger}"
-        classpath 'com.google.firebase:perf-plugin:1.4.0'
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:2.2.0'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.0'
-        classpath 'com.google.gms:google-services:4.3.10'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${deps.kotlin}"
+        classpath libs.android.gradlePlugin
+        classpath libs.firebase.appdistribution.gradlePlugin
+        classpath libs.firebase.crashlytics.gradlePlugin
+        classpath libs.firebase.perf.gradlePlugin
+        classpath libs.google.services.gradlePlugin
+        classpath libs.hilt.gradlePlugin
+        classpath libs.kotlin.gradlePlugin
     }
 }
 
 plugins {
-    id "com.vanniktech.android.junit.jacoco" version "0.16.0"
+    alias libs.plugins.grgit
+    alias libs.plugins.junitJacoco
+    alias libs.plugins.ktlint
     id "de.undercouch.download" version "4.1.2" apply false
-    id "org.ajoberstar.grgit" version "4.1.0"
-    id "org.jlleitschuh.gradle.ktlint" version "10.2.0"
 }
 
 version '5.6.2-SNAPSHOT'
@@ -120,14 +78,13 @@ allprojects {
 
     configurations.all { configuration ->
         configuration.resolutionStrategy {
-            force "androidx.annotation:annotation:${libs.versions.androidx.annotation.get()}"
-            force "androidx.lifecycle:lifecycle-viewmodel-ktx:${libs.versions.androidx.lifecycle.get()}"
-            force "com.google.code.findbugs:jsr305:${deps.findbugs}"
+            force libs.androidx.annotation
+            force libs.androidx.lifecycle.viewmodel.ktx
 
             dependencySubstitution {
                 // use the new condensed version of hamcrest
-                substitute module('org.hamcrest:hamcrest-core') with module("org.hamcrest:hamcrest:${deps.hamcrest}")
-                substitute module('org.hamcrest:hamcrest-library') with module("org.hamcrest:hamcrest:${deps.hamcrest}")
+                substitute module('org.hamcrest:hamcrest-core') with module("${libs.hamcrest.get()}")
+                substitute module('org.hamcrest:hamcrest-library') with module("${libs.hamcrest.get()}")
             }
         }
     }
@@ -147,8 +104,8 @@ configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.start
     apply plugin: 'kotlin-kapt'
 
     dependencies {
-        androidTestImplementation "org.ccci.gto.android.testing:gto-support-okta:${deps.gtoSupport}"
-        testImplementation "org.ccci.gto.android.testing:gto-support-okta:${deps.gtoSupport}"
+        androidTestImplementation libs.gtoSupport.testing.okta
+        testImplementation libs.gtoSupport.testing.okta
     }
 }
 
@@ -219,17 +176,16 @@ subprojects {
 
             dependencies {
                 compileOnly libs.androidx.annotation
-                compileOnly "com.google.code.findbugs:jsr305:${deps.findbugs}"
 
-                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${deps.kotlin}"
+                implementation libs.kotlin.stdlib
 
                 implementation libs.timber
 
-                testImplementation "androidx.test.ext:junit:${deps.androidX.testJUnit}"
+                testImplementation libs.androidx.test.junit
+                testImplementation libs.junit
+                testImplementation libs.mockito
                 testImplementation libs.mockito.kotlin
-                testImplementation "junit:junit:${deps.junit}"
-                testImplementation "org.mockito:mockito-inline:${deps.mockito}"
-                testImplementation "org.robolectric:robolectric:${deps.robolectric}"
+                testImplementation libs.robolectric
             }
         }
     }
@@ -250,7 +206,7 @@ subprojects {
 
 // jacoco config
 junitJacoco {
-    jacocoVersion = deps.jacoco
+    jacocoVersion = libs.versions.jacoco.get()
     includeNoLocationClasses = true
 }
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
                 youtubeplayer      : libs.versions.youtubePlayer.get(),
         ]
         deps.androidX = [
-                activity          : libs.versions.androidx.activity.get(),
                 appCompat         : libs.versions.androidx.appcompat.get(),
                 archCore          : libs.versions.androidx.arch.get(),
                 cardView          : libs.versions.androidx.cardview.get(),

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 buildscript {
     ext {
         deps = [
-                advrecyclerview    : '1.0.0',
                 circleindicator    : libs.versions.circleindicator.get(),
                 dagger             : libs.versions.dagger.get(),
                 eventbus           : libs.versions.eventbus.get(),
@@ -14,13 +13,11 @@ buildscript {
                 jacoco             : '0.8.7',
                 junit              : '4.13.2',
                 kotlin             : '1.6.0',
-                leakcanary         : '2.7',
                 lottie             : libs.versions.lottie.get(),
                 materialDesign     : libs.versions.materialComponents.get(),
                 mockito            : '4.1.0',
                 moshi              : '1.12.0',
                 okhttp3            : libs.versions.okhttp3.get(),
-                okta               : '1.2.1',
                 picasso            : libs.versions.picasso.get(),
                 retrofit2          : libs.versions.retrofit2.get(),
                 robolectric        : '4.7.2',
@@ -47,9 +44,6 @@ buildscript {
                 testJUnit         : '1.1.3',
                 viewPager2        : libs.versions.androidx.viewpager2.get(),
                 work              : libs.versions.androidx.work.get(),
-        ]
-        deps.firebase = [
-                inAppMessaging: '20.1.1',
         ]
         bundledContent = [
                 tools               : ['kgp', 'fourlaws', 'satisfied', 'teachmetoshare'],

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ weakdelegate = "1.0.1"
 youtubePlayer = "10.0.5"
 
 [libraries]
+advrecyclerview = "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:1.0.0"
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-activity-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-activity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
@@ -61,6 +62,7 @@ androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
+androidx-work = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
 androidx-work-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
 appsflyer = { module = "com.appsflyer:af-android-sdk", version = "6.4.3" }
 circleindicator = { module = "me.relex:circleindicator", version.ref = "circleindicator" }
@@ -75,6 +77,7 @@ facebook-soloader = { module = "com.facebook.soloader:soloader", version = "0.10
 firebase-core = { module = "com.google.firebase:firebase-core", version = "20.0.0" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
 firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk", version.ref = "firebase-crashlytics" }
+firebase-inappmessaging = "com.google.firebase:firebase-inappmessaging-display:20.1.1"
 firebase-messaging = { module = "com.google.firebase:firebase-messaging", version = "23.0.0" }
 firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebase-perf" }
 firebase-perf-ktx = { module = "com.google.firebase:firebase-perf-ktx", version.ref = "firebase-perf" }
@@ -82,11 +85,14 @@ godtoolsMpp-parser = { module = "org.cru.godtools.kotlin:parser", version.ref = 
 google-auto-value = { module = "com.google.auto.value:auto-value", version.ref = "google-auto-value" }
 google-auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "google-auto-value" }
 gtoSupport-androidx-databinding = { module = "org.ccci.gto.android:gto-support-androidx-databinding", version.ref = "gtoSupport" }
+gtoSupport-androidx-drawerlayout = { module = "org.ccci.gto.android:gto-support-androidx-drawerlayout", version.ref = "gtoSupport" }
 gtoSupport-androidx-fragment = { module = "org.ccci.gto.android:gto-support-androidx-fragment", version.ref = "gtoSupport" }
 gtoSupport-androidx-lifecycle = { module = "org.ccci.gto.android:gto-support-androidx-lifecycle", version.ref = "gtoSupport" }
 gtoSupport-androidx-room = { module = "org.ccci.gto.android:gto-support-androidx-room", version.ref = "gtoSupport" }
 gtoSupport-androidx-viewpager2 = { module = "org.ccci.gto.android:gto-support-androidx-viewpager2", version.ref = "gtoSupport" }
+gtoSupport-androidx-work = { module = "org.ccci.gto.android:gto-support-androidx-work", version.ref = "gtoSupport" }
 gtoSupport-animation = { module = "org.ccci.gto.android:gto-support-animation", version.ref = "gtoSupport" }
+gtoSupport-appcompat = { module = "org.ccci.gto.android:gto-support-appcompat", version.ref = "gtoSupport" }
 gtoSupport-base = { module = "org.ccci.gto.android:gto-support-base", version.ref = "gtoSupport" }
 gtoSupport-compat = { module = "org.ccci.gto.android:gto-support-compat", version.ref = "gtoSupport" }
 gtoSupport-core = { module = "org.ccci.gto.android:gto-support-core", version.ref = "gtoSupport" }
@@ -95,16 +101,21 @@ gtoSupport-db = { module = "org.ccci.gto.android:gto-support-db", version.ref = 
 gtoSupport-db-coroutines = { module = "org.ccci.gto.android:gto-support-db-coroutines", version.ref = "gtoSupport" }
 gtoSupport-db-livedata = { module = "org.ccci.gto.android:gto-support-db-livedata", version.ref = "gtoSupport" }
 gtoSupport-eventbus = { module = "org.ccci.gto.android:gto-support-eventbus", version.ref = "gtoSupport" }
+gtoSupport-facebook-flipper = { module = "org.ccci.gto.android:gto-support-facebook-flipper", version.ref = "gtoSupport" }
+gtoSupport-firebase-crashlytics = { module = "org.ccci.gto.android:gto-support-firebase-crashlytics", version.ref = "gtoSupport" }
 gtoSupport-jsonapi = { module = "org.ccci.gto.android:gto-support-jsonapi", version.ref = "gtoSupport" }
 gtoSupport-jsonapi-retrofit2 = { module = "org.ccci.gto.android:gto-support-jsonapi-retrofit2", version.ref = "gtoSupport" }
 gtoSupport-jsonapi-scarlet = { module = "org.ccci.gto.android:gto-support-jsonapi-scarlet", version.ref = "gtoSupport" }
 gtoSupport-kotlin-coroutines = { module = "org.ccci.gto.android:gto-support-kotlin-coroutines", version.ref = "gtoSupport" }
+gtoSupport-leakcanary = { module = "org.ccci.gto.android:gto-support-leakcanary2", version.ref = "gtoSupport" }
 gtoSupport-lottie = { module = "org.ccci.gto.android:gto-support-lottie", version.ref = "gtoSupport" }
 gtoSupport-materialComponents = { module = "org.ccci.gto.android:gto-support-material-components", version.ref = "gtoSupport" }
+gtoSupport-napier = { module = "org.ccci.gto.android:gto-support-napier", version.ref = "gtoSupport" }
 gtoSupport-okhttp3 = { module = "org.ccci.gto.android:gto-support-okhttp3", version.ref = "gtoSupport" }
 gtoSupport-okta = { module = "org.ccci.gto.android:gto-support-okta", version.ref = "gtoSupport" }
 gtoSupport-picasso = { module = "org.ccci.gto.android:gto-support-picasso", version.ref = "gtoSupport" }
 gtoSupport-recyclerview = { module = "org.ccci.gto.android:gto-support-recyclerview", version.ref = "gtoSupport" }
+gtoSupport-recyclerview-advrecyclerview = { module = "org.ccci.gto.android:gto-support-recyclerview-advrecyclerview", version.ref = "gtoSupport" }
 gtoSupport-retrofit2 = { module = "org.ccci.gto.android:gto-support-retrofit2", version.ref = "gtoSupport" }
 gtoSupport-scarlet = { module = "org.ccci.gto.android:gto-support-scarlet", version.ref = "gtoSupport" }
 gtoSupport-scarlet-actioncable = { module = "org.ccci.gto.android:gto-support-scarlet-actioncable", version.ref = "gtoSupport" }
@@ -124,10 +135,13 @@ jsoup = { module = "org.jsoup:jsoup", version = "1.14.3" }
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
+leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
+materialBanner = "com.sergivonavi:materialbanner:1.2.0"
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
+okta = "com.okta.android:okta-oidc-android:1.2.1"
 picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 picasso-transformations = { module = "jp.wasabeef:picasso-transformations", version = "2.4.0" }
 play-billing = { module = "com.android.billingclient:billing", version = "4.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 android-gradle-plugin = "7.0.3"
-androidx-activity = "1.4.0"
 androidx-annotation = "1.3.0"
 androidx-appcompat = "1.4.0"
 androidx-arch = "2.1.0"
@@ -39,7 +38,6 @@ youtubePlayer = "10.0.5"
 [libraries]
 advrecyclerview = "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:1.0.0"
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
-androidx-activity-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-activity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,11 @@
 [versions]
 android-gradle-plugin = "7.0.3"
-androidx-annotation = "1.3.0"
-androidx-appcompat = "1.4.0"
-androidx-arch = "2.1.0"
-androidx-cardview = "1.0.0"
-androidx-collection = "1.1.0"
-androidx-constraintlayout = "2.1.2"
 androidx-core = "1.7.0"
-androidx-fragment = "1.4.0"
 androidx-hilt = "1.0.0"
 androidx-lifecycle = "2.4.0"
-androidx-recyclerview = "1.2.1"
 androidx-room = "2.3.0"
-androidx-swiperefreshlayout = "1.1.0"
 androidx-viewpager2 = "1.0.0"
 androidx-work = "2.7.1"
-circleindicator = "2.1.6"
 dagger = "2.40.3"
 eventbus = "3.2.0"
 facebook-flipper = "0.122.0"
@@ -24,64 +14,68 @@ firebase-perf = "20.0.4"
 godtoolsMpp = "0.4.1-SNAPSHOT"
 google-auto-value = "1.8.2"
 gtoSupport = "3.10.1-SNAPSHOT"
+jacoco = "0.8.7"
+kotlin = "1.6.0"
 kotlinCoroutines = "1.5.2"
-lottie = "4.2.2"
 materialComponents = "1.4.0"
 okhttp3 = "4.9.3"
-picasso = "2.8"
 retrofit2 = "2.9.0"
 scarlet = "0.1.12"
 splitties = "3.0.0"
-weakdelegate = "1.0.1"
-youtubePlayer = "10.0.5"
 
 [libraries]
 advrecyclerview = "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:1.0.0"
-android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
-androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch" }
-androidx-browser = { module = "androidx.browser:browser", version = "1.4.0" }
-androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "androidx-cardview" }
-androidx-collection-ktx = { module = "androidx.collection:collection-ktx", version.ref = "androidx-collection" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+androidx-annotation = "androidx.annotation:annotation:1.3.0"
+androidx-appcompat = "androidx.appcompat:appcompat:1.4.0"
+androidx-arch-core-testing = "androidx.arch.core:core-testing:2.1.0"
+androidx-browser = "androidx.browser:browser:1.4.0"
+androidx-cardview = "androidx.cardview:cardview:1.0.0"
+androidx-collection-ktx = "androidx.collection:collection-ktx:1.1.0"
+androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.2"
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-databinding-compiler = { module = "androidx.databinding:databinding-compiler", version.ref = "android-gradle-plugin" }
-androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
+androidx-fragment-ktx = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidx-hilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidx-hilt" }
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-testing = { module = "androidx.lifecycle:lifecycle-runtime-testing", version.ref = "androidx-lifecycle" }
-androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-recyclerview = "androidx.recyclerview:recyclerview:1.2.1"
 androidx-room = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
-androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "androidx-swiperefreshlayout" }
+androidx-swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
+androidx-test-junit = "androidx.test.ext:junit:1.1.3"
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "androidx-viewpager2" }
 androidx-work = { module = "androidx.work:work-runtime", version.ref = "androidx-work" }
 androidx-work-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
-appsflyer = { module = "com.appsflyer:af-android-sdk", version = "6.4.3" }
-circleindicator = { module = "me.relex:circleindicator", version.ref = "circleindicator" }
+appsflyer = "com.appsflyer:af-android-sdk:6.4.3"
+circleindicator = "me.relex:circleindicator:2.1.6"
 dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
 eventbus-annotationProcessor = { module = "org.greenrobot:eventbus-annotation-processor", version.ref = "eventbus" }
-facebook = { module = "com.facebook.android:facebook-core", version = "12.1.0" }
+facebook = "com.facebook.android:facebook-core:12.1.0"
 facebook-flipper = { module = "com.facebook.flipper:flipper", version.ref = "facebook-flipper" }
 facebook-flipper-plugins-network = { module = "com.facebook.flipper:flipper-network-plugin", version.ref = "facebook-flipper" }
-facebook-soloader = { module = "com.facebook.soloader:soloader", version = "0.10.3" }
-firebase-core = { module = "com.google.firebase:firebase-core", version = "20.0.0" }
+facebook-soloader = "com.facebook.soloader:soloader:0.10.3"
+firebase-appdistribution-gradlePlugin = "com.google.firebase:firebase-appdistribution-gradle:2.2.0"
+firebase-core = "com.google.firebase:firebase-core:20.0.0"
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
+firebase-crashlytics-gradlePlugin = "com.google.firebase:firebase-crashlytics-gradle:2.8.0"
 firebase-crashlytics-ndk = { module = "com.google.firebase:firebase-crashlytics-ndk", version.ref = "firebase-crashlytics" }
 firebase-inappmessaging = "com.google.firebase:firebase-inappmessaging-display:20.1.1"
-firebase-messaging = { module = "com.google.firebase:firebase-messaging", version = "23.0.0" }
+firebase-messaging = "com.google.firebase:firebase-messaging:23.0.0"
 firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebase-perf" }
+firebase-perf-gradlePlugin = "com.google.firebase:perf-plugin:1.4.0"
 firebase-perf-ktx = { module = "com.google.firebase:firebase-perf-ktx", version.ref = "firebase-perf" }
 godtoolsMpp-parser = { module = "org.cru.godtools.kotlin:parser", version.ref = "godtoolsMpp" }
 google-auto-value = { module = "com.google.auto.value:auto-value", version.ref = "google-auto-value" }
 google-auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "google-auto-value" }
+google-services-gradlePlugin = "com.google.gms:google-services:4.3.10"
 gtoSupport-androidx-databinding = { module = "org.ccci.gto.android:gto-support-androidx-databinding", version.ref = "gtoSupport" }
 gtoSupport-androidx-drawerlayout = { module = "org.ccci.gto.android:gto-support-androidx-drawerlayout", version.ref = "gtoSupport" }
 gtoSupport-androidx-fragment = { module = "org.ccci.gto.android:gto-support-androidx-fragment", version.ref = "gtoSupport" }
@@ -120,46 +114,59 @@ gtoSupport-scarlet-actioncable = { module = "org.ccci.gto.android:gto-support-sc
 gtoSupport-snowplow = { module = "org.ccci.gto.android:gto-support-snowplow", version.ref = "gtoSupport" }
 gtoSupport-sync = { module = "org.ccci.gto.android:gto-support-sync", version.ref = "gtoSupport" }
 gtoSupport-testing-dagger = { module = "org.ccci.gto.android.testing:gto-support-dagger", version.ref = "gtoSupport" }
+gtoSupport-testing-okta = { module = "org.ccci.gto.android.testing:gto-support-okta", version.ref = "gtoSupport" }
 gtoSupport-testing-picasso = { module = "org.ccci.gto.android.testing:gto-support-picasso", version.ref = "gtoSupport" }
 gtoSupport-testing-timber = { module = "org.ccci.gto.android.testing:gto-support-timber", version.ref = "gtoSupport" }
 gtoSupport-util = { module = "org.ccci.gto.android:gto-support-util", version.ref = "gtoSupport" }
 gtoSupport-viewpager = { module = "org.ccci.gto.android:gto-support-viewpager", version.ref = "gtoSupport" }
 guava = { module = "com.google.guava:guava", version = "31.0.1-android" }
+hamcrest = "org.hamcrest:hamcrest:2.2"
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "dagger" }
+hilt-gradlePlugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "dagger" }
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "dagger" }
-json = { module = "org.json:json", version = "20210307" }
-jsoup = { module = "org.jsoup:jsoup", version = "1.14.3" }
+json = "org.json:json:20210307"
+jsoup = "org.jsoup:jsoup:1.14.3"
+junit = "junit:junit:4.13.2"
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinCoroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 leakcanary = "com.squareup.leakcanary:leakcanary-android:2.7"
-lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
+lottie = "com.airbnb.android:lottie:4.2.2"
 materialBanner = "com.sergivonavi:materialbanner:1.2.0"
 materialComponents = { module = "com.google.android.material:material", version.ref = "materialComponents" }
-mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
+mockito = "org.mockito:mockito-inline:4.1.0"
+mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okta = "com.okta.android:okta-oidc-android:1.2.1"
-picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
-picasso-transformations = { module = "jp.wasabeef:picasso-transformations", version = "2.4.0" }
-play-billing = { module = "com.android.billingclient:billing", version = "4.0.0" }
-play-core = { module = "com.google.android.play:core", version = "1.10.2" }
-play-installreferrer = { module = "com.android.installreferrer:installreferrer", version = "2.2" }
-play-instantapps = { module = "com.google.android.instantapps:instantapps", version = "1.1.0" }
-play-tagmanager = { module = "com.google.android.gms:play-services-tagmanager", version = "17.0.1" }
+picasso = "com.squareup.picasso:picasso:2.8"
+picasso-transformations = "jp.wasabeef:picasso-transformations:2.4.0"
+play-billing = "com.android.billingclient:billing:4.0.0"
+play-core = "com.google.android.play:core:1.10.2"
+play-installreferrer = "com.android.installreferrer:installreferrer:2.2"
+play-instantapps = "com.google.android.instantapps:instantapps:1.1.0"
+play-tagmanager = "com.google.android.gms:play-services-tagmanager:17.0.1"
 retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
 retrofit2-converters-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit2" }
-rtlViewpager = { module = "com.duolingo.open:rtl-viewpager", version = "2.0.0" }
+robolectric = "org.robolectric:robolectric:4.7.2"
+rtlViewpager = "com.duolingo.open:rtl-viewpager:2.0.0"
 scarlet = { module = "com.tinder.scarlet:scarlet", version.ref = "scarlet" }
 scarlet-adapters-stream-coroutines = { module = "com.tinder.scarlet:stream-adapter-coroutines", version.ref = "scarlet" }
 scarlet-lifecycle-android = { module = "com.tinder.scarlet:lifecycle-android", version.ref = "scarlet" }
 scarlet-websockets-okhttp = { module = "com.tinder.scarlet:websocket-okhttp", version.ref = "scarlet" }
-snowplow = { module = "com.snowplowanalytics:snowplow-android-tracker", version = "2.2.1" }
+snowplow = "com.snowplowanalytics:snowplow-android-tracker:2.2.1"
 splitties-bitflags = { module = "com.louiscad.splitties:splitties-bitflags", version.ref = "splitties" }
 splitties-fragmentargs = { module = "com.louiscad.splitties:splitties-fragmentargs", version.ref = "splitties" }
 splitties-intents = { module = "com.louiscad.splitties:splitties-intents", version.ref = "splitties" }
-taptargetview = { module = "com.getkeepsafe.taptargetview:taptargetview", version = "1.13.3" }
-timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
-tinder-statemachine = { module = "com.tinder.statemachine:statemachine", version = "0.2.0" }
-weakdelegate = { module = "com.github.Karumi:WeakDelegate", version.ref = "weakdelegate" }
-youtubePlayer = { module = "com.pierfrancescosoffritti.androidyoutubeplayer:core", version.ref = "youtubePlayer" }
+taptargetview = "com.getkeepsafe.taptargetview:taptargetview:1.13.3"
+timber = "com.jakewharton.timber:timber:5.0.1"
+tinder-statemachine = "com.tinder.statemachine:statemachine:0.2.0"
+weakdelegate = "com.github.Karumi:WeakDelegate:1.0.1"
+youtubePlayer = "com.pierfrancescosoffritti.androidyoutubeplayer:core:10.0.5"
+
+[plugins]
+grgit = { id = "org.ajoberstar.grgit", version = "4.1.0" }
+junitJacoco = { id = "com.vanniktech.android.junit.jacoco", version = "0.16.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "10.2.0" }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/ToolFileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/ToolFileSystem.kt
@@ -2,8 +2,8 @@ package org.cru.godtools.base
 
 import android.content.Context
 import dagger.hilt.EntryPoint
-import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Inject
@@ -20,4 +20,4 @@ class ToolFileSystem @Inject internal constructor(@ApplicationContext context: C
 }
 
 val Context.toolFileSystem
-    get() = EntryPoints.get(applicationContext, ToolFileSystem.Provider::class.java).fileSystem
+    get() = EntryPointAccessors.fromApplication<ToolFileSystem.Provider>(this).fileSystem

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/ArticleWebViewClient.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.article.aem.ui
 
 import android.app.Activity
 import android.net.Uri
-import android.os.Build
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -41,8 +40,7 @@ internal class ArticleWebViewClient @Inject constructor(
     }
 
     private fun notFoundResponse() = WebResourceResponse(null, null, null).apply {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_NOT_FOUND, "Resource not available")
+        setStatusCodeAndReasonPhrase(HttpURLConnection.HTTP_NOT_FOUND, "Resource not available")
     }
 
     @WorkerThread

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/ArticleRoomDatabaseMigrationIT.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/ArticleRoomDatabaseMigrationIT.kt
@@ -10,9 +10,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Config.NEWEST_SDK
+import org.robolectric.annotation.Config.OLDEST_SDK
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [21, 28])
+@Config(sdk = [OLDEST_SDK, NEWEST_SDK])
 class ArticleRoomDatabaseMigrationIT {
     @get:Rule
     val helper = MigrationTestHelper(

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.cru.godtools.article.aem.api.AemApi
 import org.cru.godtools.article.aem.db.ArticleRoomDatabase
 import org.cru.godtools.article.aem.model.Resource
@@ -189,8 +189,7 @@ class AemArticleManagerTest {
         val mediaType = "image/jpg".toMediaType()
         val resource = mock<Resource> { on { needsDownload() } doReturn true }
         whenever(resourceDao.find(uri)).thenReturn(resource)
-        wheneverDownloadingResource(uri)
-            .thenReturn(Response.success(ResponseBody.create(mediaType, data.toByteArray())))
+        wheneverDownloadingResource(uri).thenReturn(Response.success(data.toByteArray().toResponseBody(mediaType)))
 
         val startTime = System.currentTimeMillis()
         articleManager.downloadResource(uri, false)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/dagger/PicassoProvider.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/dagger/PicassoProvider.kt
@@ -3,8 +3,8 @@ package org.cru.godtools.base.tool.dagger
 import android.content.Context
 import com.squareup.picasso.Picasso
 import dagger.hilt.EntryPoint
-import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 
 @EntryPoint
@@ -13,4 +13,4 @@ internal interface PicassoProvider {
     val picasso: Picasso
 }
 
-internal val Context.picasso get() = EntryPoints.get(applicationContext, PicassoProvider::class.java).picasso
+internal val Context.picasso get() = EntryPointAccessors.fromApplication<PicassoProvider>(this).picasso

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
@@ -8,7 +8,7 @@ import org.ccci.gto.android.common.picasso.material.button.MaterialButtonIconTar
 import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.dagger.picasso
 import org.cru.godtools.base.toolFileSystem
-import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.Gravity
 import org.cru.godtools.tool.model.Resource
 
 @BindingAdapter("icon", "iconSize")
@@ -28,7 +28,7 @@ fun MaterialButton.bindIconResource(resource: Resource?, size: Int) {
 }
 
 @BindingAdapter("iconGravity")
-fun MaterialButton.bindIconGravity(gravity: ImageGravity) {
+fun MaterialButton.bindIconGravity(gravity: Gravity) {
     iconGravity = when {
         gravity.isEnd -> ICON_GRAVITY_TEXT_END
         gravity.isStart -> ICON_GRAVITY_TEXT_START

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
@@ -10,7 +10,7 @@ import org.ccci.gto.android.common.picasso.view.SimplePicassoImageView
 import org.cru.godtools.base.tool.ui.util.layoutDirection
 import org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
 import org.cru.godtools.base.toolFileSystem
-import org.cru.godtools.tool.model.ImageGravity
+import org.cru.godtools.tool.model.Gravity
 import org.cru.godtools.tool.model.ImageScaleType
 import org.cru.godtools.tool.model.Resource
 
@@ -23,7 +23,7 @@ internal fun SimplePicassoImageView.setPicassoFile(resource: Resource?) = setPic
 internal fun SimpleScaledPicassoImageView.bindScaledResource(
     resource: Resource?,
     scaleType: ImageScaleType?,
-    gravity: ImageGravity?
+    gravity: Gravity?
 ) {
     toggleBatchUpdates(true)
     setPicassoResource(resource)

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -9,7 +9,6 @@ android {
 dependencies {
     api(project(":ui:base-tool"))
 
-    implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.viewpager2)
 

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(project(":library:model"))
     implementation(project(":library:sync"))
 
-    implementation(libs.androidx.activity.ktx)
     implementation(libs.androidx.cardview)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragment.ktx)


### PR DESCRIPTION
- stop using deprecated ResponseBody.create() method
- remove unnecessary version check
- use robolectric SDK constants for test
- we no longer need to force a newer version of grpc
- track app dependencies in gradle version catalog
- remove unnecessary incorrect dependency from version catalog
