### PR TITLE
GT-1432 fix showing tips for headers and call to actions

### DIFF
--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/controller/PageController.kt
@@ -78,6 +78,7 @@ class PageController @AssistedInject internal constructor(
         binding.cardsDiscovered = settings.isFeatureDiscoveredLiveData(FEATURE_TRACT_CARD_CLICKED) or
             settings.isFeatureDiscoveredLiveData(FEATURE_TRACT_CARD_SWIPED)
         binding.pageContentLayout.activeCardListener = this
+        binding.enableTips = enableTips
 
         lifecycleOwner?.lifecycle?.apply {
             onResume { binding.isVisible = true }

--- a/ui/tract-renderer/src/main/res/layout/tract_page.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_page.xml
@@ -15,7 +15,7 @@
         <variable name="callbacks" type="org.cru.godtools.tract.ui.controller.PageController.Callbacks" />
         <variable name="isVisible" type="Boolean" />
         <variable name="cardsDiscovered" type="LiveData&lt;Boolean&gt;" />
-        <variable name="enableTips" type="Boolean" />
+        <variable name="enableTips" type="LiveData&lt;Boolean&gt;" />
         <variable name="isHeaderTipComplete" type="LiveData&lt;Boolean&gt;" />
         <variable name="isCallToActionTipComplete" type="LiveData&lt;Boolean&gt;" />
     </data>


### PR DESCRIPTION
in the tips refactor I accidentally stopped setting the enableTips boolean on the page data binding