### PR TITLE
cleanup

### DIFF
--- a/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
@@ -67,7 +67,7 @@ class FirebaseAnalyticsService @VisibleForTesting internal constructor(
     @MainThread
     @Subscribe(threadMode = ThreadMode.MAIN_ORDERED)
     fun onAnalyticsEvent(event: AnalyticsBaseEvent) {
-        if (event.isForSystem(AnalyticsSystem.FIREBASE) || event.isForSystem(AnalyticsSystem.ADOBE)) when (event) {
+        if (event.isForSystem(AnalyticsSystem.FIREBASE)) when (event) {
             is AnalyticsScreenEvent -> handleScreenEvent(event)
             is AnalyticsActionEvent -> handleActionEvent(event)
         }

--- a/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsSystem.kt
+++ b/library/analytics/src/main/java/org/cru/godtools/analytics/model/AnalyticsSystem.kt
@@ -1,5 +1,5 @@
 package org.cru.godtools.analytics.model
 
 enum class AnalyticsSystem {
-    ADOBE, APPSFLYER, FACEBOOK, FIREBASE, SNOWPLOW
+    APPSFLYER, FACEBOOK, FIREBASE, SNOWPLOW
 }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDao.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDao.kt
@@ -168,6 +168,8 @@ class GodToolsDao @Inject internal constructor(database: GodToolsDatabase) : Abs
             .getAsLiveData(this).map { it.firstOrNull() }
     }
 
+    fun updateSharesDeltaAsync(toolCode: String?, shares: Int) =
+        coroutineScope.launch { updateSharesDelta(toolCode, shares) }
     suspend fun updateSharesDelta(toolCode: String?, shares: Int) {
         if (toolCode == null) return
         if (shares == 0) return

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -9,6 +9,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -90,7 +91,7 @@ class ToolSyncTasks @Inject internal constructor(
                                 false
                             }
                         }
-                    }.all { it.await() }
+                    }.awaitAll().all { it }
             }
         }
     }

--- a/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/java/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -10,7 +10,6 @@ import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -79,20 +78,18 @@ class ToolSyncTasks @Inject internal constructor(
      */
     suspend fun syncShares() = withContext(Dispatchers.IO) {
         sharesMutex.withLock {
-            coroutineScope {
-                Query.select<Tool>().where(ToolTable.SQL_WHERE_HAS_PENDING_SHARES).get(dao)
-                    .map {
-                        async {
-                            try {
-                                val views = ToolViews(it)
-                                viewsApi.submitViews(views).isSuccessful
-                                    .also { if (it) dao.updateSharesDelta(views.toolCode, 0 - views.quantity) }
-                            } catch (ignored: IOException) {
-                                false
-                            }
+            Query.select<Tool>().where(ToolTable.SQL_WHERE_HAS_PENDING_SHARES).get(dao)
+                .map {
+                    async {
+                        try {
+                            val views = ToolViews(it)
+                            viewsApi.submitViews(views).isSuccessful
+                                .also { if (it) dao.updateSharesDelta(views.toolCode, 0 - views.quantity) }
+                        } catch (ignored: IOException) {
+                            false
                         }
-                    }.awaitAll().all { it }
-            }
+                    }
+                }.awaitAll().all { it }
         }
     }
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -21,7 +21,6 @@ import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.eventbus.lifecycle.register
 import org.ccci.gto.android.common.util.graphics.toHslColor
@@ -353,7 +352,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
 
         settings.setFeatureDiscovered(FEATURE_TOOL_OPENED)
 
-        GlobalScope.launch { dao.updateSharesDelta(tool, 1) }
+        dao.updateSharesDeltaAsync(tool, 1)
     }
 
     private val Intent?.isShortcutLaunch get() = this?.getBooleanExtra(SHORTCUT_LAUNCH, false) ?: false

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
@@ -8,22 +8,21 @@ import org.cru.godtools.tool.model.AnalyticsEvent
 
 class ContentAnalyticsEventAnalyticsActionEvent(@VisibleForTesting val event: AnalyticsEvent) :
     AnalyticsActionEvent(action = event.action.orEmpty()) {
-    override fun isForSystem(system: AnalyticsSystem) = event.isForSystem(
-        when (system) {
-            AnalyticsSystem.ADOBE -> AnalyticsEvent.System.ADOBE
-            AnalyticsSystem.APPSFLYER -> AnalyticsEvent.System.APPSFLYER
-            AnalyticsSystem.FACEBOOK -> AnalyticsEvent.System.FACEBOOK
-            AnalyticsSystem.FIREBASE -> AnalyticsEvent.System.FIREBASE
-            AnalyticsSystem.SNOWPLOW -> AnalyticsEvent.System.SNOWPLOW
-        }
-    )
+    override fun isForSystem(system: AnalyticsSystem) = when (system) {
+        AnalyticsSystem.APPSFLYER -> event.isForSystem(AnalyticsEvent.System.APPSFLYER)
+        AnalyticsSystem.FACEBOOK -> event.isForSystem(AnalyticsEvent.System.FACEBOOK)
+        AnalyticsSystem.FIREBASE ->
+            event.isForSystem(AnalyticsEvent.System.ADOBE) || event.isForSystem(AnalyticsEvent.System.FIREBASE)
+        AnalyticsSystem.SNOWPLOW -> event.isForSystem(AnalyticsEvent.System.SNOWPLOW)
+    }
 
     override val appSection get() = event.manifest.code
 
     override val adobeAttributes get() = event.attributes
 
     override val firebaseEventName get() = when {
-        isForSystem(AnalyticsSystem.ADOBE) -> event.action?.sanitizeAdobeNameForFirebase().orEmpty()
+        event.isForSystem(AnalyticsEvent.System.FIREBASE) -> super.firebaseEventName
+        event.isForSystem(AnalyticsEvent.System.ADOBE) -> event.action?.sanitizeAdobeNameForFirebase().orEmpty()
         else -> super.firebaseEventName
     }
 


### PR DESCRIPTION
- use `awaitAll()` to wait for all updates to complete
- remove unnecessary coroutineScope
- utilize the Dao coroutineScope when updating tool shares
- remove Adobe analytics system
