### PR TITLE
GT-1432 Only show tips when they are actually available

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -146,6 +146,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // region Training Tips
     private fun Menu.setupTrainingTipsMenuItem() {
         findItem(R.id.action_tips)?.let { item ->
+            dataModel.hasTips.observe(this@MultiLanguageToolActivity, item) { isVisible = it }
             dataModel.showTips.observe(this@MultiLanguageToolActivity, item) { isChecked = it }
         }
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -8,12 +8,12 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
-import androidx.lifecycle.Observer
 import androidx.lifecycle.map
 import com.google.android.material.tabs.TabLayout
 import java.util.Locale
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
+import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.ccci.gto.android.common.util.graphics.toHsvColor
 import org.ccci.gto.android.common.util.os.getLocaleArray
@@ -144,13 +144,10 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // endregion Language Toggle
 
     // region Training Tips
-    private var trainingTipsMenuObserver: Observer<Boolean>? = null
     private fun Menu.setupTrainingTipsMenuItem() {
-        trainingTipsMenuObserver?.let { dataModel.showTips.removeObserver(it) }
-
-        trainingTipsMenuObserver = findItem(R.id.action_tips)
-            ?.let { item -> Observer<Boolean> { item.isChecked = it } }
-            ?.also { dataModel.showTips.observe(this@MultiLanguageToolActivity, it) }
+        findItem(R.id.action_tips)?.let { item ->
+            dataModel.showTips.observe(this@MultiLanguageToolActivity, item) { isChecked = it }
+        }
     }
     // endregion Training Tips
     // endregion UI

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -14,6 +14,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
+import org.ccci.gto.android.common.androidx.lifecycle.and
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.orEmpty
@@ -50,7 +51,6 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
     val toolCode = MutableLiveData<String?>()
     val primaryLocales = MutableLiveData<List<Locale>>(emptyList())
     val parallelLocales = MutableLiveData<List<Locale>>(emptyList())
-    val showTips: MutableLiveData<Boolean> = savedState.getLiveData(EXTRA_SHOW_TIPS, false)
 
     // region Resolved Data
     val locales = primaryLocales.combineWith(parallelLocales) { primary, parallel -> primary + parallel }
@@ -160,6 +160,13 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
         locales.filter { loadingState[it] == LoadingState.LOADED }
     }
     // endregion Available Locales
