### PR TITLE
cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,10 @@
             android:screenOrientation="@integer/default_screen_orientation" />
 
         <activity
+            android:name=".tool.cyoa.ui.CyoaActivity"
+            android:parentActivityName="org.keynote.godtools.android.activity.MainActivity" />
+
+        <activity
             android:name=".tract.activity.TractActivity"
             android:parentActivityName="org.keynote.godtools.android.activity.MainActivity" />
 

--- a/app/src/main/java/org/cru/godtools/util/ActivityUtils.kt
+++ b/app/src/main/java/org/cru/godtools/util/ActivityUtils.kt
@@ -3,9 +3,9 @@ package org.cru.godtools.util
 import android.app.Activity
 import java.util.Locale
 import org.cru.godtools.base.tool.startLessonActivity
-import org.cru.godtools.base.tool.startTractActivity
 import org.cru.godtools.base.ui.startArticlesActivity
 import org.cru.godtools.base.ui.startCyoaActivity
+import org.cru.godtools.base.ui.startTractActivity
 import org.cru.godtools.model.Tool.Type
 
 fun Activity.openToolActivity(code: String, type: Type, vararg languages: Locale, showTips: Boolean = false) =

--- a/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/java/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -32,7 +32,7 @@ import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
 import org.cru.godtools.base.ui.buildToolExtras
 
