### PR TITLE
GT-1385 Refactor AemArticleManager to be more easily tested

### DIFF
--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/AemArticleRendererModule.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/AemArticleRendererModule.kt
@@ -28,7 +28,7 @@ abstract class AemArticleRendererModule {
     @Binds
     @IntoSet
     @EagerSingleton(on = EagerSingleton.LifecycleEvent.ACTIVITY_CREATED, threadMode = EagerSingleton.ThreadMode.ASYNC)
-    internal abstract fun aemArticleMangerEagerSingleton(aemArticleManger: AemArticleManager): Any
+    internal abstract fun aemArticleMangerDispatcherEagerSingleton(dispatcher: AemArticleManager.Dispatcher): Any
 
     companion object {
         @Provides

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -261,10 +261,8 @@ class AemArticleManager @VisibleForTesting internal constructor(
     // endregion Download Resource
 
     // region Cleanup
-    private object RunCleanup
-
     @OptIn(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
-    private val cleanupActor = coroutineScope.actor<RunCleanup>(capacity = Channel.CONFLATED) {
+    private val cleanupActor = coroutineScope.actor<Unit>(capacity = Channel.CONFLATED) {
         withTimeoutOrNull(CLEANUP_DELAY_INITIAL) { channel.receiveCatching() }
         while (!channel.isClosedForReceive) {
             fileManager.removeOrphanedFiles()
@@ -275,7 +273,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
     init {
         aemDb.invalidationTracker.addObserver(object : InvalidationTracker.Observer(Resource.TABLE_NAME) {
             override fun onInvalidated(tables: Set<String>) {
-                if (Resource.TABLE_NAME in tables) cleanupActor.trySend(RunCleanup)
+                if (Resource.TABLE_NAME in tables) cleanupActor.trySend(Unit)
             }
         })
     }

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerDispatcherTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerDispatcherTest.kt
@@ -28,7 +28,9 @@ class AemArticleManagerDispatcherTest {
     private val downloadedTranslationsFlow = MutableSharedFlow<List<Translation>>(extraBufferCapacity = 20)
 
     private val aemArticleManager = mock<AemArticleManager>()
-    private val aemDb = mock<ArticleRoomDatabase>(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val aemDb = mock<ArticleRoomDatabase>(defaultAnswer = RETURNS_DEEP_STUBS) {
+        onBlocking { aemImportDao().getAll() } doReturn emptyList()
+    }
     private val coroutineScope = TestCoroutineScope(SupervisorJob()).apply { pauseDispatcher() }
     private val dao = mock<GodToolsDao> {
         on { getAsFlow(QUERY_DOWNLOADED_ARTICLE_TRANSLATIONS) } doReturn downloadedTranslationsFlow

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerDispatcherTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerDispatcherTest.kt
@@ -1,0 +1,76 @@
+package org.cru.godtools.article.aem.service
+
+import androidx.room.InvalidationTracker
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.cru.godtools.article.aem.db.ArticleRoomDatabase
+import org.cru.godtools.article.aem.model.Resource
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AemArticleManagerDispatcherTest {
+    private val aemDb = mock<ArticleRoomDatabase>(defaultAnswer = RETURNS_DEEP_STUBS)
+    private val coroutineScope = TestCoroutineScope(SupervisorJob()).apply { pauseDispatcher() }
+    private val fileManager = mock<AemArticleManager.FileManager>()
+
+    private lateinit var dispatcher: AemArticleManager.Dispatcher
+
+    @Before
+    fun setup() {
+        dispatcher = AemArticleManager.Dispatcher(aemDb, fileManager, coroutineScope)
+    }
+
+    @After
+    fun cleanup() {
+        dispatcher.shutdown()
+        coroutineScope.cleanupTestCoroutines()
+    }
+
+    // region cleanupActor
+    @Test
+    fun `cleanupActor - Runs after pre-set delays`() {
+        coroutineScope.advanceTimeBy(CLEANUP_DELAY_INITIAL - 1)
+        verifyBlocking(fileManager, never()) { removeOrphanedFiles() }
+        coroutineScope.advanceTimeBy(1)
+        verifyBlocking(fileManager) { removeOrphanedFiles() }
+        clearInvocations(fileManager)
+
+        coroutineScope.advanceTimeBy(CLEANUP_DELAY - 1)
+        verifyBlocking(fileManager, never()) { removeOrphanedFiles() }
+        coroutineScope.advanceTimeBy(1)
+        verifyBlocking(fileManager) { removeOrphanedFiles() }
+    }
+
+    @Test
+    fun `cleanupActor - Runs after db invalidation`() {
+        val captor = argumentCaptor<InvalidationTracker.Observer>()
+        verify(aemDb.invalidationTracker).addObserver(captor.capture())
+        val observer = captor.firstValue
+
+        // multiple invalidations should be conflated to a single invalidation
+        verifyBlocking(fileManager, never()) { removeOrphanedFiles() }
+        repeat(10) { observer.onInvalidated(setOf(Resource.TABLE_NAME)) }
+        coroutineScope.runCurrent()
+        assertEquals(0, coroutineScope.currentTime)
+        verifyBlocking(fileManager) { removeOrphanedFiles() }
+        clearInvocations(fileManager)
+
+        // any invalidations should reset the cleanup delay counter
+        coroutineScope.advanceTimeBy(CLEANUP_DELAY - 1)
+        verifyBlocking(fileManager, never()) { removeOrphanedFiles() }
+        coroutineScope.advanceTimeBy(1)
+        verifyBlocking(fileManager) { removeOrphanedFiles() }
+    }
+    // endregion cleanupActor
+}

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
@@ -1,27 +1,79 @@
 package org.cru.godtools.article.aem.service
 
 import java.io.File
+import java.security.MessageDigest
+import kotlin.io.path.createTempDirectory
 import kotlinx.coroutines.runBlocking
 import org.cru.godtools.article.aem.db.ResourceDao
 import org.cru.godtools.article.aem.model.Resource
 import org.cru.godtools.article.aem.util.AemFileSystem
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.startsWith
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class AemArticleManagerFileManagerTest {
+    private val testDir = createTempDirectory().toFile()
+
     private val resourceDao = mock<ResourceDao>()
-    private val fs = mock<AemFileSystem> {
-        onBlocking { exists() } doReturn true
-        onBlocking { rootDir() } doReturn mock()
-    }
+    private val fs = spy(AemFileSystem(mock { on { filesDir } doReturn testDir }))
 
     private val fileManager = AemArticleManager.FileManager(fs, resourceDao)
+
+    @After
+    fun cleanup() {
+        testDir.deleteRecursively()
+    }
+
+    // region writeFileToDisk()
+    @Test
+    fun testWriteToDisk() = runBlocking {
+        val data = "testWriteToDisk()"
+
+        val file = data.byteInputStream().use { fileManager.writeFileToDisk(it)!! }
+        assertNotNull(file)
+        assertArrayEquals(data.toByteArray(), file.readBytes())
+    }
+
+    @Test
+    fun testWriteToDiskDedup() = runBlocking {
+        val data = "testWriteToDiskDedup()"
+
+        val file1 = data.byteInputStream().use { fileManager.writeFileToDisk(it)!! }
+        val file2 = data.byteInputStream().use { fileManager.writeFileToDisk(it)!! }
+
+        assertEquals(file1, file2)
+    }
+
+    @Test
+    fun testWriteToDiskNoDedupWithoutDigest() = runBlocking {
+        mockStatic(MessageDigest::class.java).use {
+            it.`when`<MessageDigest?> { MessageDigest.getInstance("SHA-1") } doReturn null
+            val data = "testWriteToDiskNoDedupWithoutDigest()"
+
+            val file1 = data.byteInputStream().use { fileManager.writeFileToDisk(it)!! }
+            val file2 = data.byteInputStream().use { fileManager.writeFileToDisk(it)!! }
+
+            assertNotEquals(file1, file2)
+            assertNotEquals(file1.name, file2.name)
+            assertThat(file1.name, startsWith("aem-"))
+            assertThat(file2.name, startsWith("aem-"))
+        }
+    }
+    // endregion writeFileToDisk()
 
     // region removeOrphanedFiles()
     @Test
@@ -30,7 +82,10 @@ class AemArticleManagerFileManagerTest {
         val invalidFile = mock<File>()
         val resources = listOf<Resource>(mock { onBlocking { getLocalFile(any()) } doReturn validFile })
         whenever(resourceDao.getAll()) doReturn resources
-        whenever(fs.rootDir().listFiles()) doReturn arrayOf(validFile, invalidFile)
+        val rootDir = mock<File> {
+            on { listFiles() } doReturn arrayOf(validFile, invalidFile)
+        }
+        whenever(fs.rootDir()) doReturn rootDir
 
         fileManager.removeOrphanedFiles()
         verify(resourceDao).getAll()

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
@@ -1,0 +1,50 @@
+package org.cru.godtools.article.aem.service
+
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.cru.godtools.article.aem.db.ResourceDao
+import org.cru.godtools.article.aem.model.Resource
+import org.cru.godtools.article.aem.util.AemFileSystem
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class AemArticleManagerFileManagerTest {
+    private val resourceDao = mock<ResourceDao>()
+    private val fs = mock<AemFileSystem> {
+        onBlocking { exists() } doReturn true
+        onBlocking { rootDir() } doReturn mock()
+    }
+
+    private val fileManager = AemArticleManager.FileManager(fs, resourceDao)
+
+    // region removeOrphanedFiles()
+    @Test
+    fun `removeOrphanedFiles()`(): Unit = runBlocking {
+        val validFile = mock<File>()
+        val invalidFile = mock<File>()
+        val resources = listOf<Resource>(mock { onBlocking { getLocalFile(any()) } doReturn validFile })
+        whenever(resourceDao.getAll()) doReturn resources
+        whenever(fs.rootDir().listFiles()) doReturn arrayOf(validFile, invalidFile)
+
+        fileManager.removeOrphanedFiles()
+        verify(resourceDao).getAll()
+        verify(validFile, never()).delete()
+        verify(invalidFile).delete()
+    }
+
+    @Test
+    fun `removeOrphanedFiles() - Do nothing if FileSystem doesn't exist`(): Unit = runBlocking {
+        whenever(fs.exists()) doReturn false
+
+        fileManager.removeOrphanedFiles()
+        verifyNoInteractions(resourceDao)
+        verify(fs, never()).rootDir()
+    }
+    // endregion removeOrphanedFiles()
+}

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -42,7 +42,6 @@ class AemArticleManagerTest {
     @Before
     fun setup() {
         aemDb = mock(defaultAnswer = RETURNS_DEEP_STUBS) {
-            onBlocking { aemImportDao().getAll() } doReturn emptyList()
             onBlocking { resourceDao().getAll() } doReturn emptyList()
         }
         api = mock()


### PR DESCRIPTION
- Split off file manager and dispatcher logic from core `AemArticleManager`
- Split up tests to test dispatcher and file manager parts independently