### PR TITLE
cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,10 @@ allprojects {
         }
         maven {
             url 'https://jitpack.io'
-            content { includeGroupByRegex 'com\\.github\\..*' }
+            content {
+                includeGroupByRegex 'com\\.github\\..*'
+                excludeGroup 'com.github.ajalt.colormath'
+            }
         }
         google()
         mavenCentral()

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -98,7 +98,6 @@ object Contract : BaseContract() {
 
         internal val FIELD_ID = TABLE.field(COLUMN_ID)
         val FIELD_CODE = TABLE.field(COLUMN_CODE)
-        @JvmField
         val FIELD_TYPE = TABLE.field(COLUMN_TYPE)
         val FIELD_BANNER = TABLE.field(COLUMN_BANNER)
         val FIELD_DETAILS_BANNER = TABLE.field(COLUMN_DETAILS_BANNER)
@@ -222,13 +221,11 @@ object Contract : BaseContract() {
         private const val SQL_COLUMN_LAST_ACCESSED = "$COLUMN_LAST_ACCESSED INTEGER"
 
         val SQL_JOIN_LANGUAGE = TABLE.join(LanguageTable.TABLE).on(FIELD_LANGUAGE.eq(LanguageTable.FIELD_CODE))
-        @JvmField
         val SQL_JOIN_TOOL = TABLE.join(ToolTable.TABLE).on(FIELD_TOOL.eq(ToolTable.FIELD_CODE))
 
         internal val SQL_WHERE_PRIMARY_KEY = FIELD_ID.eq(bind())
         internal val SQL_WHERE_TOOL_LANGUAGE = FIELD_TOOL.eq(bind()).and(FIELD_LANGUAGE.eq(bind()))
         val SQL_WHERE_PUBLISHED = FIELD_PUBLISHED.eq(true)
-        @JvmField
         val SQL_WHERE_DOWNLOADED = FIELD_DOWNLOADED.eq(true)
         const val SQL_ORDER_BY_VERSION_DESC = "$COLUMN_VERSION DESC"
 

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
@@ -91,7 +91,7 @@ class GodToolsDatabase @Inject internal constructor(@ApplicationContext private 
             }
         } catch (e: SQLException) {
             // rethrow exception on debug builds
-            if (context.isApplicationDebuggable()) throw e
+            if (context.isApplicationDebuggable) throw e
 
             // let's try resetting the database instead
             Timber.tag("GodToolsDatabase").e(e, "Error migrating the database")

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/DownloadProgress.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/DownloadProgress.kt
@@ -1,12 +1,10 @@
 package org.cru.godtools.download.manager
 
-private const val INDETERMINATE_VAL = 0L
-
 class DownloadProgress(progress: Long, max: Long) {
-    companion object {
-        @JvmField
+    internal companion object {
+        internal const val INDETERMINATE_VAL = 0L
+
         internal val INITIAL = DownloadProgress(INDETERMINATE_VAL, INDETERMINATE_VAL)
-        val INDETERMINATE = DownloadProgress(INDETERMINATE_VAL, INDETERMINATE_VAL)
     }
 
     val max = max.toInt().coerceAtLeast(0)

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressLiveDataTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressLiveDataTest.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.download.manager
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.cru.godtools.download.manager.DownloadProgress.Companion.INDETERMINATE_VAL
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -15,20 +16,36 @@ class DownloadProgressLiveDataTest {
     @Test
     fun testInitialProgress() {
         val liveData = DownloadProgressLiveData()
-
         assertNull(liveData.value)
+
         liveData.value = DownloadProgress.INITIAL
-        assertSame(DownloadProgress.INITIAL, liveData.value)
+        assertSame(
+            "You should be able to set the initial progress if no progress was currently set",
+            DownloadProgress.INITIAL,
+            liveData.value
+        )
 
         liveData.value = DownloadProgress(1, 2)
-        liveData.value = DownloadProgress.INITIAL
         assertEquals(DownloadProgress(1, 2), liveData.value)
 
-        liveData.value = DownloadProgress.INDETERMINATE
-        assertEquals(DownloadProgress.INDETERMINATE, liveData.value)
+        liveData.value = DownloadProgress.INITIAL
+        assertEquals(
+            "Initial DownloadProgress shouldn't override other download progress",
+            DownloadProgress(1, 2),
+            liveData.value
+        )
+
+        val indeterminate = DownloadProgress(INDETERMINATE_VAL, INDETERMINATE_VAL)
+        assertEquals(DownloadProgress.INITIAL, indeterminate)
+        liveData.value = indeterminate
+        assertEquals("You should still be able to set an indeterminate download state", indeterminate, liveData.value)
 
         liveData.value = null
         liveData.value = DownloadProgress.INITIAL
-        assertSame(DownloadProgress.INITIAL, liveData.value)
+        assertSame(
+            "You can set the DownloadProgress to initial if the progress is cleared with null first",
+            DownloadProgress.INITIAL,
+            liveData.value
+        )
     }
 }

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressLiveDataTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressLiveDataTest.kt
@@ -9,9 +9,8 @@ import org.junit.Rule
 import org.junit.Test
 
 class DownloadProgressLiveDataTest {
-    @Rule
-    @JvmField
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Test
     fun testInitialProgress() {

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/DownloadProgressTest.kt
@@ -35,8 +35,7 @@ class DownloadProgressTest {
 
     @Test
     fun testEquals() {
-        assertTrue(DownloadProgress.INITIAL == DownloadProgress.INDETERMINATE)
-        assertTrue(DownloadProgress.INDETERMINATE == DownloadProgress(0, 0))
+        assertTrue(DownloadProgress.INITIAL == DownloadProgress(0, 0))
         assertTrue(DownloadProgress(10, 20) == DownloadProgress(10, 20))
         assertFalse(DownloadProgress(9, 20) == DownloadProgress(10, 20))
         assertFalse(DownloadProgress(9, 19) == DownloadProgress(9, 20))

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -246,7 +246,7 @@ class GodToolsDownloadManagerTest {
         argumentCaptor<DownloadProgress> {
             verify(observer, times(2)).onChanged(capture())
 
-            assertEquals(DownloadProgress.INDETERMINATE, firstValue)
+            assertEquals(DownloadProgress(5, 0), firstValue)
             assertEquals(DownloadProgress(5, 10), lastValue)
         }
 

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
@@ -16,7 +16,6 @@ private const val JSON_NAME = "name"
 @JsonApiType(JSON_API_TYPE_LANGUAGE)
 class Language : Base() {
     companion object {
-        @JvmField
         val INVALID_CODE = Locale("x", "inv")
     }
 

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Translation.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Translation.kt
@@ -22,7 +22,6 @@ class Translation : Base() {
         const val JSON_LANGUAGE = "language"
         const val DEFAULT_PUBLISHED = false
         const val DEFAULT_VERSION = 0
-        @JvmField
         val DEFAULT_LAST_ACCESSED = Date(0)
     }
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/ParagraphController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/ParagraphController.kt
@@ -14,7 +14,7 @@ class ParagraphController private constructor(
     private val binding: ToolContentParagraphBinding,
     parentController: BaseController<*>,
     cacheFactory: UiControllerCache.Factory
-) : ParentController<Paragraph>(Paragraph::class, binding.content, parentController, cacheFactory) {
+) : ParentController<Paragraph>(Paragraph::class, binding.root, parentController, cacheFactory) {
     @AssistedInject
     internal constructor(
         @Assisted parent: ViewGroup,

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/ParentController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/ParentController.kt
@@ -11,13 +11,13 @@ import org.cru.godtools.tool.model.Content
 import org.cru.godtools.tool.model.Parent
 import org.greenrobot.eventbus.EventBus
 
-abstract class ParentController<T> protected constructor(
+abstract class ParentController<T : Parent> protected constructor(
     clazz: KClass<T>,
     root: View,
     parentController: BaseController<*>? = null,
     cacheFactory: UiControllerCache.Factory,
     eventBus: EventBus? = null
-) : BaseController<T>(clazz, root, parentController, eventBus) where T : Parent {
+) : BaseController<T>(clazz, root, parentController, eventBus) {
     // region Lifecycle
     @CallSuper
     override fun onBind() {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/cache/UiControllerCache.kt
@@ -5,7 +5,7 @@ import androidx.core.util.Pools
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import org.ccci.gto.android.common.app.ApplicationUtils
+import org.ccci.gto.android.common.util.content.isApplicationDebuggable
 import org.cru.godtools.base.tool.ui.controller.BaseController
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerType.Companion.DEFAULT_VARIATION
 import org.cru.godtools.tool.model.Base
@@ -35,7 +35,7 @@ class UiControllerCache @AssistedInject internal constructor(
     private fun UiControllerType.createController() =
         controllerFactories[this]?.create(parent, parentController) ?: run {
             val e = IllegalArgumentException("Unsupported Content type specified: $this")
-            if (ApplicationUtils.isDebuggable(parent.context)) throw e
+            if (parent.context.isApplicationDebuggable) throw e
             Timber.e(e, "Unsupported Content type specified: %s", toString())
             null
         }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/widget/PageContentLayout.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/widget/PageContentLayout.kt
@@ -620,32 +620,23 @@ class PageContentLayout @JvmOverloads constructor(
             const val CHILD_TYPE_CALL_TO_ACTION_TIP = 4
         }
 
-        @JvmField
-        var childType = CHILD_TYPE_UNKNOWN
+        internal var childType = CHILD_TYPE_UNKNOWN
 
         @IdRes
-        @JvmField
-        var cardPaddingViewTop = INVALID_ID_RES
+        internal var cardPaddingViewTop = INVALID_ID_RES
         @IdRes
-        @JvmField
-        var cardPeekViewTop = INVALID_ID_RES
+        internal var cardPeekViewTop = INVALID_ID_RES
         @IdRes
-        @JvmField
-        var cardStackViewTop = INVALID_ID_RES
+        internal var cardStackViewTop = INVALID_ID_RES
 
         @IdRes
-        @JvmField
-        var above = INVALID_ID_RES
+        internal var above = INVALID_ID_RES
 
         // card peek heights
-        @JvmField
-        var cardPaddingOffset = 0
-        @JvmField
-        var cardStackOffset = 0
-        @JvmField
-        var cardPeekOffset = 0
-        @JvmField
-        var siblingStackOffset = 0
+        internal var cardPaddingOffset = 0
+        internal var cardStackOffset = 0
+        internal var cardPeekOffset = 0
+        internal var siblingStackOffset = 0
 
         constructor(c: Context, attrs: AttributeSet?) : super(c, attrs) {
             c.withStyledAttributes(attrs, R.styleable.PageContentLayout_Layout) {

--- a/ui/tract-renderer/src/main/res/values/styles.xml
+++ b/ui/tract-renderer/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="horiz_margin_hero">16dp</dimen>
+    <dimen name="horiz_margin_hero">@dimen/tool_content_margin</dimen>
     <dimen name="horiz_margin_call_to_action_label">32dp</dimen>
     <dimen name="horiz_margin_call_to_action_arrow">8dp</dimen>
-    <dimen name="horiz_margin_modal">16dp</dimen>
+    <dimen name="horiz_margin_modal">@dimen/tool_content_margin</dimen>
 
-    <dimen name="tract_content_margin_horizontal">16dp</dimen>
+    <dimen name="tract_content_margin_horizontal">@dimen/tool_content_margin</dimen>
 
     <style name="Theme.GodTools.Tract.Activity.Tract" parent="Theme.GodTools.Tool" />
 </resources>


### PR DESCRIPTION
- get rid of the unnecessary INDETERMINATE download progress constant
- remove unnecessary JvmField annotation
- use isApplicationDebuggable extension val
- base tract margins on common tool margins
- simplify the generic constraints
- use the root view in the paragraph element layout
- the colormath library is in mavencentral, so don't look for it in jitpack
