### PR TITLE
GT-1433 Make it possible to adjust the locales for an active tool

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -79,7 +79,8 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
 
     // region Intent Processing
     override fun processIntent(intent: Intent?, savedInstanceState: Bundle?) {
-        intent?.extras?.let { extras ->
+        if (dataModel.primaryLocales.value.isNullOrEmpty()) {
+            val extras = intent?.extras ?: return
             val locales = extras.getLocaleArray(EXTRA_LANGUAGES)?.filterNotNull().orEmpty()
             dataModel.primaryLocales.value = locales.take(1)
             dataModel.parallelLocales.value = locales.drop(1)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -18,7 +18,6 @@ import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.ccci.gto.android.common.util.os.getLocaleArray
 import org.cru.godtools.base.EXTRA_LANGUAGES
-import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.tool.R
 import org.cru.godtools.base.tool.analytics.model.ToggleLanguageAnalyticsActionEvent
 import org.cru.godtools.base.tool.viewmodel.ToolStateHolder
@@ -76,7 +75,6 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // region Intent Processing
     override fun processIntent(intent: Intent?, savedInstanceState: Bundle?) {
         intent?.extras?.let { extras ->
-            dataModel.toolCode.value = extras.getString(EXTRA_TOOL, dataModel.toolCode.value)
             val locales = extras.getLocaleArray(EXTRA_LANGUAGES)?.filterNotNull().orEmpty()
             dataModel.primaryLocales.value = locales.take(1)
             dataModel.parallelLocales.value = locales.drop(1)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -104,7 +104,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
                 if (languageToggleController.isUpdatingTabs) return
                 val locale = tab.tag as? Locale ?: return
                 eventBus.post(ToggleLanguageAnalyticsActionEvent(dataModel.toolCode.value, locale))
-                dataModel.setActiveLocale(locale)
+                dataModel.activeLocale.value = locale
             }
 
             override fun onTabReselected(tab: TabLayout.Tab?) = Unit
@@ -167,7 +167,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
 
     private fun setupActiveTranslationManagement() {
         dataModel.locales.map { it.firstOrNull() }.notNull().observeOnce(this) {
-            if (dataModel.activeLocale.value == null) dataModel.setActiveLocale(it)
+            if (dataModel.activeLocale.value == null) dataModel.activeLocale.value = it
         }
 
         dataModel.availableLocales.observe(this) {
@@ -191,7 +191,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
             LoadingState.OFFLINE -> availableLocales.firstOrNull {
                 loadingState[it] != LoadingState.NOT_FOUND && loadingState[it] != LoadingState.INVALID_TYPE &&
                     loadingState[it] != LoadingState.OFFLINE
-            }?.let { dataModel.setActiveLocale(it) }
+            }?.let { dataModel.activeLocale.value = it }
             else -> Unit
         }
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -177,29 +177,21 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
             if (dataModel.activeLocale.value == null) dataModel.activeLocale.value = it
         }
 
-        dataModel.availableLocales.observe(this) {
-            updateActiveLocaleToAvailableLocaleIfNecessary(availableLocales = it)
-        }
-        dataModel.activeLoadingState.observe(this) {
-            updateActiveLocaleToAvailableLocaleIfNecessary(activeLoadingState = it)
-        }
-        dataModel.loadingState.observe(this) { updateActiveLocaleToAvailableLocaleIfNecessary(loadingState = it) }
-    }
-
-    private fun updateActiveLocaleToAvailableLocaleIfNecessary(
-        activeLoadingState: LoadingState? = dataModel.activeLoadingState.value,
-        availableLocales: List<Locale> = dataModel.availableLocales.value.orEmpty(),
-        loadingState: Map<Locale, LoadingState> = dataModel.loadingState.value.orEmpty()
-    ) {
-        when (activeLoadingState) {
-            // update the active language if the current active language is not found, invalid, or offline
-            LoadingState.NOT_FOUND,
-            LoadingState.INVALID_TYPE,
-            LoadingState.OFFLINE -> availableLocales.firstOrNull {
-                loadingState[it] != LoadingState.NOT_FOUND && loadingState[it] != LoadingState.INVALID_TYPE &&
-                    loadingState[it] != LoadingState.OFFLINE
-            }?.let { dataModel.activeLocale.value = it }
-            else -> Unit
+        observe(
+            dataModel.activeLoadingState,
+            dataModel.availableLocales,
+            dataModel.loadingState
+        ) { activeLoadingState, availableLocales, loadingState ->
+            when (activeLoadingState) {
+                // update the active language if the current active language is not found, invalid, or offline
+                LoadingState.NOT_FOUND,
+                LoadingState.INVALID_TYPE,
+                LoadingState.OFFLINE -> availableLocales.firstOrNull {
+                    loadingState[it] != LoadingState.NOT_FOUND && loadingState[it] != LoadingState.INVALID_TYPE &&
+                        loadingState[it] != LoadingState.OFFLINE
+                }?.let { dataModel.activeLocale.value = it }
+                else -> Unit
+            }
         }
     }
     // endregion Active Translation management

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -51,12 +51,12 @@ private const val STATE_ACTIVE_LOCALE = "activeLocale"
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
-open class MultiLanguageToolActivityDataModel @Inject constructor(
+class MultiLanguageToolActivityDataModel @Inject constructor(
     dao: GodToolsDao,
     downloadManager: GodToolsDownloadManager,
     manifestManager: ManifestManager,
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
-    protected val savedState: SavedStateHandle,
+    private val savedState: SavedStateHandle,
 ) : ViewModel() {
     val toolCode by savedState.livedata<String?>(EXTRA_TOOL, null)
     val primaryLocales = MutableLiveData<List<Locale>>(emptyList())

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -47,8 +47,6 @@ import org.cru.godtools.tool.model.Manifest
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
 
-private const val STATE_ACTIVE_LOCALE = "activeLocale"
-
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
 class MultiLanguageToolActivityDataModel @Inject constructor(
@@ -56,7 +54,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     downloadManager: GodToolsDownloadManager,
     manifestManager: ManifestManager,
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
-    private val savedState: SavedStateHandle,
+    savedState: SavedStateHandle,
 ) : ViewModel() {
     val toolCode by savedState.livedata<String?>(EXTRA_TOOL, null)
     val primaryLocales = MutableLiveData<List<Locale>>(emptyList())
@@ -116,10 +114,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     // endregion Loading State
 
     // region Active Tool
-    val activeLocale = savedState.getLiveData<String?>(STATE_ACTIVE_LOCALE)
-        .map { it?.let { Locale.forLanguageTag(it) } }
-        .distinctUntilChanged()
-    fun setActiveLocale(locale: Locale) = savedState.set(STATE_ACTIVE_LOCALE, locale.toLanguageTag())
+    val activeLocale by savedState.livedata<Locale?>()
 
     val activeLoadingState = distinctToolCode.switchCombineWith(activeLocale) { tool, l ->
         val manifest = manifestCache.get(tool, l)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -109,7 +109,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
                 isSyncFinished = syncFinished
             )
         }
-    }
+    }.distinctUntilChanged()
     // endregion Loading State
 
     // region Active Tool
@@ -160,7 +160,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
                     }
                     ?.let { add(it) }
             }
-        }
+        }.distinctUntilChanged()
     val visibleLocales = availableLocales.combineWith(loadingState) { locales, loadingState ->
         locales.filter { loadingState[it] == LoadingState.LOADED }
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -25,6 +25,7 @@ import org.ccci.gto.android.common.androidx.lifecycle.and
 import org.ccci.gto.android.common.androidx.lifecycle.combine
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
+import org.ccci.gto.android.common.androidx.lifecycle.livedata
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.ccci.gto.android.common.androidx.lifecycle.switchFold
 import org.ccci.gto.android.common.androidx.lifecycle.withInitialValue
@@ -32,6 +33,7 @@ import org.ccci.gto.android.common.db.Expression
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.findAsFlow
 import org.ccci.gto.android.common.db.getAsLiveData
+import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.tool.BaseToolRendererModule.Companion.IS_CONNECTED_LIVE_DATA
 import org.cru.godtools.base.tool.activity.BaseToolActivity.LoadingState
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -56,7 +58,7 @@ open class MultiLanguageToolActivityDataModel @Inject constructor(
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
     protected val savedState: SavedStateHandle,
 ) : ViewModel() {
-    val toolCode = MutableLiveData<String?>()
+    val toolCode by savedState.livedata<String?>(EXTRA_TOOL, null)
     val primaryLocales = MutableLiveData<List<Locale>>(emptyList())
     val parallelLocales = MutableLiveData<List<Locale>>(emptyList())
 

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -284,12 +284,12 @@ class MultiLanguageToolActivityDataModelTest {
         wheneverGetManifest(TOOL, Locale.FRENCH).thenReturn(MutableLiveData())
         dataModel.toolCode.value = TOOL
         dataModel.supportedType.value = null
-        dataModel.setActiveLocale(Locale.ENGLISH)
+        dataModel.activeLocale.value = Locale.ENGLISH
 
         dataModel.activeManifest.observeForever(observer)
         verify(manifestManager).getLatestPublishedManifestLiveData(any(), eq(Locale.ENGLISH))
         verify(manifestManager, never()).getLatestPublishedManifestLiveData(any(), eq(Locale.FRENCH))
-        dataModel.setActiveLocale(Locale.FRENCH)
+        dataModel.activeLocale.value = Locale.FRENCH
         verify(manifestManager).getLatestPublishedManifestLiveData(any(), eq(Locale.ENGLISH))
         verify(manifestManager).getLatestPublishedManifestLiveData(any(), eq(Locale.FRENCH))
         nullableArgumentCaptor<Manifest> {
@@ -308,7 +308,7 @@ class MultiLanguageToolActivityDataModelTest {
         wheneverGetManifest(TOOL, Locale.GERMAN).thenReturn(MutableLiveData())
         dataModel.toolCode.value = TOOL
         dataModel.supportedType.value = null
-        dataModel.setActiveLocale(Locale.FRENCH)
+        dataModel.activeLocale.value = Locale.FRENCH
         dataModel.primaryLocales.value = listOf(Locale.FRENCH, Locale.GERMAN)
         dataModel.visibleLocales.observeForever(observer)
 
@@ -328,7 +328,7 @@ class MultiLanguageToolActivityDataModelTest {
         wheneverGetManifest(TOOL, Locale.GERMAN).thenReturn(MutableLiveData(Manifest()))
         dataModel.toolCode.value = TOOL
         dataModel.supportedType.value = null
-        dataModel.setActiveLocale(Locale.FRENCH)
+        dataModel.activeLocale.value = Locale.FRENCH
         dataModel.primaryLocales.value = listOf(Locale.FRENCH, Locale.GERMAN)
         dataModel.visibleLocales.observeForever(observer)
 
@@ -352,7 +352,7 @@ class MultiLanguageToolActivityDataModelTest {
         wheneverGetManifest(TOOL, Locale.GERMAN).thenReturn(MutableLiveData())
         dataModel.toolCode.value = TOOL
         dataModel.supportedType.value = null
-        dataModel.setActiveLocale(Locale.ENGLISH)
+        dataModel.activeLocale.value = Locale.ENGLISH
         dataModel.primaryLocales.value = listOf(Locale.FRENCH, Locale.GERMAN)
         dataModel.isInitialSyncFinished.value = true
         dataModel.visibleLocales.observeForever(observer)
@@ -377,7 +377,7 @@ class MultiLanguageToolActivityDataModelTest {
         wheneverGetManifest(TOOL, Locale.GERMAN).thenReturn(MutableLiveData())
         dataModel.toolCode.value = TOOL
         dataModel.supportedType.value = null
-        dataModel.setActiveLocale(Locale.GERMAN)
+        dataModel.activeLocale.value = Locale.GERMAN
         dataModel.primaryLocales.value = listOf(Locale.FRENCH, Locale.GERMAN)
         dataModel.visibleLocales.observeForever(observer)
 

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -155,7 +155,7 @@ class TractActivity :
             dataModel.primaryLocales.value = primary
             dataModel.parallelLocales.value = parallel
             if (savedInstanceState == null) {
-                dataModel.setActiveLocale(data.deepLinkSelectedLanguage)
+                dataModel.activeLocale.value = data.deepLinkSelectedLanguage
                 data.deepLinkPage?.let { initialPage = it }
             }
         }
@@ -377,7 +377,7 @@ class TractActivity :
         if (event == null) return
         event.locale?.takeUnless { it == dataModel.activeLocale.value }?.let {
             dataModel.toolCode.value?.let { tool -> downloadManager.downloadLatestPublishedTranslationAsync(tool, it) }
-            dataModel.setActiveLocale(it)
+            dataModel.activeLocale.value = it
         }
         event.page?.let { goToPage(it) }
         eventBus.post(event)

--- a/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/java/org/cru/godtools/tract/activity/TractActivity.kt
@@ -148,8 +148,10 @@ class TractActivity :
     // region Intent Processing
     override fun processIntent(intent: Intent?, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
-        val data = intent?.data
-        if (intent?.action == Intent.ACTION_VIEW && data?.isTractDeepLink() == true) {
+        if (dataModel.primaryLocales.value.isNullOrEmpty() || savedInstanceState == null) {
+            if (intent?.action != Intent.ACTION_VIEW) return
+            val data = intent.data?.takeIf { it.isTractDeepLink() } ?: return
+
             dataModel.toolCode.value = data.deepLinkTool
             val (primary, parallel) = data.deepLinkLanguages
             dataModel.primaryLocales.value = primary


### PR DESCRIPTION
This PR adjusts logic within multi language tools so that the languages can be adjusted dynamically after the activity is initially created.

This does not add any UI for actually adjusting the languages, this is just adjustmenets to the underlying data model