### PR TITLE
GT-1391 Enable Shareables in new tool settings UI

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -165,14 +165,14 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
 
     // region Share tool logic
     protected open val shareMenuItemVisible by lazy { shareLinkUriLiveData.map { it != null } }
-    protected open val shareLinkUriLiveData = emptyLiveData<String>()
 
     protected open val shareLinkTitle get() = activeManifest?.title
     @get:StringRes
     protected open val shareLinkMessageRes get() = R.string.share_general_message
+    protected open val shareLinkUriLiveData = emptyLiveData<String>()
     private val shareLinkUri get() = shareLinkUriLiveData.value
 
-    protected fun Menu.setupShareMenuItem() {
+    private fun Menu.setupShareMenuItem() {
         findItem(R.id.action_share)?.let { item ->
             shareMenuItemVisible.observe(this@BaseToolActivity, item) {
                 isVisible = it
@@ -189,14 +189,14 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
         eventBus.post(ShareActionEvent)
         settings.setFeatureDiscovered(FEATURE_TOOL_SHARE)
 
-        // start the share activity chooser with our share link
+        // launch the appropriate Share Dialog based on shareItems
         when (shareItems.size) {
             1 -> shareItems.first().triggerAction(this)
             else -> ShareBottomSheetDialogFragment(shareItems).show(supportFragmentManager, null)
         }
     }
 
-    protected open fun getShareItems(): Collection<ShareItem> = buildList {
+    private fun getShareItems(): Collection<ShareItem> = buildList {
         buildShareIntent()?.let { add(DefaultShareItem(it)) }
         addAll(getShareableShareItems())
     }.filter { it.isValid }
@@ -204,7 +204,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     @Inject
     internal lateinit var shareableShareItemFactory: ShareableImageShareItem.Factory
 
-    private fun getShareableShareItems() = activeManifest?.shareables?.filterIsInstance<ShareableImage>()
+    protected open fun getShareableShareItems() = activeManifest?.shareables?.filterIsInstance<ShareableImage>()
         ?.map { shareableShareItemFactory.create(it) }.orEmpty()
 
     private fun buildShareIntent(

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.gtoSupport.compat)
     implementation(libs.gtoSupport.core)
     implementation(libs.gtoSupport.eventbus)
+    implementation(libs.gtoSupport.kotlin.coroutines)
     implementation(libs.gtoSupport.lottie)
     implementation(libs.gtoSupport.materialComponents)
     implementation(libs.gtoSupport.picasso)

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -29,6 +29,7 @@ import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_LIVE_SHARE
 import org.cru.godtools.base.URI_SHARE_BASE
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivity
 import org.cru.godtools.base.tool.model.Event
+import org.cru.godtools.base.tool.ui.shareable.model.ShareableImageShareItem
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.backgroundColor
 import org.cru.godtools.tool.model.tips.Tip
@@ -305,6 +306,8 @@ class TractActivity :
             .apply { if (page > 0) appendPath(page.toString()) }
             .appendQueryParameter("icid", "gtshare")
     }
+
+    override fun getShareableShareItems() = emptyList<ShareableImageShareItem>()
     // endregion Share Menu Logic
 
     // region Live Share Logic

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.showAllowingStateLoss
-import org.ccci.gto.android.common.androidx.lifecycle.combine
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observe
@@ -285,13 +284,9 @@ class TractActivity :
 
     // region Share Menu Logic
     override val shareMenuItemVisible by lazy {
-        combine(
-            shareLinkUriLiveData,
-            subscriberController.state,
-            dataModel.enableTips
-        ) { shareUri, subscriberState, enableTips ->
-            shareUri != null && subscriberState == State.Off && !enableTips
-        }
+        // HACK: make this dependent on shareLinkUriLiveData so that there is a subscriber to actually resolve the uri
+        //       before the user clicks the share action
+        shareLinkUriLiveData.map { false }
     }
 
     override val shareLinkUriLiveData by lazy {

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -53,7 +53,6 @@ import org.cru.godtools.tract.service.FollowupService
 import org.cru.godtools.tract.ui.liveshare.LiveShareExitDialogFragment
 import org.cru.godtools.tract.ui.liveshare.LiveShareStartingDialogFragment
 import org.cru.godtools.tract.ui.settings.SettingsBottomSheetDialogFragment
-import org.cru.godtools.tract.ui.share.model.LiveShareItem
 import org.cru.godtools.tract.util.isTractDeepLink
 import org.cru.godtools.tract.util.loadAnimation
 import org.cru.godtools.tutorial.PageSet
@@ -305,11 +304,6 @@ class TractActivity :
             .appendPath(tool)
             .apply { if (page > 0) appendPath(page.toString()) }
             .appendQueryParameter("icid", "gtshare")
-    }
-
-    override fun getShareItems() = buildList {
-        addAll(super.getShareItems())
-        if (dataModel.tool.value?.isScreenShareDisabled != true) add(LiveShareItem())
     }
     // endregion Share Menu Logic
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/databinding/TractSettingsSheetCallbacks.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/databinding/TractSettingsSheetCallbacks.kt
@@ -1,8 +1,11 @@
 package org.cru.godtools.tract.databinding
 
+import org.cru.godtools.tool.model.shareable.ShareableImage
+
 interface TractSettingsSheetCallbacks {
     fun shareLink()
     fun shareScreen()
+    fun shareShareable(shareable: ShareableImage?)
     fun toggleTrainingTips()
     fun swapLanguages()
 }

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
@@ -34,6 +34,7 @@ class SettingsBottomSheetDialogFragment :
     override fun onBindingCreated(binding: TractSettingsSheetBinding, savedInstanceState: Bundle?) {
         binding.callbacks = this
         binding.tool = activityDataModel.tool
+        binding.activeManifest = activityDataModel.activeManifest
         binding.hasTips = activityDataModel.hasTips
         binding.primaryLanguage = primaryLanguage
         binding.parallelLanguage = parallelLanguage

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
@@ -15,7 +15,9 @@ import org.ccci.gto.android.common.androidx.lifecycle.toggleValue
 import org.ccci.gto.android.common.material.bottomsheet.BindingBottomSheetDialogFragment
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
+import org.cru.godtools.base.tool.ui.shareable.ShareableImageBottomSheetDialogFragment
 import org.cru.godtools.base.ui.languages.LanguagesDropdownAdapter
+import org.cru.godtools.tool.model.shareable.ShareableImage
 import org.cru.godtools.tract.R
 import org.cru.godtools.tract.activity.TractActivity
 import org.cru.godtools.tract.databinding.TractSettingsSheetBinding
@@ -39,6 +41,7 @@ class SettingsBottomSheetDialogFragment :
         binding.primaryLanguage = primaryLanguage
         binding.parallelLanguage = parallelLanguage
         setupLanguageViews(binding)
+        setupShareables(binding)
     }
     // endregion Lifecycle
 
@@ -86,6 +89,12 @@ class SettingsBottomSheetDialogFragment :
             setOnItemClickListener { _, _, pos, _ -> updateParallelLanguage(adapter.getItem(pos)?.code) }
         }
     }
+
+    private fun setupShareables(binding: TractSettingsSheetBinding) {
+        val adapter = ShareablesAdapter(viewLifecycleOwner, this)
+        activityDataModel.activeManifest.observe(viewLifecycleOwner) { adapter.shareables = it?.shareables }
+        binding.shareables.adapter = adapter
+    }
     // endregion UI
 
     private fun updatePrimaryLanguage(locale: Locale) = with(activityDataModel) {
@@ -108,6 +117,18 @@ class SettingsBottomSheetDialogFragment :
 
     override fun shareScreen() {
         (activity as? TractActivity)?.shareLiveShareLink()
+        dismissAllowingStateLoss()
+    }
+
+    override fun shareShareable(shareable: ShareableImage?) {
+        val manifest = shareable?.manifest
+        val tool = manifest?.code
+        val locale = manifest?.locale
+        val id = shareable?.id
+        if (tool != null && locale != null && id != null) {
+            activity?.supportFragmentManager
+                ?.let { ShareableImageBottomSheetDialogFragment(tool, locale, id).show(it, null) }
+        }
         dismissAllowingStateLoss()
     }
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
@@ -12,11 +12,13 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.toggleValue
+import org.ccci.gto.android.common.kotlin.coroutines.collectInto
 import org.ccci.gto.android.common.material.bottomsheet.BindingBottomSheetDialogFragment
 import org.cru.godtools.base.tool.activity.BaseToolActivity
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
 import org.cru.godtools.base.tool.ui.shareable.ShareableImageBottomSheetDialogFragment
 import org.cru.godtools.base.ui.languages.LanguagesDropdownAdapter
+import org.cru.godtools.base.util.deviceLocale
 import org.cru.godtools.tool.model.shareable.ShareableImage
 import org.cru.godtools.tract.R
 import org.cru.godtools.tract.activity.TractActivity
@@ -64,9 +66,10 @@ class SettingsBottomSheetDialogFragment :
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // sync toolCode from activity to local DataModel
-                activityDataModel.toolCode.filterNotNull().collect { dataModel.toolCode.value = it }
+                activityDataModel.toolCode.filterNotNull().collectInto(dataModel.toolCode)
             }
         }
