### PR TITLE
GT-1433 Manage the activeLocale within the Data Model itself

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,7 @@ subprojects {
                 testImplementation libs.junit
                 testImplementation libs.mockito
                 testImplementation libs.mockito.kotlin
+                testImplementation libs.mockk
                 testImplementation libs.robolectric
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -139,6 +139,7 @@ materialBanner = "com.sergivonavi:materialbanner:1.2.0"
 materialComponents = "com.google.android.material:material:1.5.0"
 mockito = "org.mockito:mockito-inline:4.4.0"
 mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.0.0"
+mockk = "io.mockk:mockk:1.12.3"
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okta = "com.okta.android:okta-oidc-android:1.2.2"
 picasso = "com.squareup.picasso:picasso:2.8"

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -10,7 +10,6 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.map
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.tabs.TabLayout
 import java.util.Locale
@@ -18,9 +17,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import org.ccci.gto.android.common.androidx.lifecycle.combine
-import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observe
-import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.ccci.gto.android.common.util.os.getLocaleArray
 import org.cru.godtools.base.EXTRA_LANGUAGES
 import org.cru.godtools.base.tool.R
@@ -174,10 +171,6 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     override val activeToolLoadingStateLiveData get() = dataModel.activeLoadingState
 
     private fun setupActiveTranslationManagement() {
-        dataModel.locales.map { it.firstOrNull() }.notNull().observeOnce(this) {
-            if (dataModel.activeLocale.value == null) dataModel.activeLocale.value = it
-        }
-
         observe(
             dataModel.activeLoadingState,
             dataModel.availableLocales,

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -39,7 +39,6 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
         if (isFinishing) return
 
         setupDataModel()
-        setupActiveTranslationManagement()
     }
 
     override fun onContentChanged() {
@@ -169,24 +168,5 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // region Active Translation management
     override val activeManifestLiveData get() = dataModel.activeManifest
     override val activeToolLoadingStateLiveData get() = dataModel.activeLoadingState
-
-    private fun setupActiveTranslationManagement() {
-        observe(
-            dataModel.activeLoadingState,
-            dataModel.availableLocales,
-            dataModel.loadingState
-        ) { activeLoadingState, availableLocales, loadingState ->
-            when (activeLoadingState) {
-                // update the active language if the current active language is not found, invalid, or offline
-                LoadingState.NOT_FOUND,
-                LoadingState.INVALID_TYPE,
-                LoadingState.OFFLINE -> availableLocales.firstOrNull {
-                    loadingState[it] != LoadingState.NOT_FOUND && loadingState[it] != LoadingState.INVALID_TYPE &&
-                        loadingState[it] != LoadingState.OFFLINE
-                }?.let { dataModel.activeLocale.value = it }
-                else -> Unit
-            }
-        }
-    }
     // endregion Active Translation management
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -139,7 +139,8 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     // endregion Active Tool
 
     // region Available Locales
-    val availableLocales =
+    @VisibleForTesting
+    internal val availableLocales =
         combine(activeLocale, primaryLocales, parallelLocales, loadingState) { active, primary, parallel, loaded ->
             buildList {
                 primary

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -26,6 +26,8 @@ import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.getStateFlow
 import org.ccci.gto.android.common.androidx.lifecycle.livedata
+import org.ccci.gto.android.common.androidx.lifecycle.notNull
+import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.ccci.gto.android.common.androidx.lifecycle.switchFold
 import org.ccci.gto.android.common.androidx.lifecycle.withInitialValue
@@ -131,6 +133,13 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
         when {
             t == null || l == null -> emptyLiveData()
             else -> downloadManager.getDownloadProgressLiveData(t, l)
+        }
+    }
+
+    init {
+        // initialize the activeLocale if it hasn't been initialized yet
+        locales.map { it.firstOrNull() }.notNull().observeOnce {
+            if (activeLocale.value == null) activeLocale.value = it
         }
     }
     // endregion Active Tool

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -24,6 +24,8 @@ import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.hasEntry
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -277,6 +279,16 @@ class MultiLanguageToolActivityDataModelTest {
     }
     // endregion Property: loadingState
 
+    // region Active Tool
+    // region Property: activeLocale
+    @Test
+    fun `Property activeLocale - Initialize when locales initialized`() {
+        assertNull(dataModel.activeLocale.value)
+        dataModel.primaryLocales.value = listOf(Locale.ENGLISH)
+        assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
+    }
+    // endregion Property: activeLocale
+
     // region Property: activeManifest
     @Test
     fun `Property activeManifest - Change Active Locale`() {
@@ -297,6 +309,7 @@ class MultiLanguageToolActivityDataModelTest {
         }
     }
     // endregion Property: activeManifest
+    // endregion Active Tool
 
     // region Property: visibleLocales
     @Test

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -310,6 +310,56 @@ class MultiLanguageToolActivityDataModelTest {
         dataModel.primaryLocales.value = listOf(Locale.ENGLISH)
         assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
     }
+
+    @Test
+    fun `Property activeLocale - Updates when activeLoadingState is INVALID_TYPE`() {
+        val englishManifest = MutableLiveData<Manifest?>()
+        everyGetTranslation(TOOL, Locale.ENGLISH) returns MutableLiveData(Translation())
+        everyGetTranslation(TOOL, Locale.FRENCH) returns MutableLiveData(Translation())
+        everyGetManifest(TOOL, Locale.ENGLISH) returns englishManifest
+        everyGetManifest(TOOL, Locale.FRENCH) returns MutableLiveData(Manifest(type = Manifest.Type.TRACT))
+        dataModel.toolCode.value = TOOL
+        dataModel.supportedType.value = Manifest.Type.TRACT
+        dataModel.primaryLocales.value = listOf(Locale.ENGLISH, Locale.FRENCH)
+        dataModel.isInitialSyncFinished.value = true
+
+        assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
+        englishManifest.value = Manifest(type = Manifest.Type.LESSON)
+        assertEquals(Locale.FRENCH, dataModel.activeLocale.value)
+    }
+
+    @Test
+    fun `Property activeLocale - Updates when activeLoadingState is NOT_FOUND`() {
+        val englishTranslation = MutableLiveData<Translation?>()
+        everyGetTranslation(TOOL, Locale.ENGLISH) returns englishTranslation
+        everyGetTranslation(TOOL, Locale.FRENCH) returns MutableLiveData(Translation())
+        everyGetManifest(TOOL, Locale.ENGLISH) returns emptyLiveData()
+        everyGetManifest(TOOL, Locale.FRENCH) returns MutableLiveData(Manifest(type = Manifest.Type.TRACT))
+        dataModel.toolCode.value = TOOL
+        dataModel.supportedType.value = Manifest.Type.TRACT
+        dataModel.primaryLocales.value = listOf(Locale.ENGLISH, Locale.FRENCH)
+        dataModel.isInitialSyncFinished.value = true
+
+        assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
+        englishTranslation.value = null
+        assertEquals(Locale.FRENCH, dataModel.activeLocale.value)
+    }
+
+    @Test
+    fun `Property activeLocale - Updates when activeLoadingState is OFFLINE`() {
+        everyGetTranslation(TOOL, Locale.ENGLISH) returns MutableLiveData(Translation())
+        everyGetTranslation(TOOL, Locale.FRENCH) returns MutableLiveData(Translation())
+        everyGetManifest(TOOL, Locale.ENGLISH) returns emptyLiveData()
+        everyGetManifest(TOOL, Locale.FRENCH) returns MutableLiveData(Manifest(type = Manifest.Type.TRACT))
+        dataModel.toolCode.value = TOOL
+        dataModel.supportedType.value = Manifest.Type.TRACT
+        dataModel.primaryLocales.value = listOf(Locale.ENGLISH, Locale.FRENCH)
+        dataModel.isInitialSyncFinished.value = true
+
+        assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
+        isConnnected.value = false
+        assertEquals(Locale.FRENCH, dataModel.activeLocale.value)
+    }
     // endregion Property: activeLocale
 
     // region Property: activeManifest

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
@@ -6,7 +6,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
+import org.ccci.gto.android.common.db.findAsFlow
 import org.ccci.gto.android.common.scarlet.ReferenceLifecycle
 import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.api.ApiModule
@@ -15,6 +19,7 @@ import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.DownloadManagerModule
 import org.cru.godtools.download.manager.GodToolsDownloadManager
+import org.cru.godtools.model.Tool
 import org.cru.godtools.sync.GodToolsSyncService
 import org.cru.godtools.sync.SyncModule
 import org.cru.godtools.sync.task.SyncTaskModule
@@ -40,8 +45,10 @@ import org.mockito.kotlin.mock
 class ExternalSingletonsModule {
     @get:Provides
     val dao by lazy {
-        mock<GodToolsDao> {
-            on { getLatestTranslationLiveData(any(), any(), any(), any(), any()) } doAnswer { MutableLiveData(null) }
+        mockk<GodToolsDao> {
+            every { findAsFlow<Tool>(any<String>()) } returns flowOf(null)
+            every { getLatestTranslationLiveData(any(), any(), any(), any(), any()) } answers { MutableLiveData(null) }
+            every { updateSharesDeltaAsync(any(), any()) } returns mockk()
         }
     }
     @get:Provides


### PR DESCRIPTION
This moves the logic that initializes and manages `activeLocale` into the DataModel and adds tests for the logic.

Changing the primary and parallel language while viewing a tool may have an impact on this logic if the `activeLocale` no longer references the primary or parallel language