### PR TITLE
GT-1349 Use WorkManager to update tools when the user is online

### DIFF
--- a/app/src/main/java/org/cru/godtools/GodToolsApplication.kt
+++ b/app/src/main/java/org/cru/godtools/GodToolsApplication.kt
@@ -2,21 +2,26 @@ package org.cru.godtools
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.google.android.instantapps.InstantApps
 import com.google.android.play.core.missingsplits.MissingSplitsManagerFactory
 import com.google.android.play.core.splitcompat.SplitCompat
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import java.util.Locale
 import javax.inject.Inject
+import org.ccci.gto.android.common.androidx.work.TimberLogger
 import org.ccci.gto.android.common.dagger.eager.EagerSingletonInitializer
 import org.ccci.gto.android.common.firebase.crashlytics.timber.CrashlyticsTree
 import org.ccci.gto.android.common.util.LocaleUtils
 import timber.log.Timber
 
 @HiltAndroidApp
-open class GodToolsApplication : Application() {
+open class GodToolsApplication : Application(), Configuration.Provider {
     @Inject
     internal lateinit var eagerInitializer: EagerSingletonInitializer
 
@@ -60,4 +65,14 @@ open class GodToolsApplication : Application() {
         }
         Timber.plant(CrashlyticsTree())
     }
+
+    // region WorkManager Configuration.Provider
+    init {
+        TimberLogger(Log.ERROR).install()
+    }
+
+    @Inject
+    internal lateinit var workerFactory: Lazy<HiltWorkerFactory>
+    override fun getWorkManagerConfiguration() = Configuration.Builder().setWorkerFactory(workerFactory.get()).build()
+    // endregion WorkManager Configuration.Provider
 }

--- a/app/src/main/java/org/cru/godtools/dagger/ServicesModule.kt
+++ b/app/src/main/java/org/cru/godtools/dagger/ServicesModule.kt
@@ -1,21 +1,18 @@
 package org.cru.godtools.dagger
 
 import android.content.Context
-import android.util.Log
-import androidx.hilt.work.HiltWorkerFactory
-import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.squareup.picasso.Picasso
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import dagger.Reusable
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import io.github.aakira.napier.Napier
 import javax.inject.Singleton
-import org.ccci.gto.android.common.androidx.work.TimberLogger
 import org.ccci.gto.android.common.dagger.eager.EagerModule
 import org.ccci.gto.android.common.dagger.eager.EagerSingleton
 import org.ccci.gto.android.common.dagger.splitinstall.SplitInstallModule
