### PR TITLE
GT-1446 Create a custom Tool Share Sheet

### DIFF
--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -115,7 +115,6 @@ class AemArticleActivity :
     private fun setupDataModel() {
         articleDataModel.articleUri.value = articleUri
 
-        articleDataModel.article.observe(this) { updateShareMenuItem() }
         articleDataModel.article.observe(this) { onUpdateArticle(it) }
     }
 

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -156,9 +156,10 @@ class AemArticleActivity :
     // endregion Sync logic
 
     // region Share Link logic
-    override val shareMenuItemVisible by lazy { articleDataModel.article.map { it?.canonicalUri != null } }
     override val shareLinkTitle get() = articleDataModel.article.value?.title ?: super.shareLinkTitle
-    override val shareLinkUri get() = articleDataModel.article.value?.let { it.shareUri ?: it.canonicalUri }?.toString()
+    override val shareLinkUriLiveData by lazy {
+        articleDataModel.article.map { (it?.shareUri ?: it?.canonicalUri)?.toString() }
+    }
     // endregion Share Link logic
 
     override val activeToolLoadingStateLiveData by lazy {

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -72,5 +72,6 @@ dependencies {
 
     testImplementation(project(":ui:tract-renderer"))
     testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.kotlin.coroutines.test)
     kaptTest(libs.androidx.databinding.compiler)
 }

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("dagger.hilt.android.plugin")
+    id("kotlin-parcelize")
 }
 
 android {
@@ -33,6 +34,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.lifecycle.livedata.ktx)
+    implementation(libs.androidx.recyclerview)
 
     api(libs.gtoSupport.picasso)
     implementation(libs.gtoSupport.androidx.constraintlayout)
@@ -47,6 +49,7 @@ dependencies {
     implementation(libs.gtoSupport.kotlin.coroutines)
     implementation(libs.gtoSupport.lottie)
     implementation(libs.gtoSupport.materialComponents)
+    implementation(libs.gtoSupport.recyclerview)
     implementation(libs.gtoSupport.util)
 
     implementation(libs.godtoolsMpp.parser)

--- a/ui/base-tool/src/main/AndroidManifest.xml
+++ b/ui/base-tool/src/main/AndroidManifest.xml
@@ -2,4 +2,11 @@
     package="org.cru.godtools.base.tool">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
 </manifest>

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -94,7 +94,9 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
-        updateShareMenuItem()
+        // Tool Share feature discovery is dependent on the toolbar being available, so we trigger it now since the
+        // toolbar will exist
+        showNextFeatureDiscovery()
 
         // invalidate the binding to force it to re-color the updated menu
         // TODO: this is a very brute-force way of forcing a recoloring of menu items.
@@ -139,10 +141,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     private fun setupToolbar() {
-        activeManifestLiveData.observe(this) {
-            updateToolbarTitle()
-            updateShareMenuItem()
-        }
+        activeManifestLiveData.observe(this) { updateToolbarTitle() }
     }
 
     protected open fun updateToolbarTitle() {
@@ -166,10 +165,6 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
                 isEnabled = it
             }
         }
