### PR TITLE
include the debug kotlin source directory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,7 @@ android {
 
     sourceSets {
         qa {
-            java.srcDir 'src/debug/java'
+            kotlin.srcDir 'src/debug/kotlin'
             res.srcDir 'src/debug/res/values'
             manifest.srcFile 'src/debug/AndroidManifest.xml'
         }


### PR DESCRIPTION
we recently moved the debug source to a kotlin source directory, this fixes the cross-reference from the QA build
