### PR TITLE
GT-1484 Avoid a race condition between EventBus and ShortcutManager initialization

### DIFF
--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -293,11 +293,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         ) : this(manager, eventBus, settings, CoroutineScope(Dispatchers.Default + SupervisorJob()))
 
         // region Events
-        init {
-            // register event listeners
-            eventBus.register(this)
-        }
-
         @AnyThread
         @Subscribe
         fun onToolUpdate(event: ToolUpdateEvent) {
@@ -352,6 +347,9 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         }
 
         init {
+            // register event listeners
+            eventBus.register(this)
+
             // launch an initial update
             updateShortcutsActor.trySend(Unit)
         }


### PR DESCRIPTION
in rare situations eventbus can be triggered with an event before initialization has finished