+
+    // region Training Tips
+    val showTips: MutableLiveData<Boolean> = savedState.getLiveData(EXTRA_SHOW_TIPS, false)
+
+    val hasTips = activeManifest.map { !it?.tips.isNullOrEmpty() }
+    val enableTips = hasTips and showTips
+    // endregion Training Tips
 
     private val translationCache = object : LruCache<TranslationKey, LiveData<Translation?>>(10) {
         override fun create(key: TranslationKey) =

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/BaseController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/BaseController.kt
@@ -170,7 +170,7 @@ abstract class BaseController<T : Base> protected constructor(
     // endregion Clickable
 
     // region Tips
-    open val showTips: LiveData<Boolean> = parentController?.showTips ?: ImmutableLiveData(false)
+    open val enableTips: LiveData<Boolean> = parentController?.enableTips ?: ImmutableLiveData(false)
 
     open fun showTip(tip: Tip?) {
         parentController?.showTip(tip)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -220,7 +220,7 @@ class TractActivity :
     internal lateinit var pagerAdapterFactory: ManifestPagerAdapter.Factory
     private val pager get() = binding.pages
     private val pagerAdapter by lazy {
-        pagerAdapterFactory.create(this, dataModel.showTips, toolState.toolState).also { adapter ->
+        pagerAdapterFactory.create(this, dataModel.enableTips, toolState.toolState).also { adapter ->
             adapter.callbacks = this
             dataModel.activeManifest.observe(this) { manifest ->
                 val sameLocale = adapter.manifest?.locale == manifest?.locale
@@ -290,9 +290,9 @@ class TractActivity :
         combine(
             activeManifestLiveData,
             subscriberController.state,
-            dataModel.showTips
-        ) { manifest, subscriberState, showTips ->
-            manifest != null && subscriberState == State.Off && !showTips
+            dataModel.enableTips
+        ) { manifest, subscriberState, enableTips ->
+            manifest != null && subscriberState == State.Off && !enableTips
         }
     }
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/adapter/ManifestPagerAdapter.kt
@@ -32,14 +32,18 @@ import org.greenrobot.eventbus.ThreadMode
 
 class ManifestPagerAdapter @AssistedInject internal constructor(
     @Assisted lifecycleOwner: LifecycleOwner,
-    @Assisted private val showTips: LiveData<Boolean>,
+    @Assisted private val enableTips: LiveData<Boolean>,
     @Assisted private val toolState: State,
     private val pageControllerFactory: PageController.Factory,
     eventBus: EventBus
 ) : DataBindingPagerAdapter<TractPageBinding>(lifecycleOwner), PageController.Callbacks, Observer<Manifest?> {
     @AssistedFactory
     interface Factory {
-        fun create(lifecycleOwner: LifecycleOwner, showTips: LiveData<Boolean>, toolState: State): ManifestPagerAdapter
+        fun create(
+            lifecycleOwner: LifecycleOwner,
+            enableTips: LiveData<Boolean>,
+            toolState: State
+        ): ManifestPagerAdapter
     }
 
     interface Callbacks {
@@ -80,7 +84,7 @@ class ManifestPagerAdapter @AssistedInject internal constructor(
         TractPageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
     override fun onViewDataBindingCreated(binding: TractPageBinding) {
-        binding.bindController(pageControllerFactory, lifecycleOwner, showTips, toolState).also {
+        binding.bindController(pageControllerFactory, lifecycleOwner, enableTips, toolState).also {
             it.callbacks = this
         }
     }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/CardController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/CardController.kt
@@ -55,7 +55,7 @@ class CardController private constructor(
     init {
         binding.lifecycleOwner = lifecycleOwner
         binding.controller = this
-        binding.enableTips = pageController.showTips
+        binding.enableTips = pageController.enableTips
 
         lifecycleOwner?.lifecycle?.apply {
             onResume { pendingAnalyticsEvents = triggerAnalyticsEvents(model?.getAnalyticsEvents(Trigger.VISIBLE)) }

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -33,7 +33,7 @@ import org.keynote.godtools.android.db.GodToolsDao
 class PageController @AssistedInject internal constructor(
     @Assisted private val binding: TractPageBinding,
     @Assisted baseLifecycleOwner: LifecycleOwner?,
-    @Assisted override val showTips: LiveData<Boolean>,
+    @Assisted override val enableTips: LiveData<Boolean>,
     @Assisted override val toolState: State,
     private val dao: GodToolsDao,
     eventBus: EventBus,
@@ -49,7 +49,7 @@ class PageController @AssistedInject internal constructor(
         fun create(
             binding: TractPageBinding,
             lifecycleOwner: LifecycleOwner?,
-            showTips: LiveData<Boolean>,
+            enableTips: LiveData<Boolean>,
             toolState: State
         ): PageController
     }
@@ -283,6 +283,6 @@ class PageController @AssistedInject internal constructor(
 internal fun TractPageBinding.bindController(
     factory: PageController.Factory,
     lifecycleOwner: LifecycleOwner? = null,
-    showTips: LiveData<Boolean>,
+    enableTips: LiveData<Boolean>,
     toolState: State
-) = controller ?: factory.create(this, lifecycleOwner, showTips, toolState)
+) = controller ?: factory.create(this, lifecycleOwner, enableTips, toolState)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/tips/InlineTipController.kt
@@ -32,7 +32,7 @@ internal class InlineTipController private constructor(
     init {
         binding.lifecycleOwner = lifecycleOwner
         binding.controller = this
-        binding.enableTips = showTips
+        binding.enableTips = enableTips
     }
 
     public override fun onBind() {

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -25,6 +25,7 @@ import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Translation
 import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.tips.Tip
 import org.cru.godtools.tract.PARAM_LIVE_SHARE_STREAM
 import org.cru.godtools.tract.R
 import org.junit.After
@@ -193,7 +194,7 @@ class TractActivityTest {
     @Test
     fun verifyShareMenuHiddenWhenShowingTips() {
         whenGetTranslation().thenReturn(ImmutableLiveData(Translation()))
-        whenGetManifest().thenReturn(ImmutableLiveData(Manifest()))
+        whenGetManifest().thenReturn(ImmutableLiveData(Manifest(tips = { listOf(Tip()) })))
 
         val intent = context.createTractActivityIntent("test", Locale.ENGLISH, showTips = true)
         ActivityScenario.launch<TractActivity>(intent).use {


### PR DESCRIPTION
- utilize new menu livedata observer extension function
- disable tips menu item if there are no tips available for this tool
