### PR TITLE
cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -222,6 +222,7 @@ dependencies {
     kapt libs.eventbus.annotationProcessor
     kapt libs.hilt.compiler
 
+    testImplementation libs.androidx.lifecycle.runtime.testing
     testImplementation libs.gtoSupport.testing.dagger
     testImplementation libs.hilt.testing
 

--- a/app/src/main/res/layout/list_item_language.xml
+++ b/app/src/main/res/layout/list_item_language.xml
@@ -12,8 +12,7 @@
         <variable name="selected" type="LiveData&lt;java.util.Locale&gt;" />
     </data>
 
-    <androidx.appcompat.widget.AppCompatRelativeLayoutImpl
-        android:id="@+id/root"
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/bkg_list_item_language"
@@ -21,7 +20,7 @@
         android:onClick="@{() -> listener.onLanguageSelected(language)}"
         app:selected="@{ObjectsCompat.equals(language.code, selected)}">
 
-        <androidx.appcompat.widget.AppCompatImageView
+        <ImageView
             android:id="@+id/action_add"
             android:layout_width="48dp"
             android:layout_height="48dp"
@@ -30,9 +29,9 @@
             android:layout_marginStart="-8dp"
             android:layout_marginEnd="8dp"
             android:padding="8dp"
-            android:tint="@color/gt_green"
             app:visibleIf="@{language != null &amp;&amp; !language.added}"
-            app:srcCompat="@drawable/ic_download" />
+            app:srcCompat="@drawable/ic_download"
+            app:tint="@color/gt_green" />
 
         <TextView
             android:id="@+id/title"
@@ -49,5 +48,5 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Medium"
             android:textIsSelectable="false"
             tools:text="really really really really really really really really long language name" />
-    </androidx.appcompat.widget.AppCompatRelativeLayoutImpl>
+    </RelativeLayout>
 </layout>

--- a/app/src/test/kotlin/org/cru/godtools/databinding/ListItemLanguageBindingTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/databinding/ListItemLanguageBindingTest.kt
@@ -1,0 +1,74 @@
+package org.cru.godtools.databinding
+
+import android.app.Activity
+import android.app.Application
+import android.view.LayoutInflater
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.testing.TestLifecycleOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
+import org.cru.godtools.model.Language
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = Application::class)
+class ListItemLanguageBindingTest {
+    private lateinit var binding: ListItemLanguageBinding
+
+    private val selected = MutableLiveData<Locale?>()
+
+    @Before
+    fun createBinding() {
+        val activity = Robolectric.buildActivity(Activity::class.java).get()
+        binding = ListItemLanguageBinding.inflate(LayoutInflater.from(activity), null, false)
+        binding.lifecycleOwner = TestLifecycleOwner()
+        binding.selected = selected
+    }
+
+    @Test
+    fun `root View - isSelected - Language`() {
+        binding.language = Language().apply { code = Locale.ENGLISH }
+        selected.value = null
+        binding.executePendingBindings()
+        assertFalse(binding.root.isSelected)
+
+        selected.value = Locale.ENGLISH
+        binding.executePendingBindings()
+        assertTrue(binding.root.isSelected)
+
+        selected.value = null
+        binding.executePendingBindings()
+        assertFalse(binding.root.isSelected)
+
+        selected.value = Locale.FRENCH
+        binding.executePendingBindings()
+        assertFalse(binding.root.isSelected)
+    }
+
+    @Test
+    fun `root View - isSelected - None option`() {
+        // the "None" option is represented by a null language
+        binding.language = null
+        selected.value = null
+        binding.executePendingBindings()
+        assertTrue(binding.root.isSelected)
+
+        selected.value = Locale.ENGLISH
+        binding.executePendingBindings()
+        assertFalse(binding.root.isSelected)
+    }
+
+    @Test
+    fun `root View - isSelected - Data Binding Locale Equality Bug`() {
+        binding.language = Language().apply { code = Locale("en") }
+        selected.value = Locale("en")
+        binding.executePendingBindings()
+        assertTrue(binding.root.isSelected)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,4 @@
 rootProject.name = "godtools"
-enableFeaturePreview("VERSION_CATALOGS")
 
 include("library:analytics")
 include("library:api")

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/DrawableUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/DrawableUtils.kt
@@ -4,5 +4,4 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
 
-fun Drawable?.tint(@ColorInt color: Int) =
-    this?.let { DrawableCompat.wrap(it).mutate() }?.apply { DrawableCompat.setTint(this, color) }
+fun Drawable?.tint(@ColorInt color: Int) = this?.let { DrawableCompat.wrap(it).mutate() }?.apply { setTint(color) }


### PR DESCRIPTION
- DrawableCompat.setTint() is no longer necessary
- version catalogs are now stable and no longer a feature preview
- cleanup the list_item_language layout a bit
- add a unit test for list_item_language selected behavior