+        context?.deviceLocale?.let { dataModel.deviceLocale.value = it }
     }
     // endregion Data Model
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/ShareablesAdapter.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/ShareablesAdapter.kt
@@ -1,0 +1,41 @@
+package org.cru.godtools.tract.ui.settings
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.LifecycleOwner
+import org.ccci.gto.android.common.androidx.recyclerview.adapter.SimpleDataBindingAdapter
+import org.cru.godtools.tool.model.shareable.Shareable
+import org.cru.godtools.tool.model.shareable.ShareableImage
+import org.cru.godtools.tract.BR
+import org.cru.godtools.tract.R
+import org.cru.godtools.tract.databinding.TractSettingsSheetCallbacks
+
+class ShareablesAdapter(lifecycleOwner: LifecycleOwner, private val callbacks: TractSettingsSheetCallbacks) :
+    SimpleDataBindingAdapter<ViewDataBinding>(lifecycleOwner) {
+    var shareables: List<Shareable>? = null
+        set(value) {
+            field = value?.filterIsInstance<ShareableImage>()
+            notifyDataSetChanged()
+        }
+
+    override fun getItemCount() = shareables?.size ?: 0
+    private fun getItem(position: Int) = shareables?.getOrNull(position)
+    override fun getItemViewType(position: Int) = when (getItem(position)) {
+        is ShareableImage -> R.layout.tract_settings_item_shareable_image
+        else -> R.layout.tract_settings_item_shareable_image
+    }
+
+    override fun onCreateViewDataBinding(parent: ViewGroup, viewType: Int) =
+        DataBindingUtil.inflate<ViewDataBinding>(LayoutInflater.from(parent.context), viewType, parent, false)
+
+    override fun onViewDataBindingCreated(binding: ViewDataBinding, viewType: Int) {
+        super.onViewDataBindingCreated(binding, viewType)
+        binding.setVariable(BR.callbacks, callbacks)
+    }
+
+    override fun onBindViewDataBinding(binding: ViewDataBinding, position: Int) {
+        binding.setVariable(BR.item, getItem(position))
+    }
+}

