### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Upload QA Build to Firebase
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :app:packageProductionQaUniversalApk appDistributionUploadProductionQa -PfirebaseAppDistributionBuild
+          arguments: :app:packageProductionQaUniversalApk appDistributionUploadProductionQa -PfirebaseAppDistributionBuild --scan
         env:
           ORG_GRADLE_PROJECT_firebaseAppDistributionKeystoreStorePassword: ${{ secrets.BETA_KEYSTORE_PASSWORD }}
           ORG_GRADLE_PROJECT_firebaseAppDistributionKeystoreKeyPassword: ${{ secrets.BETA_KEYSTORE_PASSWORD }}          

--- a/app/src/main/java/org/cru/godtools/ui/languages/paralleldialog/LanguagesAdapter.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/paralleldialog/LanguagesAdapter.kt
@@ -3,7 +3,7 @@ package org.cru.godtools.ui.languages.paralleldialog
 import android.content.Context
 import android.widget.Filter
 import org.ccci.gto.android.common.androidx.databinding.widget.DataBindingArrayAdapter
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.R
 import org.cru.godtools.base.util.deviceLocale
 import org.cru.godtools.databinding.LanguagesParallelDialogItemBinding as ItemBinding
@@ -11,7 +11,7 @@ import org.cru.godtools.model.Language
 
 class LanguagesAdapter(context: Context) :
     DataBindingArrayAdapter<ItemBinding, Language>(context, R.layout.languages_parallel_dialog_item) {
-    override fun getItemId(position: Int) = getItem(position)?.code?.let { IdUtils.convertId(it) } ?: -1
+    override fun getItemId(position: Int) = getItem(position)?.code?.let { Ids.generate(it) } ?: -1
 
     override fun onBindingCreated(binding: ItemBinding) = Unit
     override fun onBind(binding: ItemBinding, position: Int) {

--- a/app/src/main/java/org/cru/godtools/ui/languages/paralleldialog/ParallelLanguageDialogFragment.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/paralleldialog/ParallelLanguageDialogFragment.kt
@@ -17,7 +17,7 @@ import org.ccci.gto.android.common.androidx.fragment.app.DataBindingDialogFragme
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.getAsLiveData
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.R
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.util.deviceLocale
@@ -58,7 +58,7 @@ class ParallelLanguageDialogFragment :
 
         // TODO: can this be done in data binding?
         binding.parallelLanguage.setOnItemClickListener { _, _, _, id ->
-            dataModel.selectedLocale.value = IdUtils.convertId(id) as? Locale
+            dataModel.selectedLocale.value = Ids.lookup(id) as? Locale
         }
     }
 

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
@@ -2,7 +2,8 @@ package org.cru.godtools.base
 
 import android.content.Context
 import java.io.File
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -10,6 +11,7 @@ import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FileSystemTest {
     private lateinit var context: Context
     private val rootDir = File.createTempFile("abc", null).parentFile!!
@@ -25,7 +27,7 @@ class FileSystemTest {
     }
 
     @Test
-    fun testExists() = runBlockingTest {
+    fun testExists() = runTest {
         assertTrue(fileSystem.exists())
         assertEquals(File(rootDir, "resources"), fileSystem.rootDir())
     }

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -63,8 +63,6 @@ import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
 
-private const val TAG = "GodToolsDownloadManager"
-
 @VisibleForTesting
 internal const val CLEANUP_DELAY = HOUR_IN_MS
 @VisibleForTesting

--- a/library/initial-content/src/main/java/org/cru/godtools/init/content/InitialContentImporter.kt
+++ b/library/initial-content/src/main/java/org/cru/godtools/init/content/InitialContentImporter.kt
@@ -2,16 +2,18 @@ package org.cru.godtools.init.content
 
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.cru.godtools.init.content.task.Tasks
 
 @Singleton
 class InitialContentImporter @Inject internal constructor(tasks: Tasks) {
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+
     init {
-        GlobalScope.launch(Dispatchers.IO) {
+        coroutineScope.launch(Dispatchers.IO) {
             val languages = async {
                 tasks.loadBundledLanguages()
                 tasks.initSystemLanguages()

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -70,13 +70,20 @@ internal val QUERY_DOWNLOADED_ARTICLE_TRANSLATIONS = Query.select<Translation>()
     .where(ToolTable.FIELD_TYPE.eq(Tool.Type.ARTICLE).and(TranslationTable.SQL_WHERE_DOWNLOADED))
 
 @Singleton
-class AemArticleManager @Inject internal constructor(
+class AemArticleManager @VisibleForTesting internal constructor(
     private val aemDb: ArticleRoomDatabase,
     private val api: AemApi,
     private val fileManager: FileManager,
-    private val manifestManager: ManifestManager
+    private val manifestManager: ManifestManager,
+    private val coroutineScope: CoroutineScope
 ) {
-    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    @Inject
+    internal constructor(
+        aemDb: ArticleRoomDatabase,
+        api: AemApi,
+        fileManager: FileManager,
+        manifestManager: ManifestManager
+    ) : this(aemDb, api, fileManager, manifestManager, CoroutineScope(Dispatchers.Default + SupervisorJob()))
 
     private val aemImportMutex = MutexMap()
     private val articleMutex = MutexMap()

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesAdapter.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/articles/ArticlesAdapter.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView.NO_ID
 import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.article.aem.model.Article
 import org.cru.godtools.article.databinding.ListItemArticleBinding
 import org.cru.godtools.tool.model.Manifest
@@ -34,7 +34,7 @@ class ArticlesAdapter(
 
     override fun getItemCount() = articles?.size ?: 0
     private fun getItem(position: Int) = articles?.get(position)
-    override fun getItemId(position: Int) = getItem(position)?.uri?.let { IdUtils.convertId(it) } ?: NO_ID
+    override fun getItemId(position: Int) = getItem(position)?.uri?.let { Ids.generate(it) } ?: NO_ID
 
     // region Lifecycle
     override fun onChanged(articles: List<Article>?) {

--- a/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesAdapter.kt
+++ b/ui/article-renderer/src/main/java/org/cru/godtools/article/ui/categories/CategoriesAdapter.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.RecyclerView.NO_ID
 import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.article.databinding.ListItemCategoryBinding
 import org.cru.godtools.tool.model.Category
 
@@ -26,7 +26,7 @@ internal class CategoriesAdapter(lifecycleOwner: LifecycleOwner? = null) :
 
     override fun getItemCount() = categories?.size ?: 0
     private fun getItem(position: Int) = categories?.get(position)
-    override fun getItemId(position: Int) = getItem(position)?.id?.let { IdUtils.convertId(it) } ?: NO_ID
+    override fun getItemId(position: Int) = getItem(position)?.id?.let { Ids.generate(it) } ?: NO_ID
 
     // region Lifecycle
     override fun onChanged(t: List<Category>?) {

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
@@ -12,8 +12,7 @@ import androidx.core.content.res.ResourcesCompat
 import java.util.Locale
 import org.cru.godtools.base.ui.R
 
-@OptIn(ExperimentalStdlibApi::class)
-private val typefaces = buildMap<Locale, Int> {
+private val typefaces = buildMap {
     // Sinhala, only needed for Android pre-Marshmallow
     //
     // https://forum.xda-developers.com/android/general/font-sinhala-font-android-5-0-lollipop-t3150536

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.gtoSupport.androidx.viewpager2)
     implementation(libs.gtoSupport.materialComponents)
     implementation(libs.gtoSupport.recyclerview)
+    implementation(libs.gtoSupport.util)
 
     implementation(libs.godtoolsMpp.parser)
     implementation(libs.hilt)

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/controller/CardCollectionPageController.kt
@@ -19,7 +19,7 @@ import org.ccci.gto.android.common.androidx.viewpager2.widget.currentItemLiveDat
 import org.ccci.gto.android.common.androidx.viewpager2.widget.whileMaintainingVisibleCurrentItem
 import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
 import org.ccci.gto.android.common.recyclerview.decorator.MarginItemDecoration
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.base.tool.ui.controller.BaseController
 import org.cru.godtools.base.tool.ui.controller.ParentController
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
@@ -116,7 +116,7 @@ class CardCollectionPageController @AssistedInject constructor(
             }
 
         override fun getItemCount() = cards.size
-        override fun getItemId(position: Int) = IdUtils.convertId(cards[position].id)
+        override fun getItemId(position: Int) = Ids.generate(cards[position].id)
 
         // region Lifecycle
         override fun onCreateViewDataBinding(parent: ViewGroup, viewType: Int) =

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.gtoSupport.eventbus)
     implementation(libs.gtoSupport.materialComponents)
     implementation(libs.gtoSupport.recyclerview)
+    implementation(libs.gtoSupport.util)
 
     implementation(libs.godtoolsMpp.parser)
     implementation(libs.hilt)

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -151,7 +151,7 @@ class LessonActivity :
     }
 
     private fun checkForPageEvent(event: Event) {
-        val page = dataModel.manifest.value?.lessonPages?.firstOrNull { it.listeners.contains(event.id) }
+        val page = dataModel.manifest.value?.pages?.firstOrNull { it.listeners.contains(event.id) }
         if (page != null) {
             dataModel.visiblePages += page.id
             dataModel.pages.value?.indexOfFirst { it.id == page.id }?.takeIf { it >= 0 }?.let {
@@ -211,7 +211,7 @@ class LessonActivityDataModel @Inject constructor(
     val visiblePages = SetLiveData<String>(synchronous = true)
 
     val pages = manifest.combineWith(visiblePages) { manifest, visible ->
-        manifest?.lessonPages.orEmpty().filter { !it.isHidden || it.id in visible }
+        manifest?.pages.orEmpty().filterIsInstance<LessonPage>().filter { !it.isHidden || it.id in visible }
     }.distinctUntilChanged()
 
     val pageReached = savedState.getLiveData("pageReached", 0)

--- a/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonPageAdapter.kt
+++ b/ui/lesson-renderer/src/main/java/org/cru/godtools/tool/lesson/ui/LessonPageAdapter.kt
@@ -11,7 +11,7 @@ import dagger.assisted.AssistedInject
 import org.ccci.gto.android.common.androidx.viewpager2.adapter.PrimaryItemChangeObserver
 import org.ccci.gto.android.common.androidx.viewpager2.adapter.onUpdatePrimaryItem
 import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.cru.godtools.tool.lesson.databinding.LessonPageBinding
 import org.cru.godtools.tool.lesson.ui.controller.LessonPageController
 import org.cru.godtools.tool.lesson.ui.controller.bindController
@@ -48,7 +48,7 @@ class LessonPageAdapter @AssistedInject internal constructor(
 
     override fun getItemCount() = pages.size
     private fun getItem(position: Int) = pages[position]
-    override fun getItemId(position: Int) = IdUtils.convertId(getItem(position).id)
+    override fun getItemId(position: Int) = Ids.generate(getItem(position).id)
 
     // region Lifecycle
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
@@ -11,7 +11,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import org.ccci.gto.android.common.eventbus.lifecycle.register
-import org.ccci.gto.android.common.support.v4.util.IdUtils
+import org.ccci.gto.android.common.util.Ids
 import org.ccci.gto.android.common.viewpager.adapter.DataBindingPagerAdapter
 import org.ccci.gto.android.common.viewpager.adapter.DataBindingViewHolder
 import org.cru.godtools.api.model.NavigationEvent
@@ -63,9 +63,9 @@ class ManifestPagerAdapter @AssistedInject internal constructor(
 
     override fun getCount() = manifest?.tractPages?.size ?: 0
     private fun getItem(position: Int) = manifest?.tractPages?.getOrNull(position)
-    override fun getItemId(position: Int) = getItem(position)?.id?.let { IdUtils.convertId(it) } ?: NO_ID
+    override fun getItemId(position: Int) = getItem(position)?.id?.let { Ids.generate(it) } ?: NO_ID
     override fun getItemPositionFromId(id: Long) =
-        manifest?.tractPages?.indexOfFirst { id == IdUtils.convertId(it.id) } ?: PagerAdapter.POSITION_NONE
+        manifest?.tractPages?.indexOfFirst { id == Ids.generate(it.id) } ?: PagerAdapter.POSITION_NONE
 
     private val primaryItemController get() = primaryItemBinding?.controller
     private val primaryItemPage get() = primaryItemController?.model


### PR DESCRIPTION
- buildMap no longer requires OptIn
- remove unused TAG
- don't use the GlobalScope to launch the initial content import
- use the new Ids util
- enable build scans for the QA build
- fix some coroutines flakiness with AemArticleManagerTest