-fun Activity.startAemArticleActivity(toolCode: String?, language: Locale, articleUri: Uri) {
+fun Activity.startAemArticleActivity(toolCode: String, language: Locale, articleUri: Uri) {
     val extras = buildToolExtras(toolCode, language).apply {
         putParcelable(EXTRA_ARTICLE, articleUri)
     }

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
     kapt(libs.google.auto.value)
     kapt(libs.hilt.compiler)
 
-    testImplementation(project(":ui:tract-renderer"))
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.kotlin.coroutines.test)
     kaptTest(libs.androidx.databinding.compiler)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/Activities.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/Activities.kt
@@ -6,11 +6,8 @@ import android.content.Intent
 import android.os.Bundle
 import java.util.Locale
 import org.ccci.gto.android.common.util.os.putLocale
-import org.ccci.gto.android.common.util.os.putLocaleArray
 import org.cru.godtools.base.EXTRA_LANGUAGE
-import org.cru.godtools.base.EXTRA_LANGUAGES
 import org.cru.godtools.base.EXTRA_TOOL
-import org.cru.godtools.base.ui.EXTRA_SHOW_TIPS
 
 const val SHORTCUT_LAUNCH = "org.cru.godtools.tool.SHORTCUT_LAUNCH"
 
@@ -25,21 +22,3 @@ fun Context.createLessonActivityIntent(toolCode: String, language: Locale) =
         .putExtra(EXTRA_TOOL, toolCode)
         .putExtras(Bundle().apply { putLocale(EXTRA_LANGUAGE, language) })
 // endregion LessonActivity
-
-// region TractActivity
-private const val ACTIVITY_CLASS_TRACT = "org.cru.godtools.tract.activity.TractActivity"
-
-fun Activity.startTractActivity(toolCode: String, vararg languages: Locale?, showTips: Boolean) =
-    startActivity(createTractActivityIntent(toolCode, *languages, showTips = showTips))
-
-fun Context.createTractActivityIntent(toolCode: String, vararg languages: Locale?, showTips: Boolean = false) =
-    Intent().setClassName(this, ACTIVITY_CLASS_TRACT)
-        .putExtra(EXTRA_TOOL, toolCode)
-        .putLanguagesExtra(*languages)
-        .putExtra(EXTRA_SHOW_TIPS, showTips)
-
-private fun Intent.putLanguagesExtra(vararg languages: Locale?) = putExtras(
-    // XXX: we use singleString mode to support using this intent for legacy shortcuts
-    Bundle().apply { putLocaleArray(EXTRA_LANGUAGES, languages.filterNotNull().toTypedArray(), true) }
-)
-// endregion TractActivity

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.and
+import org.ccci.gto.android.common.androidx.lifecycle.combine
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
@@ -140,15 +141,15 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
 
     // region Available Locales
     @OptIn(ExperimentalStdlibApi::class)
-    val availableLocales = activeLocale
-        .combineWith(primaryLocales, parallelLocales, loadingState) { activeLocale, primary, parallel, loaded ->
+    val availableLocales =
+        combine(activeLocale, primaryLocales, parallelLocales, loadingState) { active, primary, parallel, loaded ->
             buildList {
                 primary
                     .filterNot { loaded[it] == LoadingState.INVALID_TYPE || loaded[it] == LoadingState.NOT_FOUND }
                     .let {
-                        it.firstOrNull { it == activeLocale && loaded[it] != LoadingState.OFFLINE }
+                        it.firstOrNull { it == active && loaded[it] != LoadingState.OFFLINE }
                             ?: it.firstOrNull { loaded[it] == LoadingState.LOADED }
-                            ?: it.firstOrNull { it == activeLocale }
+                            ?: it.firstOrNull { it == active }
                             ?: it.firstOrNull()
                     }
                     ?.let { add(it) }
@@ -156,9 +157,9 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
                     .filterNot { contains(it) }
                     .filterNot { loaded[it] == LoadingState.INVALID_TYPE || loaded[it] == LoadingState.NOT_FOUND }
                     .let {
-                        it.firstOrNull { it == activeLocale && loaded[it] != LoadingState.OFFLINE }
+                        it.firstOrNull { it == active && loaded[it] != LoadingState.OFFLINE }
                             ?: it.firstOrNull { loaded[it] == LoadingState.LOADED }
-                            ?: it.firstOrNull { it == activeLocale }
+                            ?: it.firstOrNull { it == active }
                             ?: it.firstOrNull()
                     }
                     ?.let { add(it) }

--- a/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/ParentControllerTest.kt
+++ b/ui/base-tool/src/test/java/org/cru/godtools/base/tool/ui/controller/ParentControllerTest.kt
@@ -10,13 +10,13 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.view.children
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.cru.godtools.base.tool.R
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
 import org.cru.godtools.tool.model.Base
 import org.cru.godtools.tool.model.Image
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.Paragraph
 import org.cru.godtools.tool.model.Text
-import org.cru.godtools.tract.R
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.instanceOf

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -39,6 +40,7 @@ import org.mockito.kotlin.whenever
 
 private const val TOOL = "kgp"
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class MultiLanguageToolActivityDataModelTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -40,4 +40,6 @@ dependencies {
 
     kapt(libs.dagger.compiler)
     kapt(libs.hilt.compiler)
+
+    testImplementation(project(":ui:tract-renderer"))
 }

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/Activities.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/Activities.kt
@@ -48,6 +48,19 @@ fun Context.createCyoaActivityIntent(toolCode: String, vararg languages: Locale?
         .putLanguagesExtra(*languages)
 // endregion CyoaActivity
 
+// region TractActivity
+private const val ACTIVITY_CLASS_TRACT = "org.cru.godtools.tract.activity.TractActivity"
+
+fun Activity.startTractActivity(toolCode: String, vararg languages: Locale?, showTips: Boolean) =
+    startActivity(createTractActivityIntent(toolCode, *languages, showTips = showTips))
+
+fun Context.createTractActivityIntent(toolCode: String, vararg languages: Locale?, showTips: Boolean = false) =
+    Intent().setClassName(this, ACTIVITY_CLASS_TRACT)
+        .putExtra(EXTRA_TOOL, toolCode)
+        .putLanguagesExtra(*languages)
+        .putExtra(EXTRA_SHOW_TIPS, showTips)
+// endregion TractActivity
+
 fun Context.buildToolExtras(toolCode: String?, language: Locale?) = BaseActivity.buildExtras(this).apply {
     putString(EXTRA_TOOL, toolCode)
     putLocale(EXTRA_LANGUAGE, language)

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/Activities.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/Activities.kt
@@ -61,7 +61,7 @@ fun Context.createTractActivityIntent(toolCode: String, vararg languages: Locale
         .putExtra(EXTRA_SHOW_TIPS, showTips)
 // endregion TractActivity
 
-fun Context.buildToolExtras(toolCode: String?, language: Locale?) = BaseActivity.buildExtras(this).apply {
+fun Context.buildToolExtras(toolCode: String, language: Locale) = BaseActivity.buildExtras(this).apply {
     putString(EXTRA_TOOL, toolCode)
     putLocale(EXTRA_LANGUAGE, language)
 }

--- a/ui/base/src/test/kotlin/org/cru/godtools/base/ui/ActivitiesTest.kt
+++ b/ui/base/src/test/kotlin/org/cru/godtools/base/ui/ActivitiesTest.kt
@@ -1,4 +1,4 @@
-package org.cru.godtools.base.tool
+package org.cru.godtools.base.ui
 
 import android.app.Activity
 import android.content.ComponentName
@@ -9,10 +9,9 @@ import java.util.Locale
 import org.ccci.gto.android.common.util.os.getLocaleArray
 import org.cru.godtools.base.EXTRA_LANGUAGES
 import org.cru.godtools.base.EXTRA_TOOL
-import org.cru.godtools.base.ui.EXTRA_SHOW_TIPS
 import org.cru.godtools.tract.activity.TractActivity
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.arrayContaining
+import org.hamcrest.Matchers
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -37,18 +36,7 @@ class ActivitiesTest {
         doNothing().whenever(activity).startActivity(any())
     }
 
-    @Test
-    fun verifyCreateTractActivityIntent() {
-        val intent = activity.createTractActivityIntent(TOOL, Locale.ENGLISH, null, Locale.FRENCH, Locale.CANADA)
-        intent.assertTractIntent(languages = arrayOf(Locale.ENGLISH, Locale.FRENCH, Locale.CANADA))
-    }
-
-    @Test
-    fun verifyCreateTractActivityIntentWithShowTips() {
-        val intent = activity.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH, showTips = true)
-        intent.assertTractIntent(languages = arrayOf(Locale.ENGLISH, Locale.FRENCH), showTips = true)
-    }
-
+    // region TractActivity
     @Test
     fun verifyStartTractActivity() {
         activity.startTractActivity(TOOL, Locale.ENGLISH, null, Locale.FRENCH, Locale.CANADA, showTips = false)
@@ -70,10 +58,23 @@ class ActivitiesTest {
         }
     }
 
+    @Test
+    fun verifyCreateTractActivityIntent() {
+        val intent = activity.createTractActivityIntent(TOOL, Locale.ENGLISH, null, Locale.FRENCH, Locale.CANADA)
+        intent.assertTractIntent(languages = arrayOf(Locale.ENGLISH, Locale.FRENCH, Locale.CANADA))
+    }
+
+    @Test
+    fun verifyCreateTractActivityIntentWithShowTips() {
+        val intent = activity.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH, showTips = true)
+        intent.assertTractIntent(languages = arrayOf(Locale.ENGLISH, Locale.FRENCH), showTips = true)
+    }
+
     private fun Intent.assertTractIntent(tool: String = TOOL, vararg languages: Locale, showTips: Boolean = false) {
         assertEquals(ComponentName(activity, TractActivity::class.java), component)
         assertEquals(tool, getStringExtra(EXTRA_TOOL))
-        assertThat(extras!!.getLocaleArray(EXTRA_LANGUAGES)!!, arrayContaining(*languages))
+        assertThat(extras!!.getLocaleArray(EXTRA_LANGUAGES)!!, Matchers.arrayContaining(*languages))
         assertEquals(showTips, getBooleanExtra(EXTRA_SHOW_TIPS, !showTips))
     }
+    // endregion TractActivity
 }

--- a/ui/cyoa-renderer/src/main/AndroidManifest.xml
+++ b/ui/cyoa-renderer/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
         <activity
             android:name=".ui.CyoaActivity"
             android:exported="false"
-            android:parentActivityName="org.keynote.godtools.android.activity.MainActivity"
             android:screenOrientation="@integer/default_screen_orientation"
             android:theme="@style/Theme.GodTools.Tool" />
     </application>

--- a/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/java/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -48,9 +48,9 @@ import org.ccci.gto.android.common.util.LocaleUtils
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.base.tool.SHORTCUT_LAUNCH
-import org.cru.godtools.base.tool.createTractActivityIntent
 import org.cru.godtools.base.ui.createArticlesIntent
 import org.cru.godtools.base.ui.createCyoaActivityIntent
+import org.cru.godtools.base.ui.createTractActivityIntent
 import org.cru.godtools.base.ui.util.getName
 import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.Tool

--- a/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/java/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -20,8 +20,8 @@ import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.base.EXTRA_LANGUAGES
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
-import org.cru.godtools.base.tool.createTractActivityIntent
 import org.cru.godtools.base.tool.service.ManifestManager
+import org.cru.godtools.base.ui.createTractActivityIntent
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Translation
 import org.cru.godtools.tool.model.Manifest


### PR DESCRIPTION
- set the Cyoa parent activity in the app module where the parent activity actually exists
- opt-in to the experimental coroutines test APIs
- move TractActivity intent creation/launch logic to :ui:base module
- tool and language can't be null for these methods
- use combine instead of combineWith