--- a/ui/tract-renderer/src/main/res/layout/tract_settings_item_shareable_image.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_settings_item_shareable_image.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable name="callbacks" type="org.cru.godtools.tract.databinding.TractSettingsSheetCallbacks" />
+        <variable name="item" type="org.cru.godtools.tool.model.shareable.ShareableImage" />
+    </data>
+
+    <FrameLayout
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:padding="8dp"
+        android:onClick="@{() -> callbacks.shareShareable(item)}">
+
+        <org.cru.godtools.base.ui.view.DaggerPicassoImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            app:placeholder="@color/gray_F5"
+            app:picassoFile="@{item.resource}" />
+    </FrameLayout>
+</layout>

--- a/ui/tract-renderer/src/main/res/layout/tract_settings_sheet.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_settings_sheet.xml
@@ -6,7 +6,6 @@
         <import type="androidx.lifecycle.LiveData" />
         <import type="java.util.List" />
         <import type="kotlinx.coroutines.flow.StateFlow" />
-        <import type="org.cru.godtools.base.tool.ui.share.model.ShareItem" />
         <import type="org.cru.godtools.model.Tool" />
         <import type="org.cru.godtools.model.Language" />
         <import type="org.cru.godtools.tool.model.Manifest" />
@@ -15,7 +14,6 @@
         <variable name="tool" type="StateFlow&lt;Tool&gt;" />
         <variable name="activeManifest" type="LiveData&lt;Manifest&gt;" />
         <variable name="hasTips" type="LiveData&lt;Boolean&gt;" />
