### PR TITLE
cleanup

### DIFF
--- a/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/java/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -315,7 +315,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             .setType("text/plain")
             .putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name))
             .putExtra(Intent.EXTRA_TEXT, getString(R.string.share_general_message, shareLink))
-            .let { Intent.createChooser(it, getString(R.string.share_prompt)) }
+            .let { Intent.createChooser(it, null) }
             .also { startActivity(it) }
     }
 

--- a/app/src/main/java/org/cru/godtools/ui/languages/LanguagesAdapter.kt
+++ b/app/src/main/java/org/cru/godtools/ui/languages/LanguagesAdapter.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.recyclerview.widget.RecyclerView.NO_ID
 import java.util.Locale
-import org.ccci.gto.android.common.recyclerview.adapter.SimpleDataBindingAdapter
+import org.ccci.gto.android.common.androidx.recyclerview.adapter.SimpleDataBindingAdapter
 import org.cru.godtools.databinding.ListItemLanguageBinding
 import org.cru.godtools.model.Language
 

--- a/app/src/main/res/values/strings_tools.xml
+++ b/app/src/main/res/values/strings_tools.xml
@@ -7,7 +7,6 @@
     <string name="nav_all_tools">All Tools</string>
     <string name="action_tools_about">About</string>
     <string name="action_tools_open">Open</string>
-    <string name="dashboard_tools_section_categories_all">All Tools</string>
     <string name="tools_list_remove_favorite_dialog_title">Remove “%1$s” from Favorites?</string>
     <string name="tools_list_remove_favorite_dialog_confirm">Remove</string>
     <string name="tools_list_remove_favorite_dialog_dismiss">Cancel</string>
@@ -16,6 +15,7 @@
     <string name="tools_list_lesson_info_length">%1$d Min Read</string>
     <string name="tools_list_lesson_info_language_available">Available in %1$s</string>
     <string name="dashboard_tools_section_categories_label">Categories</string>
+    <string name="dashboard_tools_section_categories_all">All Tools</string>
     <string name="dashboard_tools_section_spotlight_label">Tool Spotlight</string>
     <string name="dashboard_tools_section_spotlight_description">Here are some tools we thought you might like</string>
 

--- a/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/FileSystem.kt
@@ -13,14 +13,12 @@ import kotlinx.coroutines.withContext
 open class FileSystem(context: Context, dirName: String) {
     private val coroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    private val dirTask = coroutineScope.async { File(context.filesDir, dirName) }
+    protected val dirTask = coroutineScope.async { File(context.filesDir, dirName) }
     private val dirCreated = coroutineScope.async { dirTask.await().run { (exists() || mkdirs()) && isDirectory } }
 
     suspend fun exists() = dirCreated.await()
     suspend fun rootDir() = dirTask.await()
 
-    suspend fun createTmpFile(prefix: String, suffix: String? = null): File =
-        withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }
     suspend fun file(filename: String) = File(dirTask.await(), filename)
 
     suspend fun openInputStream(filename: String): InputStream =

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/AemFileSystem.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/util/AemFileSystem.kt
@@ -2,9 +2,15 @@ package org.cru.godtools.article.aem.util
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.cru.godtools.base.FileSystem
 
 @Singleton
-class AemFileSystem @Inject constructor(@ApplicationContext context: Context) : FileSystem(context, "aem-resources")
+class AemFileSystem @Inject constructor(@ApplicationContext context: Context) : FileSystem(context, "aem-resources") {
+    suspend fun createTmpFile(prefix: String, suffix: String? = null): File =
+        withContext(Dispatchers.IO) { File.createTempFile(prefix, suffix, dirTask.await()) }
+}

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/AemImportRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/AemImportRepositoryTest.kt
@@ -2,7 +2,8 @@ package org.cru.godtools.article.aem.db
 
 import android.net.Uri
 import java.util.Date
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.base.TimeConstants.WEEK_IN_MS
 import org.cru.godtools.article.aem.model.AemImport
 import org.hamcrest.MatcherAssert.assertThat
@@ -15,11 +16,12 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AemImportRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : AemImportRepository(db) {}
 
     @Test
