### PR TITLE
GT-1507 Fix DataModel crash

### DIFF
--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -50,6 +50,7 @@ class MultiLanguageToolActivityDataModelTest {
     private lateinit var manifestManager: ManifestManager
     private lateinit var dataModel: MultiLanguageToolActivityDataModel
     private val isConnnected = MutableLiveData(true)
+    private val savedStateHandle = SavedStateHandle()
 
     @Before
     fun setupDataModel() {
@@ -66,7 +67,7 @@ class MultiLanguageToolActivityDataModelTest {
             mockk(),
             manifestManager,
             isConnnected,
-            SavedStateHandle()
+            savedStateHandle
         )
         excludeRecords { dao.findAsFlow<Tool>(any<String>()) }
     }
@@ -359,6 +360,17 @@ class MultiLanguageToolActivityDataModelTest {
         assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
         isConnnected.value = false
         assertEquals(Locale.FRENCH, dataModel.activeLocale.value)
+    }
+
+    @Test
+    fun `Property activeLocale - Persisted via SavedStateHandle`() {
+        dataModel.primaryLocales.value = listOf(Locale.ENGLISH)
+        assertEquals(Locale.ENGLISH, dataModel.activeLocale.value)
+
+        // creating a new DataModel using the same SavedState emulates recreation after process death
+        val dataModel2 =
+            MultiLanguageToolActivityDataModel(dao, mockk(), manifestManager, isConnnected, savedStateHandle)
+        assertEquals(Locale.ENGLISH, dataModel2.activeLocale.value)
     }
     // endregion Property: activeLocale
 


### PR DESCRIPTION
- add a unit test that replicates the crash during application restart
- initialize LiveData caches before they get used later in initialization