-        <variable name="shareables" type="List&lt;ShareItem&gt;" />
         <variable name="primaryLanguage" type="LiveData&lt;Language&gt;" />
         <variable name="parallelLanguage" type="LiveData&lt;Language&gt;" />
     </data>
@@ -273,28 +271,47 @@
                 android:textSize="12sp" />
         </com.google.android.material.textfield.TextInputLayout>
 
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="shareables_divider,shareables_title,shareables"
+            app:visibleIf="@{activeManifest.shareables != null &amp;&amp; !activeManifest.shareables.empty}" />
+
         <com.google.android.material.divider.MaterialDivider
             android:id="@+id/shareables_divider"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
-            app:layout_constraintBottom_toTopOf="@id/shareables_actions"
+            app:layout_constraintBottom_toTopOf="@id/shareables_title"
             app:layout_constraintEnd_toStartOf="@id/margin_end"
             app:layout_constraintStart_toEndOf="@id/margin_start"
-            app:layout_constraintTop_toBottomOf="@id/languages"
-            app:visibleIf="@{shareables != null &amp;&amp; !shareables.empty}" />
+            app:layout_constraintTop_toBottomOf="@id/languages" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/shareables_actions"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/shareables_title"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
+            android:text="@string/tract_settings_shareables_title"
+            android:textAppearance="@style/TextAppearance.GodTools.Tract.Settings.Section.Title"
+            app:layout_constraintBottom_toTopOf="@id/shareables"
+            app:layout_constraintEnd_toStartOf="@id/margin_end"
+            app:layout_constraintStart_toEndOf="@id/margin_start"
+            app:layout_constraintTop_toBottomOf="@id/shareables_divider" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/shareables"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
             android:clipToPadding="false"
             android:orientation="horizontal"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
+            android:paddingLeft="8dp"
+            android:paddingRight="8dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:visibleIf="@{shareables != null &amp;&amp; !shareables.empty}" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/shareables_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/ui/tract-renderer/src/main/res/layout/tract_settings_sheet.xml
+++ b/ui/tract-renderer/src/main/res/layout/tract_settings_sheet.xml
@@ -9,9 +9,11 @@
         <import type="org.cru.godtools.base.tool.ui.share.model.ShareItem" />
         <import type="org.cru.godtools.model.Tool" />
         <import type="org.cru.godtools.model.Language" />
+        <import type="org.cru.godtools.tool.model.Manifest" />
 
         <variable name="callbacks" type="org.cru.godtools.tract.databinding.TractSettingsSheetCallbacks" />
         <variable name="tool" type="StateFlow&lt;Tool&gt;" />
+        <variable name="activeManifest" type="LiveData&lt;Manifest&gt;" />
         <variable name="hasTips" type="LiveData&lt;Boolean&gt;" />
         <variable name="shareables" type="List&lt;ShareItem&gt;" />
         <variable name="primaryLanguage" type="LiveData&lt;Language&gt;" />
@@ -65,6 +67,12 @@
             app:layout_constraintTop_toBottomOf="@id/title" />
 
         <!-- region action_share -->
+        <androidx.constraintlayout.widget.Group
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="action_share,action_share_icon,action_share_label"
+            app:goneIf="@{activeManifest == null}" />
+
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/action_share"
             style="@style/Widget.GodTools.Tract.Settings.Action"
@@ -101,7 +109,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="action_share_screen,action_share_screen_icon,action_share_screen_label"
-            app:goneIf="@{tool.screenShareDisabled}" />
+            app:goneIf="@{tool.screenShareDisabled || activeManifest == null}" />
 
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/action_share_screen"

--- a/ui/tract-renderer/src/main/res/values/strings_tract_renderer.xml
+++ b/ui/tract-renderer/src/main/res/values/strings_tract_renderer.xml
@@ -25,4 +25,5 @@
     <string name="tract_settings_action_share">Share link</string>
     <string name="tract_settings_languages_title">Parallel Language</string>
     <string name="tract_settings_languages_description">Toggle between two different languages in this tool.</string>
+    <string name="tract_settings_shareables_title">Related graphics</string>
 </resources>


### PR DESCRIPTION
- display tool shareables in the tract settings dialog
- make sure deviceLocale is up to date for the Settings dialog
- remove LiveShareItem from the share items for tracts
- don't include Shareables in the Share dialog for tract tools
- the ShareMenuItem no longer exists for TractActivities, so make it never visible