-    fun `accessAemImport()`() = runBlockingTest {
+    fun `accessAemImport()`() = runTest {
         val uri = mock<Uri>()
         val start = Date()
         repo.accessAemImport(uri)
@@ -38,7 +40,7 @@ class AemImportRepositoryTest : AbstractArticleRoomDatabaseTest() {
     }
 
     @Test
-    fun `removeOrphanedAemImports()`() = runBlockingTest {
+    fun `removeOrphanedAemImports()`() = runTest {
         repo.removeOrphanedAemImports()
 
         val accessedBefore = argumentCaptor<Date>()

--- a/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/java/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.article.aem.db
 
 import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.cru.godtools.article.aem.model.TranslationRef
 import org.cru.godtools.article.aem.model.toTranslationRefKey
 import org.cru.godtools.model.Translation
@@ -35,7 +35,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
 
     // region isProcessed()
     @Test
-    fun `isProcessed() - Missing Translation`() = runBlockingTest {
+    fun `isProcessed() - Missing Translation`() = runTest {
         whenFindingTranslation().thenReturn(null)
 
         assertFalse(repo.isProcessed(translation))
@@ -44,7 +44,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     }
 
     @Test
-    fun `isProcessed() - Invalid Translation`() = runBlockingTest {
+    fun `isProcessed() - Invalid Translation`() = runTest {
         translation.toolCode = null
 
         assertFalse(repo.isProcessed(translation))
@@ -52,7 +52,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     }
 
     @Test
-    fun `isProcessed() - Not Processed`() = runBlockingTest {
+    fun `isProcessed() - Not Processed`() = runTest {
         whenFindingTranslation().thenReturn(translationRef)
 
         assertFalse(repo.isProcessed(translation))
@@ -61,7 +61,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     }
 
     @Test
-    fun `isProcessed() - Processed`() = runBlockingTest {
+    fun `isProcessed() - Processed`() = runTest {
         translationRef.processed = true
         whenFindingTranslation().thenReturn(translationRef)
 
@@ -75,7 +75,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
 
     // region removeMissingTranslations()
     @Test
-    fun `removeMissingTranslations()`() = runBlockingTest {
+    fun `removeMissingTranslations()`() = runTest {
         val translation2 = Translation().apply {
             toolCode = "invalid"
             languageCode = LOCALE
@@ -95,7 +95,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     }
 
     @Test
-    fun `removeMissingTranslations() - Nothing to remove`() = runBlockingTest {
+    fun `removeMissingTranslations() - Nothing to remove`() = runTest {
         translationDao.stub {
             onBlocking { getAll() } doReturn listOf(translationRef)
         }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -187,7 +187,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     protected open fun getShareItems(): List<ShareItem> =
-        listOfNotNull(buildShareIntent()?.let { DefaultShareItem(shareLinkTitle, it) })
+        listOfNotNull(buildShareIntent()?.let { DefaultShareItem(it) })
 
     private fun buildShareIntent(
         title: String? = shareLinkTitle,
@@ -207,7 +207,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         shareUrl: String? = shareLinkUri
     ) {
         val intent = buildShareIntent(title, message, shareUrl) ?: return
-        DefaultShareItem(title, intent).triggerAction(this)
+        DefaultShareItem(intent).triggerAction(this)
     }
     // endregion Share tool logic
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -194,6 +194,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
                 loadingState[it] != LoadingState.NOT_FOUND && loadingState[it] != LoadingState.INVALID_TYPE &&
                     loadingState[it] != LoadingState.OFFLINE
             }?.let { dataModel.setActiveLocale(it) }
+            else -> Unit
         }
     }
     // endregion Active Translation management

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -17,8 +17,8 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.and
@@ -64,7 +64,7 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
     private val distinctToolCode = toolCode.distinctUntilChanged()
     private val distinctLocales = locales.distinctUntilChanged()
 
-    val tool = distinctToolCode.asFlow().flatMapLatest { it?.let { dao.findAsFlow<Tool>(it) } ?: emptyFlow() }
+    val tool = distinctToolCode.asFlow().flatMapLatest { it?.let { dao.findAsFlow<Tool>(it) } ?: flowOf(null) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     val languages = distinctLocales.switchMap {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/LottieAnimationViewBindingAdapter.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/LottieAnimationViewBindingAdapter.kt
@@ -3,10 +3,11 @@ package org.cru.godtools.base.tool.databinding
 import androidx.databinding.BindingAdapter
 import com.airbnb.lottie.LottieAnimationView
 import org.ccci.gto.android.common.lottie.setAnimationFromFile
+import org.cru.godtools.base.tool.model.getFileBlocking
 import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.Resource
 
 @BindingAdapter("animation")
 internal fun LottieAnimationView.setAnimation(resource: Resource?) {
-    resource?.localName?.let { setAnimationFromFile(context.toolFileSystem.getFileBlocking(it)) }
+    resource?.getFileBlocking(context.toolFileSystem)?.let { setAnimationFromFile(it) }
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/MaterialButtonAdapters.kt
@@ -7,6 +7,7 @@ import com.google.android.material.button.MaterialButton.ICON_GRAVITY_TEXT_START
 import org.ccci.gto.android.common.picasso.material.button.MaterialButtonIconTarget
 import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.dagger.picasso
+import org.cru.godtools.base.tool.model.getFileBlocking
 import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.Gravity
 import org.cru.godtools.tool.model.Resource
@@ -14,7 +15,7 @@ import org.cru.godtools.tool.model.Resource
 @BindingAdapter("icon", "iconSize")
 fun MaterialButton.bindIconResource(resource: Resource?, size: Int) {
     val target = MaterialButtonIconTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
+    val file = resource?.getFileBlocking(context.toolFileSystem)
     val imageSize = dpToPixelSize(size, resources)
     if (file != null) {
         context.picasso.load(file)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/PicassoImageViewAdapters.kt
@@ -7,6 +7,7 @@ import jp.wasabeef.picasso.transformations.CropTransformation.GravityHorizontal
 import jp.wasabeef.picasso.transformations.CropTransformation.GravityVertical
 import org.ccci.gto.android.common.picasso.view.PicassoImageView
 import org.ccci.gto.android.common.picasso.view.SimplePicassoImageView
+import org.cru.godtools.base.tool.model.getFileBlocking
 import org.cru.godtools.base.tool.ui.util.layoutDirection
 import org.cru.godtools.base.tool.widget.SimpleScaledPicassoImageView
 import org.cru.godtools.base.toolFileSystem
@@ -49,4 +50,4 @@ internal fun SimpleScaledPicassoImageView.bindScaledResource(
 }
 
 private fun <T> T.setPicassoResource(resource: Resource?) where T : ImageView, T : PicassoImageView =
-    setPicassoFile(resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) })
+    setPicassoFile(resource?.getFileBlocking(context.toolFileSystem))

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/databinding/TextViewAdapters.kt
@@ -11,6 +11,7 @@ import org.ccci.gto.android.common.picasso.widget.TextViewDrawableStartTarget
 import org.ccci.gto.android.common.util.dpToPixelSize
 import org.cru.godtools.base.tool.R
 import org.cru.godtools.base.tool.dagger.picasso
+import org.cru.godtools.base.tool.model.getFileBlocking
 import org.cru.godtools.base.tool.ui.util.getTypeface
 import org.cru.godtools.base.toolFileSystem
 import org.cru.godtools.tool.model.Resource
@@ -42,7 +43,7 @@ fun TextView.bindTextNode(text: Text?, textSize: Float?) {
 @BindingAdapter("android:drawableStart", "drawableStartSize")
 fun TextView.bindDrawableStartResource(resource: Resource?, drawableStartSize: Int) {
     val target = TextViewDrawableStartTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
+    val file = resource?.getFileBlocking(context.toolFileSystem)
     val imageSize = dpToPixelSize(drawableStartSize, resources)
     if (file != null) {
         context.picasso.load(file)
@@ -58,7 +59,7 @@ fun TextView.bindDrawableStartResource(resource: Resource?, drawableStartSize: I
 @BindingAdapter("android:drawableEnd", "drawableEndSize")
 fun TextView.bindDrawableEndResource(resource: Resource?, drawableEndSize: Int) {
     val target = TextViewDrawableEndTarget.of(this)
-    val file = resource?.localName?.let { context.toolFileSystem.getFileBlocking(it) }
+    val file = resource?.getFileBlocking(context.toolFileSystem)
     val imageSize = dpToPixelSize(drawableEndSize, resources)
     if (file != null) {
         context.picasso.load(file)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/model/Resource.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/model/Resource.kt
@@ -1,0 +1,6 @@
+package org.cru.godtools.base.tool.model
+
+import org.cru.godtools.base.ToolFileSystem
+import org.cru.godtools.tool.model.Resource
+
+fun Resource.getFileBlocking(fileSystem: ToolFileSystem) = localName?.let { fileSystem.getFileBlocking(it) }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareBottomSheetDialogFragment.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/ShareBottomSheetDialogFragment.kt
@@ -55,9 +55,7 @@ internal class ShareBottomSheetDialogFragment() :
 
     override fun onShowChooser() {
         val shareItem = primaryShareItem
-        shareItem?.shareIntent?.let {
-            startActivity(Intent.createChooser(it, getString(R.string.share_tool_title, shareItem.shareTitle)))
-        }
+        shareItem?.shareIntent?.let { startActivity(Intent.createChooser(it, null)) }
         dismissAllowingStateLoss()
     }
     // endregion ResolveInfoAdapter.Callbacks

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/DefaultShareItem.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/DefaultShareItem.kt
@@ -4,15 +4,12 @@ import android.app.Activity
 import android.content.Intent
 import kotlinx.parcelize.Parcelize
 import org.ccci.gto.android.common.Ordered
-import org.cru.godtools.base.tool.R
 
 @Parcelize
-class DefaultShareItem(override val shareTitle: String? = null, override val shareIntent: Intent) : ShareItem {
+class DefaultShareItem(override val shareIntent: Intent) : ShareItem {
     override val order get() = Ordered.HIGHEST_PRECEDENCE
 
     override fun triggerAction(activity: Activity) {
-        activity.startActivity(
-            Intent.createChooser(shareIntent, activity.getString(R.string.share_tool_title, shareTitle))
-        )
+        activity.startActivity(Intent.createChooser(shareIntent, null))
     }
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/ShareItem.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/share/model/ShareItem.kt
@@ -7,7 +7,6 @@ import androidx.annotation.LayoutRes
 import org.ccci.gto.android.common.Ordered
 
 interface ShareItem : Parcelable, Ordered {
-    val shareTitle: String? get() = null
     val shareIntent: Intent? get() = null
 
     @get:LayoutRes

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -300,7 +300,7 @@ class TractActivity :
 
     override fun getShareItems() = buildList {
         addAll(super.getShareItems())
-        if (dataModel.tool.value?.isScreenShareDisabled != true) add(LiveShareItem(shareLinkTitle))
+        if (dataModel.tool.value?.isScreenShareDisabled != true) add(LiveShareItem())
     }
     // endregion Share Menu Logic
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.tract.ui.share.model
 
 import android.app.Activity
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.cru.godtools.base.tool.ui.share.model.ShareItem
 import org.cru.godtools.tract.R
@@ -9,8 +8,7 @@ import org.cru.godtools.tract.activity.TractActivity
 
 @Parcelize
 class LiveShareItem : ShareItem {
-    @IgnoredOnParcel
-    override val actionLayout = R.layout.tract_share_item_live_share
+    override val actionLayout get() = R.layout.tract_share_item_live_share
 
     override fun triggerAction(activity: Activity) {
         (activity as? TractActivity)?.shareLiveShareLink()

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/ui/share/model/LiveShareItem.kt
@@ -8,7 +8,7 @@ import org.cru.godtools.tract.R
 import org.cru.godtools.tract.activity.TractActivity
 
 @Parcelize
-class LiveShareItem(override val shareTitle: String?) : ShareItem {
+class LiveShareItem : ShareItem {
     @IgnoredOnParcel
     override val actionLayout = R.layout.tract_share_item_live_share
 


### PR DESCRIPTION
- use the new base binding adapter
- use flowOf(null) to ensure we don't continue to use an old tool model
- chooser title is unused if the intent is an ACTION_SEND intent
