### PR TITLE
GT-1328 GT-1329 Reload/dismiss pages when they change

### DIFF
--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -40,9 +40,10 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
 
     override fun onInvalidPage(fragment: CyoaPageFragment<*>, page: Page?) {
         if (fragment !== pageFragment) return
-        when (page) {
-            null -> supportFragmentManager.popBackStack()
-            else -> showPage(page, false)
+        when {
+            page != null -> showPage(page, false)
+            supportFragmentManager.backStackEntryCount == 0 -> finish()
+            else -> supportFragmentManager.popBackStack()
         }
     }
 

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
@@ -8,10 +8,13 @@ import org.cru.godtools.tool.cyoa.databinding.CyoaPageCardCollectionBinding
 import org.cru.godtools.tool.cyoa.ui.controller.CardCollectionPageController
 import org.cru.godtools.tool.cyoa.ui.controller.bindController
 import org.cru.godtools.tool.model.page.CardCollectionPage
+import org.cru.godtools.tool.model.page.Page
 
 @AndroidEntryPoint
 class CyoaCardCollectionPageFragment(page: String? = null) :
     CyoaPageFragment<CyoaPageCardCollectionBinding>(R.layout.cyoa_page_card_collection, page) {
+    override fun supportsPage(page: Page) = page is CardCollectionPage
+
     // region Controller
     @Inject
     internal lateinit var controllerFactory: CardCollectionPageController.Factory

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
@@ -8,10 +8,13 @@ import org.cru.godtools.tool.cyoa.databinding.CyoaPageContentBinding
 import org.cru.godtools.tool.cyoa.ui.controller.ContentPageController
 import org.cru.godtools.tool.cyoa.ui.controller.bindController
 import org.cru.godtools.tool.model.page.ContentPage
+import org.cru.godtools.tool.model.page.Page
 
 @AndroidEntryPoint
 class CyoaContentPageFragment(page: String? = null) :
     CyoaPageFragment<CyoaPageContentBinding>(R.layout.cyoa_page_content, page) {
+    override fun supportsPage(page: Page) = page is ContentPage
+
     // region Controller
     @Inject
     internal lateinit var controllerFactory: ContentPageController.Factory

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -123,7 +123,6 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
 
                 // TODO: There isn't a reliable way to ensure that regular up navigation is processed, so for now we use
@@ -142,11 +141,9 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1")
             }
         }
@@ -161,11 +158,9 @@ class CyoaActivityTest {
             it.onActivity {
                 it.showPage(page2)
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1")
             }
         }
@@ -179,11 +174,9 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page3")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page2")
             }
         }
@@ -199,7 +192,6 @@ class CyoaActivityTest {
                 it.assertPageStack("page1")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page2")
             }
         }
@@ -216,11 +208,9 @@ class CyoaActivityTest {
             it.onActivity {
                 it.showPage(page3)
                 it.showPage(page4)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page3", "page4")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
             }
         }
@@ -238,16 +228,13 @@ class CyoaActivityTest {
                 it.assertPageStack("page1")
 
                 assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page2")
 
                 repeat(3) { _ ->
                     assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                    it.supportFragmentManager.executePendingTransactions()
                     it.assertPageStack("page3")
 
                     assertTrue(shadowOf(it).clickMenuItem(android.R.id.home))
-                    it.supportFragmentManager.executePendingTransactions()
                     it.assertPageStack("page2")
                 }
             }
@@ -264,7 +251,6 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.processContentEvent(eventId1.event())
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
 
                 it.supportFragmentManager.popBackStackImmediate()
@@ -282,8 +268,6 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.processContentEvent(eventId1.event())
-                it.supportFragmentManager.executePendingTransactions()
-
                 it.assertPageStack("page2")
             }
         }
