### PR TITLE
GT-1423 GT-1349 Fix DownloadManager issues

### DIFF
--- a/library/download-manager/build.gradle.kts
+++ b/library/download-manager/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.kotlin.coroutines.test)
 
+    kapt(libs.androidx.hilt.compiler)
     kapt(libs.dagger.compiler)
     kapt(libs.hilt.compiler)
 }


### PR DESCRIPTION
- if nothing changes about an attachment, don't update it in the database
   - This caused an infinite loop when the device was offline and unable to download an attachment
- fix the DownloadLatestPublishedTranslationWorker
   - This prevented the Worker from correctly starting when the device came back online
