### PR TITLE
GT-1382 Track & Sync User counters with the API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ gtoSupport-androidx-room = { module = "org.ccci.gto.android:gto-support-androidx
 gtoSupport-androidx-viewpager2 = { module = "org.ccci.gto.android:gto-support-androidx-viewpager2", version.ref = "gtoSupport" }
 gtoSupport-androidx-work = { module = "org.ccci.gto.android:gto-support-androidx-work", version.ref = "gtoSupport" }
 gtoSupport-animation = { module = "org.ccci.gto.android:gto-support-animation", version.ref = "gtoSupport" }
+gtoSupport-api-okhttp3 = { module = "org.ccci.gto.android:gto-support-api-okhttp3", version.ref = "gtoSupport" }
 gtoSupport-appcompat = { module = "org.ccci.gto.android:gto-support-appcompat", version.ref = "gtoSupport" }
 gtoSupport-base = { module = "org.ccci.gto.android:gto-support-base", version.ref = "gtoSupport" }
 gtoSupport-compat = { module = "org.ccci.gto.android:gto-support-compat", version.ref = "gtoSupport" }

--- a/library/api/build.gradle.kts
+++ b/library/api/build.gradle.kts
@@ -11,8 +11,10 @@ dependencies {
     api(libs.gtoSupport.jsonapi.retrofit2)
     api(libs.gtoSupport.scarlet)
     api(libs.gtoSupport.scarlet.actioncable)
+    implementation(libs.gtoSupport.api.okhttp3)
     implementation(libs.gtoSupport.dagger)
     implementation(libs.gtoSupport.jsonapi.scarlet)
+    implementation(libs.gtoSupport.okta)
     implementation(libs.gtoSupport.retrofit2)
     implementation(libs.gtoSupport.util)
 
@@ -21,6 +23,7 @@ dependencies {
     implementation(libs.dagger)
     implementation(libs.hilt)
     implementation(libs.kotlin.coroutines)
+    implementation(libs.okta)
     implementation(libs.scarlet.lifecycle.android)
     implementation(libs.scarlet.adapters.stream.coroutines)
     implementation(libs.scarlet.websockets.okhttp)

--- a/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
@@ -37,6 +37,7 @@ import org.cru.godtools.model.GlobalActivityAnalytics
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
+import org.cru.godtools.model.UserCounter
 import org.cru.godtools.model.jsonapi.ToolTypeConverter
 import retrofit2.Retrofit
 import retrofit2.create
@@ -65,6 +66,7 @@ object ApiModule {
         .addClasses(AuthToken.Request::class.java, AuthToken::class.java)
         .addClasses(GlobalActivityAnalytics::class.java)
         .addClasses(PublisherInfo::class.java, NavigationEvent::class.java)
+        .addClasses(UserCounter::class.java)
         .addConverters(ToolTypeConverter)
         .addConverters(LocaleTypeConverter)
         .build()
@@ -129,6 +131,10 @@ object ApiModule {
     @Provides
     @Reusable
     fun @receiver:Named(MOBILE_CONTENT_API) Retrofit.translationsApi() = create<TranslationsApi>()
+
+    @Provides
+    @Reusable
+    fun @receiver:Named(MOBILE_CONTENT_API_AUTHENTICATED) Retrofit.userCountersApi() = create<UserCountersApi>()
 
     @Provides
     @Reusable

--- a/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/ApiModule.kt
@@ -27,6 +27,7 @@ import org.ccci.gto.android.common.retrofit2.converter.LocaleConverterFactory
 import org.ccci.gto.android.common.scarlet.ReferenceLifecycle
 import org.ccci.gto.android.common.scarlet.actioncable.ActionCableMessageAdapterFactory
 import org.ccci.gto.android.common.scarlet.actioncable.okhttp3.ActionCableRequestFactory
+import org.cru.godtools.api.model.AuthToken
 import org.cru.godtools.api.model.NavigationEvent
 import org.cru.godtools.api.model.PublisherInfo
 import org.cru.godtools.api.model.ToolViews
@@ -61,6 +62,7 @@ object ApiModule {
         .addClasses(Attachment::class.java)
         .addClasses(Translation::class.java)
         .addClasses(Followup::class.java)
+        .addClasses(AuthToken.Request::class.java, AuthToken::class.java)
         .addClasses(GlobalActivityAnalytics::class.java)
         .addClasses(PublisherInfo::class.java, NavigationEvent::class.java)
         .addConverters(ToolTypeConverter)
@@ -70,6 +72,7 @@ object ApiModule {
     // region mobile-content-api APIs
     const val MOBILE_CONTENT_API_URL = "MOBILE_CONTENT_API_BASE_URL"
     private const val MOBILE_CONTENT_API = "MOBILE_CONTENT_API"
+    private const val MOBILE_CONTENT_API_AUTHENTICATED = "MOBILE_CONTENT_API_AUTHENTICATED"
 
     @Provides
     @Reusable
@@ -87,11 +90,29 @@ object ApiModule {
 
     @Provides
     @Reusable
+    @Named(MOBILE_CONTENT_API_AUTHENTICATED)
+    fun mobileContentApiAuthenticatedRetrofit(
+        @Named(MOBILE_CONTENT_API) retrofit: Retrofit,
+        okhttp: OkHttpClient,
+        sessionInterceptor: GodToolsSessionInterceptor
+    ): Retrofit = retrofit.newBuilder()
+        .callFactory(
+            okhttp.newBuilder()
+                .addInterceptor(sessionInterceptor)
+                .build()
+        ).build()
+
+    @Provides
+    @Reusable
     fun @receiver:Named(MOBILE_CONTENT_API) Retrofit.analyticsApi() = create<AnalyticsApi>()
 
     @Provides
     @Reusable
     fun @receiver:Named(MOBILE_CONTENT_API) Retrofit.attachmentsApi() = create<AttachmentsApi>()
+
+    @Provides
+    @Reusable
+    fun @receiver:Named(MOBILE_CONTENT_API) Retrofit.authApi() = create<AuthApi>()
 
     @Provides
     @Reusable

--- a/library/api/src/main/java/org/cru/godtools/api/AuthApi.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/AuthApi.kt
@@ -1,0 +1,14 @@
+package org.cru.godtools.api
+
+import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
+import org.cru.godtools.api.model.AuthToken
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+private const val PATH_AUTHENTICATE = "auth"
+
+interface AuthApi {
+    @POST(PATH_AUTHENTICATE)
+    fun authenticate(@Body request: AuthToken.Request): Call<JsonApiObject<AuthToken>>
+}

--- a/library/api/src/main/java/org/cru/godtools/api/GodToolsSessionInterceptor.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/GodToolsSessionInterceptor.kt
@@ -1,0 +1,58 @@
+package org.cru.godtools.api
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.okta.oidc.Tokens
+import com.okta.oidc.clients.sessions.SessionClient
+import com.okta.oidc.util.AuthorizationException
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.net.HttpURLConnection
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.runBlocking
+import okhttp3.Request
+import okhttp3.Response
+import org.ccci.gto.android.common.api.UserIdSession
+import org.ccci.gto.android.common.api.okhttp3.interceptor.SessionInterceptor
+import org.ccci.gto.android.common.okta.oidc.clients.sessions.oktaUserId
+import org.ccci.gto.android.common.okta.oidc.clients.sessions.refreshToken
+import org.ccci.gto.android.common.okta.oidc.oktaUserId
+import org.cru.godtools.api.model.AuthToken
+
+private const val HTTP_HEADER_AUTHORIZATION = "Authorization"
+
+@Singleton
+class GodToolsSessionInterceptor @Inject constructor(
+    @ApplicationContext context: Context,
+    private val authApi: AuthApi,
+    private val sessionClient: SessionClient
+) : SessionInterceptor<UserIdSession>(context = context) {
+    override fun loadSession(prefs: SharedPreferences) = sessionClient.oktaUserId?.let { UserIdSession(prefs, it) }
+
+    override fun attachSession(request: Request, session: UserIdSession): Request {
+        if (!session.isValid) return request
+
+        return request.newBuilder()
+            .addHeader(HTTP_HEADER_AUTHORIZATION, session.id!!)
+            .build()
+    }
+
+    override fun establishSession() = sessionClient.tokens?.let { authenticateWithOktaTokens(it) }
+        ?: runBlocking {
+            try {
+                sessionClient.refreshToken()
+            } catch (e: AuthorizationException) {
+                null
+            }
+        }?.let { authenticateWithOktaTokens(it) }
+
+    private fun authenticateWithOktaTokens(tokens: Tokens): UserIdSession? {
+        val request = tokens.accessToken?.let { AuthToken.Request(it) } ?: return null
+        return authApi.authenticate(request).execute().takeIf { it.isSuccessful }
+            ?.body()?.takeUnless { it.hasErrors() }
+            ?.dataSingle?.let { UserIdSession(userId = tokens.oktaUserId, sessionId = it.token) }
+            ?.takeIf { it.isValid }
+    }
+
+    override fun isSessionInvalid(response: Response) = response.code == HttpURLConnection.HTTP_UNAUTHORIZED
+}

--- a/library/api/src/main/java/org/cru/godtools/api/UserCountersApi.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/UserCountersApi.kt
@@ -1,0 +1,13 @@
+package org.cru.godtools.api
+
+import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
+import org.cru.godtools.model.UserCounter
+import retrofit2.Response
+import retrofit2.http.GET
+
+private const val PATH_USER_COUNTERS = "user/counters"
+
+interface UserCountersApi {
+    @GET(PATH_USER_COUNTERS)
+    suspend fun getCounters(): Response<JsonApiObject<UserCounter>>
+}

--- a/library/api/src/main/java/org/cru/godtools/api/UserCountersApi.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/UserCountersApi.kt
@@ -4,10 +4,20 @@ import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
 import org.cru.godtools.model.UserCounter
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.Path
 
 private const val PATH_USER_COUNTERS = "user/counters"
+
+private const val PARAM_COUNTER_ID = "counter_id"
 
 interface UserCountersApi {
     @GET(PATH_USER_COUNTERS)
     suspend fun getCounters(): Response<JsonApiObject<UserCounter>>
+
+    @PATCH("$PATH_USER_COUNTERS/{$PARAM_COUNTER_ID}")
+    suspend fun updateCounter(
+        @Path(PARAM_COUNTER_ID) counterId: String,
+        counter: UserCounter
+    ): Response<JsonApiObject<UserCounter>>
 }

--- a/library/api/src/main/java/org/cru/godtools/api/model/AuthToken.kt
+++ b/library/api/src/main/java/org/cru/godtools/api/model/AuthToken.kt
@@ -1,0 +1,16 @@
+package org.cru.godtools.api.model
+
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
+
+private const val ATTR_OKTA_TOKEN = "okta_access_token"
+private const val ATTR_TOKEN = "token"
+
+@JsonApiType("auth-token")
+class AuthToken {
+    @JsonApiAttribute(ATTR_TOKEN)
+    var token: String? = null
+
+    @JsonApiType("auth-token-request")
+    class Request(@JsonApiAttribute(ATTR_OKTA_TOKEN) val oktaAccessToken: String)
+}

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.TrainingTip
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.TranslationFile
+import org.cru.godtools.model.UserCounter
 import org.keynote.godtools.android.db.Contract.BaseTable.LanguageCode
 import org.keynote.godtools.android.db.Contract.BaseTable.ToolCode
 
@@ -459,6 +460,51 @@ object Contract : BaseContract() {
             LanguageCode.SQL_COLUMN_LANGUAGE,
             SQL_COLUMN_TIP_ID,
             SQL_COLUMN_IS_COMPLETE,
+            SQL_PRIMARY_KEY
+        )
+        // endregion DB Migrations
+    }
+
+    internal object UserCounterTable : Base {
+        internal const val TABLE_NAME = "user_counters"
+        private val TABLE = Table.forClass<UserCounter>()
+
+        internal const val COLUMN_COUNTER_ID = "counter_id"
+        internal const val COLUMN_COUNT = "count"
+        internal const val COLUMN_DECAYED_COUNT = "decayed_count"
+        internal const val COLUMN_DELTA = "delta"
+
+        private val FIELD_COUNTER_ID = TABLE.field(COLUMN_COUNTER_ID)
+
+        internal val PROJECTION_ALL = arrayOf(COLUMN_COUNTER_ID, COLUMN_COUNT, COLUMN_DECAYED_COUNT, COLUMN_DELTA)
+
+        private const val SQL_COLUMN_COUNTER_ID = "$COLUMN_COUNTER_ID TEXT"
+        private const val SQL_COLUMN_COUNT = "$COLUMN_COUNT INTEGER"
+        private const val SQL_COLUMN_DECAYED_COUNT = "$COLUMN_DECAYED_COUNT REAL"
+        private const val SQL_COLUMN_DELTA = "$COLUMN_DELTA INTEGER"
+        private val SQL_PRIMARY_KEY = uniqueIndex(COLUMN_COUNTER_ID)
+
+        internal val SQL_WHERE_PRIMARY_KEY = FIELD_COUNTER_ID.eq(bind())
+
+        internal val SQL_CREATE_TABLE = create(
+            TABLE_NAME,
+            SQL_COLUMN_ROWID,
+            SQL_COLUMN_COUNTER_ID,
+            SQL_COLUMN_COUNT,
+            SQL_COLUMN_DECAYED_COUNT,
+            SQL_COLUMN_DELTA,
+            SQL_PRIMARY_KEY
+        )
+        internal val SQL_DELETE_TABLE = drop(TABLE_NAME)
+
+        // region DB Migrations
+        internal val SQL_V46_CREATE_USER_COUNTERS = create(
+            TABLE_NAME,
+            SQL_COLUMN_ROWID,
+            SQL_COLUMN_COUNTER_ID,
+            SQL_COLUMN_COUNT,
+            SQL_COLUMN_DECAYED_COUNT,
+            SQL_COLUMN_DELTA,
             SQL_PRIMARY_KEY
         )
         // endregion DB Migrations

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -465,13 +465,13 @@ object Contract : BaseContract() {
         // endregion DB Migrations
     }
 
-    internal object UserCounterTable : Base {
+    object UserCounterTable : Base {
         internal const val TABLE_NAME = "user_counters"
         private val TABLE = Table.forClass<UserCounter>()
 
         internal const val COLUMN_COUNTER_ID = "counter_id"
-        internal const val COLUMN_COUNT = "count"
-        internal const val COLUMN_DECAYED_COUNT = "decayed_count"
+        const val COLUMN_COUNT = "count"
+        const val COLUMN_DECAYED_COUNT = "decayed_count"
         internal const val COLUMN_DELTA = "delta"
 
         private val FIELD_COUNTER_ID = TABLE.field(COLUMN_COUNTER_ID)

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -475,6 +475,7 @@ object Contract : BaseContract() {
         internal const val COLUMN_DELTA = "delta"
 
         private val FIELD_COUNTER_ID = TABLE.field(COLUMN_COUNTER_ID)
+        val FIELD_DELTA = TABLE.field(COLUMN_DELTA)
 
         internal val PROJECTION_ALL = arrayOf(COLUMN_COUNTER_ID, COLUMN_COUNT, COLUMN_DECAYED_COUNT, COLUMN_DELTA)
 

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDao.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDao.kt
@@ -32,6 +32,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.TrainingTip
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.TranslationFile
+import org.cru.godtools.model.UserCounter
 import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.Contract.FollowupTable
 import org.keynote.godtools.android.db.Contract.GlobalActivityAnalyticsTable
@@ -41,6 +42,7 @@ import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TrainingTipTable
 import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
+import org.keynote.godtools.android.db.Contract.UserCounterTable
 
 @Singleton
 class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) :
@@ -86,6 +88,10 @@ class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) :
             TrainingTip::class.java, TrainingTipTable.TABLE_NAME, TrainingTipTable.PROJECTION_ALL, TrainingTipMapper,
             TrainingTipTable.SQL_WHERE_PRIMARY_KEY
         )
+        registerType(
+            UserCounter::class.java, UserCounterTable.TABLE_NAME, UserCounterTable.PROJECTION_ALL, UserCounterMapper,
+            UserCounterTable.SQL_WHERE_PRIMARY_KEY
+        )
     }
 
     public override fun getPrimaryKeyWhere(obj: Any) = when (obj) {
@@ -94,6 +100,7 @@ class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) :
         is Language -> getPrimaryKeyWhere(Language::class.java, obj.code)
         is Tool -> getPrimaryKeyWhere(Tool::class.java, obj.code!!)
         is TrainingTip -> getPrimaryKeyWhere(TrainingTip::class.java, obj.tool, obj.locale, obj.tipId)
+        is UserCounter -> getPrimaryKeyWhere(UserCounter::class.java, obj.id)
         is Base -> getPrimaryKeyWhere(obj.javaClass, obj.id)
         else -> super.getPrimaryKeyWhere(obj)
     }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
@@ -20,10 +20,11 @@ import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TrainingTipTable
 import org.keynote.godtools.android.db.Contract.TranslationFileTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
+import org.keynote.godtools.android.db.Contract.UserCounterTable
 import timber.log.Timber
 
 private const val DATABASE_NAME = "resource.db"
-private const val DATABASE_VERSION = 45
+private const val DATABASE_VERSION = 46
 
 /*
  * Version history
@@ -40,6 +41,7 @@ private const val DATABASE_VERSION = 45
  * 44: 2020-08-10
  * v5.3.1 - v5.6.1
  * 45: 2021-12-02
+ * 46: 2022-01-07
  */
 
 @Singleton
@@ -58,6 +60,7 @@ class GodToolsDatabase @Inject internal constructor(@ApplicationContext private 
             db.execSQL(AttachmentTable.SQL_CREATE_TABLE)
             db.execSQL(GlobalActivityAnalyticsTable.SQL_CREATE_TABLE)
             db.execSQL(TrainingTipTable.SQL_CREATE_TABLE)
+            db.execSQL(UserCounterTable.SQL_CREATE_TABLE)
             db.setTransactionSuccessful()
         } finally {
             db.endTransaction()
@@ -83,6 +86,7 @@ class GodToolsDatabase @Inject internal constructor(@ApplicationContext private 
                         db.execSQL(ToolTable.SQL_V45_ALTER_HIDDEN)
                         db.execSQL(ToolTable.SQL_V45_POPULATE_HIDDEN)
                     }
+                    46 -> db.execSQL(UserCounterTable.SQL_V46_CREATE_USER_COUNTERS)
                     else -> throw SQLiteException("Unrecognized db version:$upgradeTo old:$oldVersion new:$newVersion")
                 }
 
@@ -116,6 +120,7 @@ class GodToolsDatabase @Inject internal constructor(@ApplicationContext private 
             db.execSQL(AttachmentTable.SQL_DELETE_TABLE)
             db.execSQL(GlobalActivityAnalyticsTable.SQL_DELETE_TABLE)
             db.execSQL(TrainingTipTable.SQL_DELETE_TABLE)
+            db.execSQL(UserCounterTable.SQL_DELETE_TABLE)
 
             // legacy tables
             db.execSQL(LegacyTables.SQL_DELETE_GSSUBSCRIBERS)

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/UserCounterMapper.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/UserCounterMapper.kt
@@ -1,0 +1,33 @@
+package org.keynote.godtools.android.db
+
+import android.content.ContentValues
+import android.database.Cursor
+import org.ccci.gto.android.common.db.AbstractMapper
+import org.ccci.gto.android.common.util.database.getDouble
+import org.ccci.gto.android.common.util.database.getInt
+import org.ccci.gto.android.common.util.database.getString
+import org.cru.godtools.model.UserCounter
+import org.keynote.godtools.android.db.Contract.UserCounterTable.COLUMN_COUNT
+import org.keynote.godtools.android.db.Contract.UserCounterTable.COLUMN_COUNTER_ID
+import org.keynote.godtools.android.db.Contract.UserCounterTable.COLUMN_DECAYED_COUNT
+import org.keynote.godtools.android.db.Contract.UserCounterTable.COLUMN_DELTA
+
+internal object UserCounterMapper : AbstractMapper<UserCounter>() {
+    override fun mapField(values: ContentValues, field: String, obj: UserCounter) {
+        when (field) {
+            COLUMN_COUNTER_ID -> values.put(field, obj.id)
+            COLUMN_COUNT -> values.put(field, obj.apiCount)
+            COLUMN_DECAYED_COUNT -> values.put(field, obj.apiDecayedCount)
+            COLUMN_DELTA -> values.put(field, obj.delta)
+            else -> super.mapField(values, field, obj)
+        }
+    }
+
+
+    override fun newObject(c: Cursor) = UserCounter(c.getString(COLUMN_COUNTER_ID).orEmpty())
+    override fun toObject(c: Cursor) = super.toObject(c).apply {
+        apiCount = c.getInt(COLUMN_COUNT, 0)
+        apiDecayedCount = c.getDouble(COLUMN_DECAYED_COUNT, 0.0)
+        delta = c.getInt(COLUMN_DELTA, 0)
+    }
+}

--- a/library/model/src/main/kotlin/org/cru/godtools/model/UserCounter.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/UserCounter.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.model
+
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiId
+import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
+
+private const val JSON_API_TYPE = "user-counter"
+
+private const val JSON_COUNT = "count"
+private const val JSON_DECAYED_COUNT = "decayed-count"
+private const val JSON_INCREMENT = "increment"
+
+@JsonApiType(JSON_API_TYPE)
+class UserCounter @JvmOverloads constructor(@JsonApiId val id: String = "") {
+    @JsonApiAttribute(JSON_INCREMENT, deserialize = false)
+    var delta: Int = 0
+
+    @JsonApiAttribute(JSON_COUNT, serialize = false)
+    var apiCount: Int = 0
+    val count get() = apiCount + (delta ?: 0)
+
+    @JsonApiAttribute(JSON_DECAYED_COUNT, serialize = false)
+    var apiDecayedCount: Double = 0.0
+    val decayedCount get() = apiDecayedCount + (delta ?: 0)
+}

--- a/library/model/src/test/kotlin/org/cru/godtools/model/UserCounterTest.kt
+++ b/library/model/src/test/kotlin/org/cru/godtools/model/UserCounterTest.kt
@@ -1,0 +1,26 @@
+package org.cru.godtools.model
+
+import org.ccci.gto.android.common.jsonapi.JsonApiConverter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserCounterTest {
+    // region jsonapi parsing
+    private val jsonApiConverter by lazy {
+        JsonApiConverter.Builder()
+            .addClasses(UserCounter::class.java)
+            .build()
+    }
+
+    @Test
+    fun testJsonApiParsing() {
+        val counter = parseJson("user_counter.json").dataSingle!!
+        assertEquals("tool_opens", counter.id)
+        assertEquals(41, counter.apiCount)
+        assertEquals(26.000768, counter.apiDecayedCount, 0.000001)
+    }
+
+    private fun parseJson(file: String) = this::class.java.getResourceAsStream(file)!!.reader()
+        .use { jsonApiConverter.fromJson(it.readText(), UserCounter::class.java) }
+    // endregion jsonapi parsing
+}

--- a/library/model/src/test/resources/org/cru/godtools/model/user_counter.json
+++ b/library/model/src/test/resources/org/cru/godtools/model/user_counter.json
@@ -1,0 +1,13 @@
+{
+  "data": [
+    {
+      "id": "tool_opens",
+      "type": "user-counter",
+      "attributes": {
+        "count": 41,
+        "decayed-count": 26.00076844851781,
+        "last-decay": "2021-12-21"
+      }
+    }
+  ]
+}

--- a/library/sync/build.gradle.kts
+++ b/library/sync/build.gradle.kts
@@ -8,13 +8,15 @@ dependencies {
     api(libs.androidx.hilt.work)
     api(libs.androidx.work.ktx)
 
-    implementation(libs.gtoSupport.base)
     api(libs.gtoSupport.sync)
+    implementation(libs.gtoSupport.base)
+    implementation(libs.gtoSupport.okta)
 
     implementation(libs.dagger)
     implementation(libs.eventbus)
     implementation(libs.hilt)
     implementation(libs.kotlin.coroutines)
+    implementation(libs.okta)
 
     testImplementation(libs.kotlin.coroutines.test)
 

--- a/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -21,6 +21,7 @@ import org.cru.godtools.sync.task.BaseSyncTasks
 import org.cru.godtools.sync.task.FollowupSyncTasks
 import org.cru.godtools.sync.task.LanguagesSyncTasks
 import org.cru.godtools.sync.task.ToolSyncTasks
+import org.cru.godtools.sync.task.UserCounterSyncTasks
 import org.cru.godtools.sync.work.scheduleSyncFollowupWork
 import org.cru.godtools.sync.work.scheduleSyncLanguagesWork
 import org.cru.godtools.sync.work.scheduleSyncToolSharesWork
@@ -34,6 +35,7 @@ private const val SYNCTYPE_TOOLS = 3
 private const val SYNCTYPE_FOLLOWUPS = 4
 private const val SYNCTYPE_TOOL_SHARES = 5
 private const val SYNCTYPE_GLOBAL_ACTIVITY = 6
+private const val SYNCTYPE_USER_COUNTERS = 7
 
 @Singleton
 class GodToolsSyncService @VisibleForTesting internal constructor(
@@ -68,6 +70,7 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
                         if (!syncFollowups()) workManager.scheduleSyncFollowupWork()
                     }
                     SYNCTYPE_GLOBAL_ACTIVITY -> with<AnalyticsSyncTasks> { syncGlobalActivity(task.args) }
+                    SYNCTYPE_USER_COUNTERS -> with<UserCounterSyncTasks> { syncCounters(task.args) }
                 }
             } catch (e: IOException) {
                 // queue up work tasks here because of the IOException
@@ -107,6 +110,13 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
     fun syncGlobalActivity(force: Boolean = false): SyncTask = GtSyncTask(
         bundleOf(
             EXTRA_SYNCTYPE to SYNCTYPE_GLOBAL_ACTIVITY,
+            ContentResolver.SYNC_EXTRAS_MANUAL to force
+        )
+    )
+
+    fun syncUserCounters(force: Boolean = false): SyncTask = GtSyncTask(
+        bundleOf(
+            EXTRA_SYNCTYPE to SYNCTYPE_USER_COUNTERS,
             ContentResolver.SYNC_EXTRAS_MANUAL to force
         )
     )

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/BaseSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/BaseSyncTasks.kt
@@ -11,9 +11,9 @@ import org.greenrobot.eventbus.EventBus
 
 @WorkerThread
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-abstract class BaseSyncTasks internal constructor(private val eventBus: EventBus) {
+abstract class BaseSyncTasks internal constructor(private val eventBus: EventBus? = null) {
     fun sendEvents(events: SimpleArrayMap<Class<*>, Any>) {
-        for (i in 0 until events.size()) eventBus.post(events.valueAt(i))
+        for (i in 0 until events.size()) eventBus?.post(events.valueAt(i))
         events.clear()
     }
 

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/SyncTaskModule.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/SyncTaskModule.kt
@@ -35,4 +35,9 @@ abstract class SyncTaskModule {
     @IntoMap
     @SyncTaskKey(ToolSyncTasks::class)
     abstract fun toolSyncTasks(tasks: ToolSyncTasks): BaseSyncTasks
+
+    @Binds
+    @IntoMap
+    @SyncTaskKey(UserCounterSyncTasks::class)
+    abstract fun userCounterSyncTasks(tasks: UserCounterSyncTasks): BaseSyncTasks
 }

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
@@ -1,0 +1,58 @@
+package org.cru.godtools.sync.task
+
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import com.okta.oidc.clients.sessions.SessionClient
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.ccci.gto.android.common.base.TimeConstants
+import org.ccci.gto.android.common.db.Query
+import org.cru.godtools.api.UserCountersApi
+import org.cru.godtools.model.UserCounter
+import org.keynote.godtools.android.db.Contract.UserCounterTable
+import org.keynote.godtools.android.db.GodToolsDao
+
+private const val SYNC_TIME_COUNTERS = "last_synced.user_counters"
+private const val STALE_DURATION_COUNTERS = TimeConstants.DAY_IN_MS
+
+@VisibleForTesting
+internal val QUERY_DIRTY_COUNTERS =
+    Query.select<UserCounter>().where(UserCounterTable.FIELD_DELTA.gt(0))
+
+@Singleton
+class UserCounterSyncTasks @Inject internal constructor(
+    private val dao: GodToolsDao,
+    private val countersApi: UserCountersApi,
+    private val sessionClient: SessionClient
+) : BaseSyncTasks() {
+    private val countersMutex = Mutex()
+
+    suspend fun syncCounters(args: Bundle = Bundle.EMPTY): Boolean = withContext(Dispatchers.IO) {
+        countersMutex.withLock {
+            if (!sessionClient.isAuthenticated) return@withContext true
+
+            // short-circuit if we aren't forcing a sync and the data isn't stale
+            if (!isForced(args) &&
+                System.currentTimeMillis() - dao.getLastSyncTime(SYNC_TIME_COUNTERS) < STALE_DURATION_COUNTERS
+            ) return@withContext true
+
+            val counters = countersApi.getCounters().takeIf { it.isSuccessful }
+                ?.body()?.takeUnless { it.hasErrors() }
+                ?.data ?: return@withContext false
+
+            dao.transaction { storeUserCounters(counters) }
+            dao.updateLastSyncTime(SYNC_TIME_COUNTERS)
+
+            true
+        }
+    }
+
+    private fun storeUserCounters(counters: List<UserCounter>) = counters.forEach { storeUserCounter(it) }
+    private fun storeUserCounter(counter: UserCounter) {
+        dao.updateOrInsert(counter, UserCounterTable.COLUMN_COUNT, UserCounterTable.COLUMN_DECAYED_COUNT)
+    }
+}

--- a/library/user-data/build.gradle.kts
+++ b/library/user-data/build.gradle.kts
@@ -1,0 +1,9 @@
+dependencies {
+    implementation(project(":library:db"))
+    implementation(project(":library:model"))
+    implementation(project(":library:sync"))
+
+    implementation(libs.dagger)
+
+    kapt(libs.dagger.compiler)
+}

--- a/library/user-data/src/main/AndroidManifest.xml
+++ b/library/user-data/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="org.cru.godtools.user.data" />

--- a/library/user-data/src/main/kotlin/org/cru/godtools/user/data/Counters.kt
+++ b/library/user-data/src/main/kotlin/org/cru/godtools/user/data/Counters.kt
@@ -1,0 +1,24 @@
+package org.cru.godtools.user.data
+
+import android.database.sqlite.SQLiteDatabase
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.cru.godtools.model.UserCounter
+import org.cru.godtools.sync.GodToolsSyncService
+import org.keynote.godtools.android.db.GodToolsDao
+
+class Counters @Inject internal constructor(
+    private val dao: GodToolsDao,
+    private val syncService: GodToolsSyncService
+) {
+    suspend fun updateCounter(id: String, change: Int = 1) = withContext(Dispatchers.IO) {
+        with(dao) {
+            transaction {
+                insert(UserCounter(id), SQLiteDatabase.CONFLICT_IGNORE)
+                updateUserCounterDelta(id, change)
+            }
+        }
+        syncService.syncDirtyUserCounters().sync()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ include("library:download-manager")
 include("library:initial-content")
 include("library:model")
 include("library:sync")
+include("library:user-data")
 
 include("ui:article-aem-renderer")
 include("ui:article-renderer")


### PR DESCRIPTION
- create a UserCounter model for syncing UserCounters from the API
- track user counters in the database
- Add support for authenticated APIs on mobile-content-api
- add API interface for reading user counters from the API
- add logic to sync user counters from the API
- add a db method to update a UserCounter delta
- add logic to sync dirty user counters to the API
- create Counters singleton for updating a user counter