-    }
-
-    protected fun updateShareMenuItem() {
-        showNextFeatureDiscovery()
     }
 
     protected fun shareCurrentTool() {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -180,15 +180,15 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     protected fun showShareActivityChooser(
+        title: String? = shareLinkTitle,
         @StringRes message: Int = shareLinkMessageRes,
         shareUrl: String? = shareLinkUri
     ) {
         if (shareUrl == null) return
 
-        val title = shareLinkTitle
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
-            putExtra(Intent.EXTRA_SUBJECT, getString(R.string.share_tool_subject, title))
+            putExtra(Intent.EXTRA_SUBJECT, title.orEmpty())
             putExtra(Intent.EXTRA_TEXT, getString(message, shareUrl))
         }
         startActivity(Intent.createChooser(intent, getString(R.string.share_tool_title, title)))

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -14,6 +14,7 @@ import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.map
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
 import java.io.IOException
@@ -21,6 +22,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.ccci.gto.android.common.eventbus.lifecycle.register
 import org.ccci.gto.android.common.util.graphics.toHslColor
@@ -149,8 +151,13 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     // endregion Status Bar / Toolbar logic
 
     // region Share tool logic
-    private val _shareMenuItemVisible by lazy { MutableLiveData(shareLinkUri != null) }
-    protected open val shareMenuItemVisible: LiveData<Boolean> get() = _shareMenuItemVisible
+    protected open val shareMenuItemVisible by lazy { shareLinkUriLiveData.map { it != null } }
+    protected open val shareLinkUriLiveData = emptyLiveData<String>()
+
+    protected open val shareLinkTitle get() = activeManifest?.title
+    @get:StringRes
+    protected open val shareLinkMessageRes get() = R.string.share_general_message
+    private val shareLinkUri get() = shareLinkUriLiveData.value
 
     protected fun Menu.setupShareMenuItem() {
         findItem(R.id.action_share)?.let { item ->
@@ -162,14 +169,8 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     protected fun updateShareMenuItem() {
-        _shareMenuItemVisible.value = shareLinkUri != null
         showNextFeatureDiscovery()
     }
-
-    protected open val shareLinkTitle get() = activeManifest?.title
-    @get:StringRes
-    protected open val shareLinkMessageRes get() = R.string.share_general_message
-    protected open val shareLinkUri: String? get() = null
 
     protected fun shareCurrentTool() {
         // short-circuit if we don't have a share tool url

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/OtherActionsAdapter.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/OtherActionsAdapter.kt
@@ -1,0 +1,34 @@
+package org.cru.godtools.base.tool.ui.share
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.LifecycleOwner
+import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
+import org.cru.godtools.base.tool.BR
+import org.cru.godtools.base.tool.ui.share.model.ShareItem
+
+class OtherActionsAdapter(
+    lifecycleOwner: LifecycleOwner,
+    items: List<ShareItem>,
+    private val callbacks: Callbacks? = null
+) : SimpleDataBindingAdapter<ViewDataBinding>(lifecycleOwner) {
+    interface Callbacks {
+        fun triggerAction(item: ShareItem?)
+    }
+
+    private val items = items.filter { it.actionLayout != null }
+
+    override fun getItemCount() = items.size
+    override fun getItemViewType(position: Int) = items[position].actionLayout!!
+
+    override fun onCreateViewDataBinding(parent: ViewGroup, viewType: Int): ViewDataBinding =
+        DataBindingUtil.inflate<ViewDataBinding?>(LayoutInflater.from(parent.context), viewType, parent, false).also {
+            it.setVariable(BR.callbacks, callbacks)
+        }
+
+    override fun onBindViewDataBinding(binding: ViewDataBinding, position: Int) {
+        binding.setVariable(BR.item, items[position])
+    }
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareAppsAdapter.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareAppsAdapter.kt
@@ -1,0 +1,33 @@
+package org.cru.godtools.base.tool.ui.share
+
+import android.content.pm.ResolveInfo
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
+import org.cru.godtools.base.tool.BR
+import org.cru.godtools.base.tool.R
+
+internal class ShareAppsAdapter(private val items: List<ResolveInfo>, private val callbacks: Callbacks) :
+    SimpleDataBindingAdapter<ViewDataBinding>() {
+    interface Callbacks {
+        fun onOpenApp(info: ResolveInfo)
+        fun onShowChooser()
+    }
+
+    override fun getItemCount() = items.size + 1
+    override fun getItemViewType(position: Int) = when (position) {
+        items.size -> R.layout.tool_share_item_more
+        else -> R.layout.tool_share_item_app
+    }
+
+    override fun onCreateViewDataBinding(parent: ViewGroup, viewType: Int) =
+        DataBindingUtil.inflate<ViewDataBinding>(LayoutInflater.from(parent.context), viewType, parent, false).also {
+            it.setVariable(BR.callbacks, callbacks)
+        }
+
+    override fun onBindViewDataBinding(binding: ViewDataBinding, position: Int) {
+        binding.setVariable(BR.info, items.getOrNull(position))
+    }
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareBottomSheetDialogFragment.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareBottomSheetDialogFragment.kt
@@ -1,0 +1,71 @@
+package org.cru.godtools.base.tool.ui.share
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
+import android.content.pm.ResolveInfo
+import android.os.Bundle
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.ccci.gto.android.common.material.bottomsheet.BindingBottomSheetDialogFragment
+import org.cru.godtools.base.tool.R
+import org.cru.godtools.base.tool.databinding.ToolShareSheetBinding
+import org.cru.godtools.base.tool.ui.share.model.ShareItem
+import splitties.fragmentargs.arg
+import splitties.fragmentargs.argOrNull
+
+internal class ShareBottomSheetDialogFragment() :
+    BindingBottomSheetDialogFragment<ToolShareSheetBinding>(R.layout.tool_share_sheet),
+    ShareAppsAdapter.Callbacks,
+    OtherActionsAdapter.Callbacks {
+    constructor(shareItems: List<ShareItem>) : this() {
+        primaryShareItem = shareItems.firstOrNull()?.takeIf { it.shareIntent != null }
+        otherShareItems = if (primaryShareItem != null) shareItems.drop(1) else shareItems
+    }
+
+    private var primaryShareItem by argOrNull<ShareItem>()
+    private var otherShareItems by arg<List<ShareItem>>()
+
+    override fun onBindingCreated(binding: ToolShareSheetBinding, savedInstanceState: Bundle?) {
+        binding.primaryShareItem = primaryShareItem
+        binding.otherShareItems = otherShareItems
+
+        primaryShareItem?.shareIntent?.let { intent ->
+            viewLifecycleOwner.lifecycleScope.launch {
+                val items = withContext(Dispatchers.IO) {
+                    requireContext().packageManager.queryIntentActivities(intent, MATCH_DEFAULT_ONLY).take(6)
+                }
+                binding.apps.adapter = ShareAppsAdapter(items, this@ShareBottomSheetDialogFragment)
+            }
+        }
+        binding.otherActions.adapter = OtherActionsAdapter(this, otherShareItems, this)
+    }
+
+    // region ResolveInfoAdapter.Callbacks
+    override fun onOpenApp(info: ResolveInfo) {
+        primaryShareItem?.shareIntent?.let { Intent(it) }?.let { intent ->
+            intent.component = ComponentName(info.activityInfo.packageName, info.activityInfo.name)
+            intent.setPackage(info.activityInfo.packageName)
+            startActivity(intent)
+        }
+        dismissAllowingStateLoss()
+    }
+
+    override fun onShowChooser() {
+        val shareItem = primaryShareItem
+        shareItem?.shareIntent?.let {
+            startActivity(Intent.createChooser(it, getString(R.string.share_tool_title, shareItem.shareTitle)))
+        }
+        dismissAllowingStateLoss()
+    }
+    // endregion ResolveInfoAdapter.Callbacks
+
+    // region OtherActionsAdapter.Callbacks
+    override fun triggerAction(item: ShareItem?) {
+        activity?.let { item?.triggerAction(it) }
+        dismissAllowingStateLoss()
+    }
+    // endregion OtherActionsAdapter.Callbacks
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/DefaultShareItem.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/DefaultShareItem.kt
@@ -1,0 +1,16 @@
+package org.cru.godtools.base.tool.ui.share.model
+
+import android.app.Activity
+import android.content.Intent
+import kotlinx.parcelize.Parcelize
+import org.ccci.gto.android.common.Ordered
+import org.cru.godtools.base.tool.R
+
+@Parcelize
+class DefaultShareItem(override val shareTitle: String? = null, override val shareIntent: Intent) : ShareItem {
+    override val order get() = Ordered.HIGHEST_PRECEDENCE
+
+    override fun triggerAction(activity: Activity) {
+        activity.startActivity(Intent.createChooser(shareIntent, activity.getString(R.string.share_tool_title, shareTitle)))
+    }
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/ShareItem.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/ShareItem.kt
@@ -1,0 +1,16 @@
+package org.cru.godtools.base.tool.ui.share.model
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Parcelable
+import androidx.annotation.LayoutRes
+import org.ccci.gto.android.common.Ordered
+
+interface ShareItem : Parcelable, Ordered {
+    val shareTitle: String? get() = null
+    val shareIntent: Intent? get() = null
+
+    @get:LayoutRes
+    val actionLayout: Int? get() = null
+    fun triggerAction(activity: Activity)
+}

--- a/ui/base-tool/src/main/res/drawable/ic_more_horiz_24dp.xml
+++ b/ui/base-tool/src/main/res/drawable/ic_more_horiz_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/tintable"
+        android:pathData="M6,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM18,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/ui/base-tool/src/main/res/layout/tool_share_item_app.xml
+++ b/ui/base-tool/src/main/res/layout/tool_share_item_app.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <data>
+        <variable name="callbacks" type="org.cru.godtools.base.tool.ui.share.ShareAppsAdapter.Callbacks" />
+        <variable name="info" type="android.content.pm.ResolveInfo" />
+    </data>
+
+    <RelativeLayout
+        style="@style/Widget.GodTools.Tool.ShareSheet.App"
+        android:onClick="@{() -> callbacks.onOpenApp(info)}">
+
+        <ImageView
+            android:id="@+id/icon"
+            style="@style/Widget.GodTools.Tool.ShareSheet.App.Icon"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
+            android:src="@{info.loadIcon(context.packageManager)}"
+            tools:src="@mipmap/ic_launcher" />
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/Widget.GodTools.Tool.ShareSheet.App.Name"
+            android:layout_below="@id/icon"
+            android:layout_centerHorizontal="true"
+            android:gravity="center_horizontal"
+            android:text="@{info.loadLabel(context.packageManager)}"
+            tools:text="GodTools" />
+    </RelativeLayout>
+</layout>

--- a/ui/base-tool/src/main/res/layout/tool_share_item_more.xml
+++ b/ui/base-tool/src/main/res/layout/tool_share_item_more.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable name="callbacks" type="org.cru.godtools.base.tool.ui.share.ShareAppsAdapter.Callbacks" />
+    </data>
+
+    <RelativeLayout
+        style="@style/Widget.GodTools.Tool.ShareSheet.App"
+        android:onClick="@{() -> callbacks.onShowChooser()}">
+
+        <ImageView
+            android:id="@+id/icon"
+            style="@style/Widget.GodTools.Tool.ShareSheet.App.Icon"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
+            android:src="@drawable/ic_more_horiz_24dp"
+            app:tint="@android:color/black" />
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/Widget.GodTools.Tool.ShareSheet.App.Name"
+            android:layout_below="@id/icon"
+            android:layout_centerHorizontal="true"
+            android:gravity="center_horizontal"
+            android:text="@string/tool_share_sheet_more_apps" />
+    </RelativeLayout>
+</layout>

--- a/ui/base-tool/src/main/res/layout/tool_share_sheet.xml
+++ b/ui/base-tool/src/main/res/layout/tool_share_sheet.xml
@@ -8,6 +8,9 @@
 
         <variable name="primaryShareItem" type="ShareItem" />
         <variable name="otherShareItems" type="List&lt;ShareItem&gt;" />
+
+        <!-- HACK: placeholder to provide BR.item, can be removed once we have shareables support added -->
+        <variable name="item" type="org.cru.godtools.base.tool.ui.share.model.ShareItem" />
     </data>
 
     <LinearLayout

--- a/ui/base-tool/src/main/res/layout/tool_share_sheet.xml
+++ b/ui/base-tool/src/main/res/layout/tool_share_sheet.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <import type="android.content.Intent" />
+        <import type="java.util.List" />
+        <import type="org.cru.godtools.base.tool.ui.share.model.ShareItem" />
+
+        <variable name="primaryShareItem" type="ShareItem" />
+        <variable name="otherShareItems" type="List&lt;ShareItem&gt;" />
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="32dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="32dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:text="@string/menu_share_tool"
+            android:textAppearance="@style/TextAppearance.GodTools.Headline" />
+
+        <TextView
+            android:id="@+id/subject"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="32dp"
+            android:layout_marginRight="32dp"
+            android:layout_marginBottom="16dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:text="@{primaryShareItem.shareIntent.getStringExtra(Intent.EXTRA_TEXT)}"
+            app:visibleIf="@{primaryShareItem != null}" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:visibleIf="@{primaryShareItem != null}" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/apps"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:orientation="horizontal"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:visibleIf="@{primaryShareItem != null}" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:visibleIf="@{primaryShareItem != null &amp;&amp; otherShareItems != null &amp;&amp; !otherShareItems.empty}" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/other_actions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:orientation="horizontal"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:visibleIf="@{otherShareItems != null &amp;&amp; !otherShareItems.empty}" />
+    </LinearLayout>
+</layout>

--- a/ui/base-tool/src/main/res/values/strings_tool_renderer.xml
+++ b/ui/base-tool/src/main/res/values/strings_tool_renderer.xml
@@ -13,4 +13,7 @@
 
     <string name="tract_content_input_error_required">%1$s is required</string>
     <string name="tract_content_input_error_invalid_email">Please enter a valid email address</string>
+
+    <!-- Share Sheet -->
+    <string name="tool_share_sheet_more_apps">More</string>
 </resources>

--- a/ui/base-tool/src/main/res/values/strings_tool_renderer.xml
+++ b/ui/base-tool/src/main/res/values/strings_tool_renderer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="menu_share_tool">Share</string>
-    <string name="share_tool_subject" translatable="false">%1$s</string>
     <string name="share_tool_title">Share “%1$s” using</string>
     <string name="share_tool_message_article">I wanted to share this article with you and would like to hear your thoughts about it.\n%1$s</string>
 

--- a/ui/base-tool/src/main/res/values/styles_share_sheet.xml
+++ b/ui/base-tool/src/main/res/values/styles_share_sheet.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- region Apps -->
+    <style name="Widget.GodTools.Tool.ShareSheet.App" parent="Base">
+        <item name="android:layout_width">96dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingLeft">8dp</item>
+        <item name="android:paddingTop">20dp</item>
+        <item name="android:paddingRight">8dp</item>
+        <item name="android:paddingBottom">8dp</item>
+    </style>
+
+    <style name="Widget.GodTools.Tool.ShareSheet.App.Icon" parent="Base">
+        <item name="android:layout_width">56dp</item>
+        <item name="android:layout_height">56dp</item>
+        <item name="android:scaleType">fitCenter</item>
+    </style>
+
+    <style name="Widget.GodTools.Tool.ShareSheet.App.Name" parent="Base">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">4dp</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:lines">2</item>
+        <item name="android:textAppearance">@style/TextAppearance.GodTools.Tool.ShareSheet.App.Name</item>
+    </style>
+
+    <style name="TextAppearance.GodTools.Tool.ShareSheet.App.Name" parent="TextAppearance.GodTools.Small" />
+    <!-- endregion Apps -->
+
+    <!-- region Other Actions -->
+    <dimen name="tool_share_sheet_other_action_size">128dp</dimen>
+    <dimen name="tool_share_sheet_other_action_padding">8dp</dimen>
+
+    <style name="Widget.GodTools.Tool.ShareSheet.Item.Other" parent="Base">
+        <item name="android:layout_width">@dimen/tool_share_sheet_other_action_size</item>
+        <item name="android:layout_height">@dimen/tool_share_sheet_other_action_size</item>
+        <item name="android:padding">@dimen/tool_share_sheet_other_action_padding</item>
+        <item name="android:clipToPadding">false</item>
+    </style>
+    <!-- endregion Other Actions -->
+</resources>

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -5,6 +5,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.cru.godtools.base.tool.activity.BaseToolActivity.LoadingState
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -18,6 +22,7 @@ import org.hamcrest.Matchers.anEmptyMap
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.hasEntry
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -49,6 +54,7 @@ class MultiLanguageToolActivityDataModelTest {
 
     @Before
     fun setupDataModel() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         dao = mock()
         downloadManager = mock()
         manifestManager = mock()
@@ -64,6 +70,11 @@ class MultiLanguageToolActivityDataModelTest {
     @Before
     fun setupObserver() {
         observer = mock()
+    }
+
+    @After
+    fun cleanupDataModel() {
+        Dispatchers.resetMain()
     }
 
     private fun wheneverGetManifest(tool: String, locale: Locale) =

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/databinding/ToolShareSheetBindingTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/databinding/ToolShareSheetBindingTest.kt
@@ -1,0 +1,54 @@
+package org.cru.godtools.base.tool.databinding
+
+import android.view.LayoutInflater
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cru.godtools.base.tool.R
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.Robolectric
+
+@RunWith(AndroidJUnit4::class)
+class ToolShareSheetBindingTest {
+    private lateinit var binding: ToolShareSheetBinding
+
+    @Before
+    fun createBinding() {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).get()
+        activity.setTheme(R.style.Theme_MaterialComponents)
+
+        binding = ToolShareSheetBinding.inflate(LayoutInflater.from(activity), null, false)
+        binding.lifecycleOwner = activity
+        binding.executePendingBindings()
+    }
+
+    // region otherActions
+    @Test
+    fun `otherActions - hidden when otherShareItems is null`() {
+        binding.otherShareItems = null
+        binding.executePendingBindings()
+
+        assertEquals(View.GONE, binding.otherActions.visibility)
+    }
+
+    @Test
+    fun `otherActions - hidden when otherShareItems is empty`() {
+        binding.otherShareItems = emptyList()
+        binding.executePendingBindings()
+
+        assertEquals(View.GONE, binding.otherActions.visibility)
+    }
+
+    @Test
+    fun `otherActions - visible when otherShareItems contains items`() {
+        binding.otherShareItems = listOf(mock())
+        binding.executePendingBindings()
+
+        assertEquals(View.VISIBLE, binding.otherActions.visibility)
+    }
+    // endregion otherActions
+}

--- a/ui/base/src/main/res/values/colors.xml
+++ b/ui/base/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="gray_BE">#bebebe</color>
     <color name="gray_E6">#E6E6E6</color>
     <color name="gray_F2">#F2F2F2</color>
+    <color name="gray_F5">#F5F5F5</color>
     <color name="white">#ffffff</color>
 
     <!-- theme colors -->

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.tract.ui.share.model
+
+import android.app.Activity
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.cru.godtools.base.tool.ui.share.model.ShareItem
+import org.cru.godtools.tract.R
+import org.cru.godtools.tract.activity.TractActivity
+
+@Parcelize
+class LiveShareItem(override val shareTitle: String?) : ShareItem {
+    @IgnoredOnParcel
+    override val actionLayout = R.layout.tract_share_item_live_share
+
+    override fun triggerAction(activity: Activity) {
+        (activity as? TractActivity)?.shareLiveShareLink()
+    }
+}

--- a/ui/tract-renderer/src/main/res/layout/tract_share_item_live_share.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_share_item_live_share.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable name="callbacks" type="org.cru.godtools.base.tool.ui.share.OtherActionsAdapter.Callbacks" />
+        <variable name="item" type="org.cru.godtools.base.tool.ui.share.model.ShareItem" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        style="@style/Widget.GodTools.Tool.ShareSheet.Item.Other"
+        android:onClick="@{() -> callbacks.triggerAction(item)}">
+        <!-- TODO: define an actual ShapeAppearanceOverlay -->
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/background"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:background="@color/gray_F5"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShapeAppearance.MaterialComponents.MediumComponent" />
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:src="@drawable/ic_tract_live_share"
+            app:layout_constraintBottom_toTopOf="@id/text"
+            app:layout_constraintEnd_toEndOf="@id/background"
+            app:layout_constraintStart_toStartOf="@id/background"
+            app:layout_constraintTop_toTopOf="@id/background"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:tint="@color/gt_blue" />
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginRight="8dp"
+            android:gravity="top|center_horizontal"
+            android:text="@string/menu_live_share_publish"
+            app:layout_constraintBottom_toBottomOf="@id/background"
+            app:layout_constraintEnd_toEndOf="@id/background"
+            app:layout_constraintStart_toStartOf="@id/background"
+            app:layout_constraintTop_toBottomOf="@id/icon" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/ui/tract-renderer/src/main/res/menu/activity_tract_live_share.xml
+++ b/ui/tract-renderer/src/main/res/menu/activity_tract_live_share.xml
@@ -9,22 +9,4 @@
         android:title="@string/menu_live_share_active"
         android:visible="false"
         app:showAsAction="always" />
-
-    <item
-        android:id="@+id/action_share"
-        android:icon="@drawable/ic_share"
-        android:orderInCategory="200"
-        android:title="@string/menu_share_tool"
-        app:showAsAction="always">
-        <menu>
-            <item
-                android:id="@+id/action_share_tool"
-                android:orderInCategory="100"
-                android:title="@string/menu_share_tract" />
-            <item
-                android:id="@+id/action_live_share_publish"
-                android:orderInCategory="200"
-                android:title="@string/menu_live_share_publish" />
-        </menu>
-    </item>
 </menu>

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -142,7 +142,7 @@ class TractActivityTest {
     @Test
     fun verifyShareMenuVisible() {
         whenGetTranslation().thenReturn(ImmutableLiveData(Translation()))
-        whenGetManifest().thenReturn(ImmutableLiveData(Manifest()))
+        whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
         ActivityScenario.launch<TractActivity>(context.createTractActivityIntent("test", Locale.ENGLISH)).use {
             it.moveToState(Lifecycle.State.RESUMED)
@@ -158,7 +158,7 @@ class TractActivityTest {
     @Test
     fun verifyShareMenuVisibleForDeepLink() {
         whenGetTranslation().thenReturn(ImmutableLiveData(Translation()))
-        whenGetManifest().thenReturn(ImmutableLiveData(Manifest()))
+        whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
         val intent = Intent(context, TractActivity::class.java).apply {
             action = Intent.ACTION_VIEW
@@ -194,7 +194,8 @@ class TractActivityTest {
     @Test
     fun verifyShareMenuHiddenWhenShowingTips() {
         whenGetTranslation().thenReturn(ImmutableLiveData(Translation()))
-        whenGetManifest().thenReturn(ImmutableLiveData(Manifest(tips = { listOf(Tip()) })))
+        whenGetManifest()
+            .thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH, tips = { listOf(Tip()) })))
 
         val intent = context.createTractActivityIntent("test", Locale.ENGLISH, showTips = true)
         ActivityScenario.launch<TractActivity>(intent).use {
@@ -211,7 +212,7 @@ class TractActivityTest {
     @Test
     fun verifyShareMenuHiddenWhenLiveShareSubscriber() {
         whenGetTranslation().thenReturn(ImmutableLiveData(Translation()))
-        whenGetManifest().thenReturn(ImmutableLiveData(Manifest()))
+        whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
         val intent = Intent(context, TractActivity::class.java).apply {
             action = Intent.ACTION_VIEW


### PR DESCRIPTION
- wrap shareToolUri into LiveData to be able to observe changes
- get rid of unnecessary updateShareMenuItem method
- remove unnecessary message for share message subject
- create ShareBottomSheetDialogFragment
- trigger the new share sheet when there is more than 1 share item
- add Live Share item to custom share sheet