@@ -299,7 +283,6 @@ class CyoaActivityTest {
             it.onActivity {
                 it.processContentEvent(eventId1.event())
                 it.processContentEvent(eventId2.event())
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 it.supportFragmentManager.popBackStackImmediate()
@@ -322,8 +305,6 @@ class CyoaActivityTest {
             it.onActivity {
                 it.processContentEvent(eventId1.event())
                 it.processContentEvent(eventId2.event())
-                it.supportFragmentManager.executePendingTransactions()
-
                 it.assertPageStack("page1")
             }
         }
@@ -339,8 +320,6 @@ class CyoaActivityTest {
             it.onActivity {
                 it.processContentEvent(eventId1.event())
                 it.processContentEvent(eventId2.event())
-                it.supportFragmentManager.executePendingTransactions()
-
                 it.assertPageStack("page2")
             }
         }
@@ -355,11 +334,9 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
 
                 manifestEnglish.value = manifest(listOf(page1))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1")
             }
         }
@@ -373,12 +350,10 @@ class CyoaActivityTest {
             it.onActivity {
                 it.showPage(page2)
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 manifestEnglish.value = manifest(listOf(page1, page3))
                 it.onBackPressed()
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1")
             }
         }
@@ -392,11 +367,9 @@ class CyoaActivityTest {
             it.onActivity {
                 it.showPage(page2)
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 manifestEnglish.value = manifest(listOf(page1))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1")
             }
         }
@@ -409,12 +382,10 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaContentPageFragment)
 
                 manifestEnglish.value = manifest(listOf(page1, cardCollectionPage2))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaCardCollectionPageFragment)
             }
@@ -428,16 +399,13 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaContentPageFragment)
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 manifestEnglish.value = manifest(listOf(page1, cardCollectionPage2, page3))
                 it.onBackPressed()
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaCardCollectionPageFragment)
             }
@@ -451,15 +419,13 @@ class CyoaActivityTest {
         scenario {
             it.onActivity {
                 it.showPage(page2)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaContentPageFragment)
+
                 it.showPage(page3)
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2", "page3")
 
                 manifestEnglish.value = manifest(listOf(page1, cardCollectionPage2))
-                it.supportFragmentManager.executePendingTransactions()
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaCardCollectionPageFragment)
             }
@@ -468,6 +434,7 @@ class CyoaActivityTest {
     // endregion Update Manifest
 
     private fun CyoaActivity.assertPageStack(vararg pages: String) {
+        supportFragmentManager.executePendingTransactions()
         assertEquals(pages.size - 1, supportFragmentManager.backStackEntryCount)
         pages.dropLast(1).forEachIndexed { i, page ->
             assertEquals(page, supportFragmentManager.getBackStackEntryAt(i).name)

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -343,6 +343,20 @@ class CyoaActivityTest {
     }
 
     @Test
+    fun `Update Manifest - page removed - current - initial`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario {
+            it.onActivity {
+                it.assertPageStack("page1")
+
+                manifestEnglish.value = manifest(listOf(page2))
+                assertTrue(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
     fun `Update Manifest - page removed - parent`() {
         manifestEnglish.value = manifest(listOf(page1, page2, page3))
 
@@ -355,6 +369,23 @@ class CyoaActivityTest {
                 manifestEnglish.value = manifest(listOf(page1, page3))
                 it.onBackPressed()
                 it.assertPageStack("page1")
+            }
+        }
+    }
+
+    @Test
+    fun `Update Manifest - page removed - parent - initial`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario {
+            it.onActivity {
+                it.showPage(page2)
+                it.assertPageStack("page1", "page2")
+
+                manifestEnglish.value = manifest(listOf(page2))
+                assertFalse(it.isFinishing)
+                it.onBackPressed()
+                assertTrue(it.isFinishing)
             }
         }
     }


### PR DESCRIPTION
- have the CyoaPageFragment notify a listener if it is no longer valid
- add some unit tests dealing with varying invalid/missing pages when changing the manifest
- execute any pending transactions before asserting the page stack
- finish the tool if the initial page disappears and the stack goes to show it