@@ -35,11 +32,6 @@ abstract class ServicesModule {
     @EagerSingleton(threadMode = EagerSingleton.ThreadMode.ASYNC)
     abstract fun eagerAccountListRegistrationService(service: AccountListRegistrationService): Any
 
-    @Binds
-    @IntoSet
-    @EagerSingleton(threadMode = EagerSingleton.ThreadMode.MAIN)
-    abstract fun eagerWorkManager(workManager: WorkManager): Any
-
     companion object {
         @Provides
         @Singleton
@@ -52,11 +44,7 @@ abstract class ServicesModule {
         fun napierConfig(): Any = Napier.apply { base(TimberAntilog) }
 
         @Provides
-        @Singleton
-        fun workManager(@ApplicationContext context: Context, workerFactory: HiltWorkerFactory): WorkManager {
-            WorkManager.initialize(context, Configuration.Builder().setWorkerFactory(workerFactory).build())
-            TimberLogger(Log.ERROR).install()
-            return WorkManager.getInstance(context)
-        }
+        @Reusable
+        fun workManager(@ApplicationContext context: Context) = WorkManager.getInstance(context)
     }
 }

--- a/library/download-manager/build.gradle.kts
+++ b/library/download-manager/build.gradle.kts
@@ -8,6 +8,10 @@ dependencies {
     implementation(project(":library:db"))
     implementation(project(":library:model"))
 
+    api(libs.androidx.hilt.work)
+    api(libs.androidx.work.ktx)
+
+    implementation(libs.gtoSupport.androidx.work)
     implementation(libs.gtoSupport.base)
     implementation(libs.gtoSupport.compat)
     implementation(libs.gtoSupport.dagger)

--- a/library/download-manager/src/main/java/org/cru/godtools/download/manager/work/DownloadLatestPublishedTranslationWorker.kt
+++ b/library/download-manager/src/main/java/org/cru/godtools/download/manager/work/DownloadLatestPublishedTranslationWorker.kt
@@ -1,0 +1,58 @@
+package org.cru.godtools.download.manager.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.ccci.gto.android.common.androidx.work.getLocale
+import org.ccci.gto.android.common.androidx.work.putLocale
+import org.cru.godtools.download.manager.GodToolsDownloadManager
+import org.cru.godtools.model.TranslationKey
+
+private const val WORK_NAME = "DownloadTranslation"
+private const val TAG_DOWNLOAD_MANAGER = "DownloadManager"
+private const val KEY_TRANSLATION = "translation"
+
+internal fun WorkManager.scheduleDownloadTranslationWork(key: TranslationKey) = enqueueUniqueWork(
+    key.workName,
+    ExistingWorkPolicy.KEEP,
+    OneTimeWorkRequestBuilder<DownloadLatestPublishedTranslationWorker>()
+        .addTag(TAG_DOWNLOAD_MANAGER)
+        .setConstraints(
+            Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.UNMETERED)
+                .build()
+        )
+        .setInputData(
+            Data.Builder()
+                .putTranslationKey(KEY_TRANSLATION, key)
+                .build()
+        )
+        .build()
+)
+
+@HiltWorker
+internal class DownloadLatestPublishedTranslationWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val downloadManager: GodToolsDownloadManager
+) : CoroutineWorker(context, workerParams) {
+    override suspend fun doWork(): Result {
+        val key = inputData.getTranslationKey(KEY_TRANSLATION)
+        return if (downloadManager.downloadLatestPublishedTranslation(key)) Result.success() else Result.retry()
+    }
+}
+
+private val TranslationKey.workName get() = "$WORK_NAME:$tool:${locale?.toLanguageTag()}"
+
+private fun Data.Builder.putTranslationKey(key: String, translation: TranslationKey) =
+    putString("$key:tool", translation.tool).putLocale("$key:locale", translation.locale)
+private fun Data.getTranslationKey(key: String) = TranslationKey(getString("$key:tool"), getLocale("$key:locale"))

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.download.manager
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
+import androidx.work.WorkManager
 import java.io.File
 import java.util.Locale
 import kotlin.random.Random
