### PR TITLE
GT-1329 Fix fragment back stack bug when replacing a page

### DIFF
--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -41,7 +41,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
     override fun onInvalidPage(fragment: CyoaPageFragment<*, *>, page: Page?) {
         if (fragment !== pageFragment) return
         when {
-            page != null -> showPage(page, false)
+            page != null -> showPage(page, true)
             supportFragmentManager.backStackEntryCount == 0 -> finish()
             else -> supportFragmentManager.popBackStack()
         }
@@ -84,7 +84,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
         if (pageFragment != null) return
 
         manifest.pages.firstOrNull { !it.isHidden }
-            ?.let { showPage(it, false) }
+            ?.let { showPage(it, true) }
     }
 
     private fun checkForPageEvent(event: Event) {
@@ -98,7 +98,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
 
         // dismiss/show pages as necessary
         when {
-            newPage != null -> showPage(newPage, addCurrentPageToBackStack = !dismissCurrentPage)
+            newPage != null -> showPage(newPage, replaceCurrentPage = dismissCurrentPage)
             dismissCurrentPage -> when {
                 supportFragmentManager.backStackEntryCount > 0 -> supportFragmentManager.popBackStack()
                 pageFragment != null -> supportFragmentManager.commit { remove(pageFragment) }
@@ -128,7 +128,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
 
                 // otherwise pop entire backstack and show parent page as the root page
                 if (backStackEntryCount > 0) popBackStack(getBackStackEntryAt(0).id, POP_BACK_STACK_INCLUSIVE)
-                showPage(parent, false)
+                showPage(parent, true)
                 return true
             }
         }
@@ -136,7 +136,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
     }
 
     @VisibleForTesting
-    internal fun showPage(page: Page, addCurrentPageToBackStack: Boolean = true) {
+    internal fun showPage(page: Page, replaceCurrentPage: Boolean = false) {
         val fragment = when (page) {
             is CardCollectionPage -> CyoaCardCollectionPageFragment(page.id)
             is ContentPage -> CyoaContentPageFragment(page.id)
@@ -144,7 +144,7 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
         }
         supportFragmentManager.commit {
             setReorderingAllowed(true)
-            if (addCurrentPageToBackStack) pageFragment?.let { addToBackStack(it.pageId) }
+            if (!replaceCurrentPage) pageFragment?.let { addToBackStack(it.pageId) }
             replace(R.id.page, fragment)
             setPrimaryNavigationFragment(fragment)
         }

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -142,11 +142,22 @@ class CyoaActivity : MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyo
             is ContentPage -> CyoaContentPageFragment(page.id)
             else -> return
         }
-        supportFragmentManager.commit {
+        val fm = supportFragmentManager
+        fm.commit {
             setReorderingAllowed(true)
-            if (!replaceCurrentPage) pageFragment?.let { addToBackStack(it.pageId) }
             replace(R.id.page, fragment)
             setPrimaryNavigationFragment(fragment)
+            pageFragment?.let {
+                if (replaceCurrentPage) {
+                    val backStackSize = fm.backStackEntryCount
+                    if (backStackSize > 0) {
+                        addToBackStack(fm.getBackStackEntryAt(backStackSize - 1).name)
+                        fm.popBackStack()
+                    }
+                } else {
+                    addToBackStack(it.pageId)
+                }
+            }
         }
     }
     // endregion Page management

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.tool.cyoa.ui
 
 import android.content.Context
+import android.view.ViewGroup
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
@@ -14,6 +15,7 @@ import javax.inject.Inject
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.base.ui.createCyoaActivityIntent
+import org.cru.godtools.tool.cyoa.R
 import org.cru.godtools.tool.model.EventId
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.page.CardCollectionPage
@@ -421,6 +423,9 @@ class CyoaActivityTest {
                 manifestEnglish.value = manifest(listOf(page1, cardCollectionPage2))
                 it.assertPageStack("page1", "page2")
                 assertTrue(it.pageFragment is CyoaCardCollectionPageFragment)
+
+                it.onBackPressed()
+                it.assertPageStack("page1")
             }
         }
     }
@@ -473,5 +478,6 @@ class CyoaActivityTest {
             assertEquals(page, supportFragmentManager.getBackStackEntryAt(i).name)
         }
         assertEquals(pages.last(), pageFragment!!.pageId)
+        assertEquals(1, findViewById<ViewGroup>(R.id.page).childCount)
     }
 }


### PR DESCRIPTION
- when asserting a page stack, assert that only 1 fragment is currently visible
- rename parameter to replaceCurrentPage to model the functionality without exposing the internals of how it's working
- rework the replace logic to always use the back stack (except for replacing the root page)
