### PR TITLE
GT-1384 Fire screen analytics events for CYOA renderer

### DIFF
--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEvent.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEvent.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.tool.cyoa.analytics.model
+
+import org.cru.godtools.tool.model.page.CardCollectionPage.Card
+
+class CyoaCardCollectionPageAnalyticsScreenEvent(card: Card) : CyoaPageAnalyticsScreenEvent(card.page, suffix = card.id)

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
@@ -3,10 +3,13 @@ package org.cru.godtools.tool.cyoa.analytics.model
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
 import org.cru.godtools.tool.model.page.Page
 
-open class CyoaPageAnalyticsScreenEvent(page: Page, suffix: String = "") : ToolAnalyticsScreenEvent(
+private const val SEPARATOR = ":"
+
+open class CyoaPageAnalyticsScreenEvent(page: Page, suffix: String? = null) : ToolAnalyticsScreenEvent(
     screen = page.toAnalyticsScreenName(suffix),
     tool = page.manifest.code,
     locale = page.manifest.locale
 )
 
-private fun Page.toAnalyticsScreenName(suffix: String) = "${manifest.code.orEmpty()}:$id$suffix"
+private fun Page.toAnalyticsScreenName(suffix: String?) =
+    listOfNotNull(manifest.code.orEmpty(), id, suffix).joinToString(SEPARATOR)

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
@@ -1,0 +1,12 @@
+package org.cru.godtools.tool.cyoa.analytics.model
+
+import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
+import org.cru.godtools.tool.model.page.Page
+
+open class CyoaPageAnalyticsScreenEvent(page: Page, suffix: String = "") : ToolAnalyticsScreenEvent(
+    screen = page.toAnalyticsScreenName(suffix),
+    tool = page.manifest.code,
+    locale = page.manifest.locale
+)
+
+private fun Page.toAnalyticsScreenName(suffix: String) = "${manifest.code.orEmpty()}:$id$suffix"

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -38,7 +38,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
         else -> super.onOptionsItemSelected(item)
     }
 