@@ -88,6 +89,7 @@ class GodToolsDownloadManagerTest {
     private lateinit var fs: ToolFileSystem
     private lateinit var settings: Settings
     private lateinit var translationsApi: TranslationsApi
+    private lateinit var workManager: WorkManager
     private lateinit var testScope: TestCoroutineScope
 
     private lateinit var downloadManager: GodToolsDownloadManager
@@ -115,10 +117,19 @@ class GodToolsDownloadManagerTest {
         observer = mock()
         settings = mock()
         translationsApi = mock()
+        workManager = mock()
         testScope = TestCoroutineScope()
 
         downloadManager = GodToolsDownloadManager(
-            attachmentsApi, dao, eventBus, fs, settings, translationsApi, testScope, testScope.coroutineContext
+            attachmentsApi,
+            dao,
+            eventBus,
+            fs,
+            settings,
+            translationsApi,
+            { workManager },
+            testScope,
+            testScope.coroutineContext
         )
     }
 

--- a/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/java/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -2,8 +2,10 @@ package org.cru.godtools.download.manager
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
+import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import java.io.File
+import java.io.IOException
 import java.util.Locale
 import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -13,6 +15,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.find
@@ -54,6 +57,7 @@ import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -68,6 +72,8 @@ import org.mockito.kotlin.stubbing
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import retrofit2.Response
 
@@ -117,7 +123,9 @@ class GodToolsDownloadManagerTest {
         observer = mock()
         settings = mock()
         translationsApi = mock()
-        workManager = mock()
+        workManager = mock {
+            on { enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) } doReturn mock()
+        }
         testScope = TestCoroutineScope()
 
         downloadManager = GodToolsDownloadManager(
@@ -433,26 +441,23 @@ class GodToolsDownloadManagerTest {
         isDownloaded = false
     }
 
+    // region downloadLatestPublishedTranslation()
     @Test
-    fun verifyDownloadLatestPublishedTranslation() {
+    fun `downloadLatestPublishedTranslation()`() = runTest {
         val files = Array(3) { getTmpFile() }
         downloadManager.getDownloadProgressLiveData(TOOL, Locale.FRENCH).observeForever(observer)
-        dao.stub {
-            on { getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true) } doReturn translation
-        }
+        whenever(dao.getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true)) doReturn translation
         fs.stub {
             onBlocking { file("a.txt") } doReturn files[0]
             onBlocking { file("b.txt") } doReturn files[1]
             onBlocking { file("c.txt") } doReturn files[2]
         }
         val response: ResponseBody = mock { on { byteStream() } doReturn getInputStreamForResource("abc.zip") }
-        translationsApi.stub {
-            onBlocking { download(translation.id) } doReturn Response.success(response)
-        }
+        whenever(translationsApi.download(translation.id)) doReturn Response.success(response)
 
-        runBlocking { downloadManager.downloadLatestPublishedTranslation(TranslationKey(translation)) }
+        assertTrue(downloadManager.downloadLatestPublishedTranslation(TranslationKey(translation)))
         verify(dao).getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true)
-        runBlocking { verify(translationsApi).download(translation.id) }
+        verify(translationsApi).download(translation.id)
         assertArrayEquals("a".repeat(1024).toByteArray(), files[0].readBytes())
         assertArrayEquals("b".repeat(1024).toByteArray(), files[1].readBytes())
         assertArrayEquals("c".repeat(1024).toByteArray(), files[2].readBytes())
@@ -465,11 +470,32 @@ class GodToolsDownloadManagerTest {
         verify(dao).update(translation, TranslationTable.COLUMN_DOWNLOADED)
         assertTrue(translation.isDownloaded)
         verify(eventBus).post(TranslationUpdateEvent)
+        verifyNoInteractions(workManager)
         argumentCaptor<DownloadProgress> {
             verify(observer, atLeastOnce()).onChanged(capture())
             assertNull(lastValue)
         }
     }
+
+    @Test
+    fun `downloadLatestPublishedTranslation() - API IOException`() = runTest {
+        downloadManager.getDownloadProgressLiveData(TOOL, Locale.FRENCH).observeForever(observer)
+        whenever(dao.getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true)) doReturn translation
+        whenever(translationsApi.download(translation.id)) doAnswer { throw IOException() }
+        clearInvocations(dao)
+
+        assertFalse(downloadManager.downloadLatestPublishedTranslation(TranslationKey(translation)))
+        verify(dao).getLatestTranslation(TOOL, Locale.FRENCH, isPublished = true)
+        verify(translationsApi).download(translation.id)
+        verify(workManager).enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>())
+        verifyNoMoreInteractions(dao)
+        verifyNoInteractions(eventBus)
+        argumentCaptor<DownloadProgress> {
+            verify(observer, atLeastOnce()).onChanged(capture())
+            assertNull(lastValue)
+        }
+    }
+    // endregion downloadLatestPublishedTranslation()
 
     @Test
     fun verifyImportTranslation() {

--- a/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -22,6 +22,7 @@ import org.cru.godtools.sync.task.FollowupSyncTasks
 import org.cru.godtools.sync.task.LanguagesSyncTasks
 import org.cru.godtools.sync.task.ToolSyncTasks
 import org.cru.godtools.sync.work.scheduleSyncFollowupWork
+import org.cru.godtools.sync.work.scheduleSyncLanguagesWork
 import org.cru.godtools.sync.work.scheduleSyncToolSharesWork
 import org.cru.godtools.sync.work.scheduleSyncToolsWork
 import org.greenrobot.eventbus.EventBus
@@ -54,7 +55,9 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
         coroutineScope.launch {
             try {
                 when (syncType) {
-                    SYNCTYPE_LANGUAGES -> with<LanguagesSyncTasks> { syncLanguages(task.args) }
+                    SYNCTYPE_LANGUAGES -> with<LanguagesSyncTasks> {
+                        if (!syncLanguages(task.args)) workManager.scheduleSyncLanguagesWork()
+                    }
                     SYNCTYPE_TOOLS -> with<ToolSyncTasks> {
                         if (!syncTools(task.args)) workManager.scheduleSyncToolsWork()
                     }
@@ -69,6 +72,7 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
             } catch (e: IOException) {
                 // queue up work tasks here because of the IOException
                 when (syncType) {
+                    SYNCTYPE_LANGUAGES -> workManager.scheduleSyncLanguagesWork()
                     SYNCTYPE_TOOLS -> workManager.scheduleSyncToolsWork()
                     SYNCTYPE_TOOL_SHARES -> workManager.scheduleSyncToolSharesWork()
                     SYNCTYPE_FOLLOWUPS -> workManager.scheduleSyncFollowupWork()

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -46,7 +46,7 @@ class ToolSyncTasks @Inject internal constructor(
     private val sharesMutex = Mutex()
 
     @AnyThread
-    suspend fun syncTools(args: Bundle) = withContext(Dispatchers.IO) {
+    suspend fun syncTools(args: Bundle = Bundle.EMPTY) = withContext(Dispatchers.IO) {
         toolsMutex.withLock {
             // short-circuit if we aren't forcing a sync and the data isn't stale
             if (!isForced(args) &&

--- a/library/sync/src/main/java/org/cru/godtools/sync/work/SyncFollowupWorker.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/work/SyncFollowupWorker.kt
@@ -13,10 +13,10 @@ import org.cru.godtools.sync.task.FollowupSyncTasks
 private const val WORK_NAME = "SyncFollowup"
 
 internal fun WorkManager.scheduleSyncFollowupWork() =
-    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, SyncWorkRequestBuilder<SyncFollowupWorker>().build())
+    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SyncWorkRequestBuilder<SyncFollowupWorker>().build())
 
 @HiltWorker
-class SyncFollowupWorker @AssistedInject constructor(
+internal class SyncFollowupWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted workerParams: WorkerParameters,
     private val followupSyncTasks: FollowupSyncTasks

--- a/library/sync/src/main/java/org/cru/godtools/sync/work/SyncLanguagesWorker.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/work/SyncLanguagesWorker.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.sync.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.cru.godtools.sync.task.LanguagesSyncTasks
+
+private const val WORK_NAME = "SyncTools"
+
+internal fun WorkManager.scheduleSyncLanguagesWork() =
+    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SyncWorkRequestBuilder<SyncLanguagesWorker>().build())
+
+@HiltWorker
+internal class SyncLanguagesWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val languageSyncTasks: LanguagesSyncTasks
+) : CoroutineWorker(context, workerParams) {
+    override suspend fun doWork() = if (languageSyncTasks.syncLanguages()) Result.success() else Result.retry()
+}

--- a/library/sync/src/main/java/org/cru/godtools/sync/work/SyncToolSharesWorker.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/work/SyncToolSharesWorker.kt
@@ -13,10 +13,10 @@ import org.cru.godtools.sync.task.ToolSyncTasks
 private const val WORK_NAME = "SyncToolShares"
 
 internal fun WorkManager.scheduleSyncToolSharesWork() =
-    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, SyncWorkRequestBuilder<SyncToolSharesWorker>().build())
+    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SyncWorkRequestBuilder<SyncToolSharesWorker>().build())
 
 @HiltWorker
-class SyncToolSharesWorker @AssistedInject constructor(
+internal class SyncToolSharesWorker @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted workerParams: WorkerParameters,
     private val toolSyncTasks: ToolSyncTasks

--- a/library/sync/src/main/java/org/cru/godtools/sync/work/SyncToolsWorker.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/work/SyncToolsWorker.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.sync.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.cru.godtools.sync.task.ToolSyncTasks
+
+private const val WORK_NAME = "SyncTools"
+
+internal fun WorkManager.scheduleSyncToolsWork() =
+    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SyncWorkRequestBuilder<SyncToolsWorker>().build())
+
+@HiltWorker
+internal class SyncToolsWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val toolSyncTasks: ToolSyncTasks
+) : CoroutineWorker(context, workerParams) {
+    override suspend fun doWork() = if (toolSyncTasks.syncTools()) Result.success() else Result.retry()
+}


### PR DESCRIPTION
- support deferred initialization of WorkManager
- keep existing work to avoid reseting backoff timers
- when syncing tools fails, reschedule with workmanager
- use WorkManager to retry languages sync the next time the device is online
- use WorkManager to reschedule a tool download if it failed