-    override fun onInvalidPage(fragment: CyoaPageFragment<*>, page: Page?) {
+    override fun onInvalidPage(fragment: CyoaPageFragment<*, *>, page: Page?) {
         if (fragment !== pageFragment) return
         when {
             page != null -> showPage(page, false)
@@ -76,7 +76,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
     internal val pageFragment
         get() = with(supportFragmentManager) {
             if (hasPendingActions) executePendingTransactions()
-            primaryNavigationFragment as? CyoaPageFragment<*>
+            primaryNavigationFragment as? CyoaPageFragment<*, *>
         }
     private val activePage get() = pageFragment?.page?.value
 

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
@@ -11,8 +11,12 @@ import org.cru.godtools.tool.model.page.CardCollectionPage
 import org.cru.godtools.tool.model.page.Page
 
 @AndroidEntryPoint
-class CyoaCardCollectionPageFragment(page: String? = null) :
-    CyoaPageFragment<CyoaPageCardCollectionBinding>(R.layout.cyoa_page_card_collection, page) {
+class CyoaCardCollectionPageFragment(
+    page: String? = null
+) : CyoaPageFragment<CyoaPageCardCollectionBinding, CardCollectionPageController>(
+    R.layout.cyoa_page_card_collection,
+    page
+) {
     override fun supportsPage(page: Page) = page is CardCollectionPage
 
     // region Controller

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaCardCollectionPageFragment.kt
@@ -1,9 +1,11 @@
 package org.cru.godtools.tool.cyoa.ui
 
 import androidx.lifecycle.map
+import androidx.viewpager2.widget.ViewPager2
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.cru.godtools.tool.cyoa.R
+import org.cru.godtools.tool.cyoa.analytics.model.CyoaCardCollectionPageAnalyticsScreenEvent
 import org.cru.godtools.tool.cyoa.databinding.CyoaPageCardCollectionBinding
 import org.cru.godtools.tool.cyoa.ui.controller.CardCollectionPageController
 import org.cru.godtools.tool.cyoa.ui.controller.bindController
@@ -24,8 +26,19 @@ class CyoaCardCollectionPageFragment(
     internal lateinit var controllerFactory: CardCollectionPageController.Factory
 
     override fun setupPageController(binding: CyoaPageCardCollectionBinding) {
-        controller = binding.bindController(controllerFactory, viewLifecycleOwner, toolState.toolState)
-            .also { page.map { it as? CardCollectionPage }.observe(viewLifecycleOwner, it) }
+        controller = binding.bindController(controllerFactory, viewLifecycleOwner, toolState.toolState).also {
+            page.map { it as? CardCollectionPage }.observe(viewLifecycleOwner, it)
+            binding.cards.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) = triggerAnalyticsScreenView()
+            })
+        }
     }
     // endregion Controller
+
+    // region Analytics
+    override fun triggerAnalyticsScreenView() {
+        val card = controller?.currentCard ?: return
+        eventBus.post(CyoaCardCollectionPageAnalyticsScreenEvent(card))
+    }
+    // endregion Analytics
 }

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
@@ -11,8 +11,9 @@ import org.cru.godtools.tool.model.page.ContentPage
 import org.cru.godtools.tool.model.page.Page
 
 @AndroidEntryPoint
-class CyoaContentPageFragment(page: String? = null) :
-    CyoaPageFragment<CyoaPageContentBinding>(R.layout.cyoa_page_content, page) {
+class CyoaContentPageFragment(
+    page: String? = null
+) : CyoaPageFragment<CyoaPageContentBinding, ContentPageController>(R.layout.cyoa_page_content, page) {
     override fun supportsPage(page: Page) = page is ContentPage
 
     // region Controller

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaContentPageFragment.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.map
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.cru.godtools.tool.cyoa.R
+import org.cru.godtools.tool.cyoa.analytics.model.CyoaPageAnalyticsScreenEvent
 import org.cru.godtools.tool.cyoa.databinding.CyoaPageContentBinding
 import org.cru.godtools.tool.cyoa.ui.controller.ContentPageController
 import org.cru.godtools.tool.cyoa.ui.controller.bindController
@@ -25,4 +26,11 @@ class CyoaContentPageFragment(
             .also { page.map { it as? ContentPage }.observe(viewLifecycleOwner, it) }
     }
     // endregion Controller
+
+    // region Analytics
+    override fun triggerAnalyticsScreenView() {
+        val page = page.value ?: return
+        eventBus.post(CyoaPageAnalyticsScreenEvent(page))
+    }
+    // endregion Analytics
 }

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
@@ -5,7 +5,10 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.map
+import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.findListener
+import org.ccci.gto.android.common.androidx.lifecycle.notNull
+import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.base.tool.ui.controller.BaseController
@@ -13,10 +16,14 @@ import org.cru.godtools.base.tool.viewmodel.ToolStateHolder
 import org.cru.godtools.base.ui.fragment.BaseFragment
 import org.cru.godtools.tool.cyoa.BR
 import org.cru.godtools.tool.model.page.Page
+import org.greenrobot.eventbus.EventBus
 import splitties.fragmentargs.arg
 
 abstract class CyoaPageFragment<B : ViewDataBinding, C : BaseController<*>>(@LayoutRes layoutId: Int, page: String?) :
     BaseFragment<B>(layoutId) {
+    @Inject
+    protected lateinit var eventBus: EventBus
+
     private val dataModel by activityViewModels<MultiLanguageToolActivityDataModel>()
     internal val toolState by activityViewModels<ToolStateHolder>()
     private val pageInsets by activityViewModels<PageInsets>()
@@ -31,6 +38,11 @@ abstract class CyoaPageFragment<B : ViewDataBinding, C : BaseController<*>>(@Lay
         super.onBindingCreated(binding, savedInstanceState)
         binding.setVariable(BR.contentInsets, pageInsets.insets)
         setupPageController(binding)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        page.notNull().observeOnce(this) { triggerAnalyticsScreenView() }
     }
 
     internal fun onContentEvent(event: Event) {
@@ -72,4 +84,8 @@ abstract class CyoaPageFragment<B : ViewDataBinding, C : BaseController<*>>(@Lay
     }
     // endregion Controller
     // endregion Page
+
+    // region Analytics
+    protected abstract fun triggerAnalyticsScreenView()
+    // endregion Analytics
 }

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
@@ -15,7 +15,7 @@ import org.cru.godtools.tool.cyoa.BR
 import org.cru.godtools.tool.model.page.Page
 import splitties.fragmentargs.arg
 
-abstract class CyoaPageFragment<B : ViewDataBinding>(@LayoutRes layoutId: Int, page: String?) :
+abstract class CyoaPageFragment<B : ViewDataBinding, C : BaseController<*>>(@LayoutRes layoutId: Int, page: String?) :
     BaseFragment<B>(layoutId) {
     private val dataModel by activityViewModels<MultiLanguageToolActivityDataModel>()
     internal val toolState by activityViewModels<ToolStateHolder>()
@@ -53,7 +53,7 @@ abstract class CyoaPageFragment<B : ViewDataBinding>(@LayoutRes layoutId: Int, p
 
     // region InvalidPageListener
     fun interface InvalidPageListener {
-        fun onInvalidPage(fragment: CyoaPageFragment<*>, page: Page?)
+        fun onInvalidPage(fragment: CyoaPageFragment<*, *>, page: Page?)
     }
 
     internal abstract fun supportsPage(page: Page): Boolean
@@ -64,7 +64,7 @@ abstract class CyoaPageFragment<B : ViewDataBinding>(@LayoutRes layoutId: Int, p
     // endregion InvalidPageListener
 
     // region Controller
-    protected var controller: BaseController<*>? = null
+    protected var controller: C? = null
 
     protected open fun setupPageController(binding: B) = Unit
     protected open fun cleanupPageController() {

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
@@ -78,6 +78,7 @@ class CardCollectionPageController @AssistedInject constructor(
 
     // region Cards ViewPager
     private val adapter = CyoaCardCollectionPageCardDataBindingAdapter()
+    internal val currentCard get() = model?.cards?.getOrNull(binding.cards.currentItem)
 
     init {
         with(binding.cards) {

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
@@ -9,7 +9,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlin.math.abs
+import kotlinx.coroutines.Job
 import org.ccci.gto.android.common.androidx.lifecycle.ConstrainedStateLifecycleOwner
+import org.ccci.gto.android.common.androidx.lifecycle.onPause
+import org.ccci.gto.android.common.androidx.lifecycle.onResume
 import org.ccci.gto.android.common.androidx.viewpager2.adapter.PrimaryItemChangeObserver
 import org.ccci.gto.android.common.androidx.viewpager2.adapter.onUpdatePrimaryItem
 import org.ccci.gto.android.common.androidx.viewpager2.widget.currentItemLiveData
@@ -23,6 +26,7 @@ import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
 import org.cru.godtools.tool.cyoa.R
 import org.cru.godtools.tool.cyoa.databinding.CyoaPageCardCollectionBinding
 import org.cru.godtools.tool.cyoa.databinding.CyoaPageCardCollectionCardBinding
+import org.cru.godtools.tool.model.AnalyticsEvent.Trigger
 import org.cru.godtools.tool.model.page.CardCollectionPage
 import org.cru.godtools.tool.model.page.CardCollectionPage.Card
 import org.cru.godtools.tool.state.State
@@ -44,6 +48,10 @@ class CardCollectionPageController @AssistedInject constructor(
         ): CardCollectionPageController
     }
 
+    init {
+        binding.controller = this
+    }
+
     override fun onBind() {
         super.onBind()
         binding.page = model
@@ -52,6 +60,21 @@ class CardCollectionPageController @AssistedInject constructor(
         }
     }
 
+    // region Analytics Events
+    private var pendingVisibleAnalyticsEvents: List<Job>? = null
+
+    init {
+        lifecycleOwner.lifecycle.apply {
+            onResume {
+                pendingVisibleAnalyticsEvents = triggerAnalyticsEvents(model?.getAnalyticsEvents(Trigger.VISIBLE))
+            }
+            onPause {
+                pendingVisibleAnalyticsEvents?.cancelPendingAnalyticsEvents()
+                triggerAnalyticsEvents(model?.getAnalyticsEvents(Trigger.HIDDEN))
+            }
+        }
+    }
+    // endregion Analytics Events
 
     // region Cards ViewPager
     private val adapter = CyoaCardCollectionPageCardDataBindingAdapter()
@@ -144,6 +167,22 @@ class CardCollectionPageController @AssistedInject constructor(
             binding.lifecycleOwner = lifecycleOwner
             binding.controller = this
         }
+
+        // region Analytics Events
+        private var pendingVisibleAnalyticsEvents: List<Job>? = null
+
+        init {
+            lifecycleOwner?.lifecycle?.apply {
+                onResume {
+                    pendingVisibleAnalyticsEvents = triggerAnalyticsEvents(model?.getAnalyticsEvents(Trigger.VISIBLE))
+                }
+                onPause {
+                    pendingVisibleAnalyticsEvents?.cancelPendingAnalyticsEvents()
+                    triggerAnalyticsEvents(model?.getAnalyticsEvents(Trigger.HIDDEN))
+                }
+            }
+        }
+        // endregion Analytics Events
     }
 }
 

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEventTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEventTest.kt
@@ -1,0 +1,43 @@
+package org.cru.godtools.tool.cyoa.analytics.model
+
+import java.util.Locale
+import org.cru.godtools.analytics.model.AnalyticsSystem
+import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.page.Page
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+private const val TOOL = "tool"
+private const val PAGE = "page"
+
+class CyoaPageAnalyticsScreenEventTest {
+    private val manifest: Manifest = mock {
+        on { code } doReturn TOOL
+        on { locale } doReturn Locale.ENGLISH
+    }
+    private val page: Page = mock {
+        on { manifest } doReturn manifest
+        on { id } doReturn PAGE
+    }
+
+    @Test
+    fun `Property - screen`() {
+        assertEquals("tool:page", CyoaPageAnalyticsScreenEvent(page).screen)
+    }
+
+    @Test
+    fun `isForSystem() - Supported`() {
+        val event = CyoaPageAnalyticsScreenEvent(page)
+        assertTrue(event.isForSystem(AnalyticsSystem.FIREBASE))
+    }
+
+    @Test
+    fun `isForSystem() - Not Supported`() {
+        val event = CyoaPageAnalyticsScreenEvent(page)
+        assertFalse(event.isForSystem(AnalyticsSystem.APPSFLYER))
+    }
+}

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -85,12 +85,14 @@ class CyoaActivityTest {
     private fun contentPage(id: String, stubbing: KStubbing<ContentPage>.(ContentPage) -> Unit = {}) =
         mock<ContentPage> {
             on { this.id } doReturn id
+            on { manifest } doReturn manifest()
             stubbing(it)
         }
 
     private fun cardCollectionPage(id: String, stubbing: KStubbing<CardCollectionPage>.(CardCollectionPage) -> Unit = {}) =
         mock<CardCollectionPage> {
             on { this.id } doReturn id
+            on { manifest } doReturn manifest()
             stubbing(it)
         }
 


### PR DESCRIPTION
- fire off any analytics events defined in the content xml for content pages and card collection pages
- initial pass at a CYOA analytics screen event
- add a controller generic to CyoaPageFragment
- create a screen analytics event for card collection cards
- trigger screen analytics events when viewing cyoa pages
