### PR TITLE
GT-1475 Implement custom URI deeplink support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,9 +78,13 @@ android {
             minifyEnabled false
             shrinkResources false
 
-            manifestPlaceholders += ["appAuthRedirectScheme": "org.cru.godtools.debug"]
+            manifestPlaceholders += [
+                    "appAuthRedirectScheme": "org.cru.godtools.debug.okta",
+                    "hostGodtoolsCustomUri": "org.cru.godtools.debug"
+            ]
 
-            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.debug\""
+            buildConfigField "String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools.debug\""
+            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.debug.okta\""
             resValue "string", "app_name_debug", "GodTools (Dev)"
         }
         qa {
@@ -90,9 +94,13 @@ android {
             applicationIdSuffix ".qa"
             versionNameSuffix "-qa"
 
-            manifestPlaceholders += ["appAuthRedirectScheme": "org.cru.godtools.qa"]
+            manifestPlaceholders += [
+                    "appAuthRedirectScheme": "org.cru.godtools.qa.okta",
+                    "hostGodtoolsCustomUri": "org.cru.godtools.qa"
+            ]
 
-            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.qa\""
+            buildConfigField "String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools.qa\""
+            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.qa.okta\""
             resValue "string", "app_name_debug", "GodTools (QA)"
 
             // Firebase App Distribution build
@@ -115,9 +123,13 @@ android {
                 signingConfig signingConfigs.release
             }
 
-            manifestPlaceholders += ["appAuthRedirectScheme": "org.cru.godtools"]
+            manifestPlaceholders += [
+                    "appAuthRedirectScheme": "org.cru.godtools.okta",
+                    "hostGodtoolsCustomUri": "org.cru.godtools"
+            ]
 
-            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools\""
+            buildConfigField "String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools\""
+            buildConfigField "String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.okta\""
         }
     }
     bundle {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,17 @@
                 <data android:host="godtoolsapp.com" />
                 <data android:path="/lessons" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="godtools" />
+                <data android:host="${hostGodtoolsCustomUri}" />
+                <data android:path="/dashboard" />
+                <data android:pathPattern="/dashboard/.*" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/kotlin/org/cru/godtools/dagger/ConfigModule.kt
+++ b/app/src/main/kotlin/org/cru/godtools/dagger/ConfigModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.api.ApiModule
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -14,4 +15,8 @@ object ConfigModule {
     @get:Provides
     @get:Named(ApiModule.MOBILE_CONTENT_API_URL)
     val mobileContentApiBaseUrl = BuildConfig.MOBILE_CONTENT_API
+
+    @get:Provides
+    @get:Named(DAGGER_HOST_CUSTOM_URI)
+    val godtoolsCustomUriHost = BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardAppsFlyerDeepLinkResolver.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardAppsFlyerDeepLinkResolver.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import org.cru.godtools.analytics.appsflyer.AppsFlyerDeepLinkResolver
 import org.cru.godtools.base.ui.createDashboardIntent
-import org.cru.godtools.base.ui.dashboard.Page
 
 internal object DashboardAppsFlyerDeepLinkResolver : AppsFlyerDeepLinkResolver {
     override fun resolve(context: Context, uri: Uri?, data: Map<String, String?>) = when {
@@ -16,13 +15,6 @@ internal object DashboardAppsFlyerDeepLinkResolver : AppsFlyerDeepLinkResolver {
 
     override fun resolve(context: Context, deepLinkValue: String) = deepLinkValue.split("|")
         .takeIf { it[0] == "dashboard" }
-        ?.let {
-            when (it.getOrNull(1)) {
-                "tools" -> Page.ALL_TOOLS
-                "lessons" -> Page.LESSONS
-                "home" -> Page.FAVORITE_TOOLS
-                else -> Page.FAVORITE_TOOLS
-            }
-        }
+        ?.let { findPageByUriPathSegment(it.getOrNull(1)) }
         ?.let { context.createDashboardIntent(it) }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardDeepLinks.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardDeepLinks.kt
@@ -2,6 +2,14 @@ package org.cru.godtools.ui.dashboard
 
 import android.net.Uri
 import org.cru.godtools.base.HOST_GODTOOLSAPP_COM
+import org.cru.godtools.base.ui.dashboard.Page
 
 internal fun Uri.isDashboardLessonsDeepLink() =
     (scheme == "http" || scheme == "https") && host.equals(HOST_GODTOOLSAPP_COM, true) && path == "/lessons"
+
+internal fun findPageByUriPathSegment(segment: String?) = when (segment) {
+    "lessons" -> Page.LESSONS
+    "tools" -> Page.ALL_TOOLS
+    "home" -> Page.FAVORITE_TOOLS
+    else -> Page.FAVORITE_TOOLS
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardDeepLinks.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardDeepLinks.kt
@@ -1,11 +1,17 @@
 package org.cru.godtools.ui.dashboard
 
 import android.net.Uri
+import org.cru.godtools.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.base.HOST_GODTOOLSAPP_COM
+import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.ui.dashboard.Page
 
 internal fun Uri.isDashboardLessonsDeepLink() =
     (scheme == "http" || scheme == "https") && host.equals(HOST_GODTOOLSAPP_COM, true) && path == "/lessons"
+
+internal fun Uri.isDashboardCustomUriSchemeDeepLink() = SCHEME_GODTOOLS.equals(scheme, true) &&
+    HOST_GODTOOLS_CUSTOM_URI.equals(host, true) &&
+    pathSegments.getOrNull(0) == "dashboard"
 
 internal fun findPageByUriPathSegment(segment: String?) = when (segment) {
     "lessons" -> Page.LESSONS

--- a/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
@@ -6,19 +6,44 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import io.mockk.every
+import io.mockk.mockk
 import org.ccci.gto.android.common.dagger.eager.EagerModule
+import org.ccci.gto.android.common.sync.SyncRegistry
+import org.ccci.gto.android.common.sync.SyncTask
+import org.cru.godtools.dagger.EventBusModule
 import org.cru.godtools.dagger.ServicesModule
+import org.cru.godtools.sync.GodToolsSyncService
+import org.greenrobot.eventbus.EventBus
 import org.mockito.Mockito
 import org.mockito.kotlin.mock
 
 @Module(includes = [EagerModule::class])
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [ServicesModule::class]
+    replaces = [EventBusModule::class, ServicesModule::class]
 )
 class ExternalSingletonsModule {
     @get:Provides
+    val eventbus by lazy { mockk<EventBus>(relaxUnitFun = true) }
+    @get:Provides
     val picasso by lazy { mock<Picasso>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS) }
+    @get:Provides
+    val syncService by lazy {
+        val completedSyncTask = object : SyncTask {
+            override fun sync(): Int {
+                val id = SyncRegistry.startSync()
+                SyncRegistry.finishSync(id)
+                return id
+            }
+        }
+
+        mockk<GodToolsSyncService> {
+            every { syncFollowups() } returns completedSyncTask
+            every { syncTools(any()) } returns completedSyncTask
+            every { syncToolShares() } returns completedSyncTask
+        }
+    }
     @get:Provides
     val workManager by lazy { mock<WorkManager>() }
 }

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/DashboardActivityTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/DashboardActivityTest.kt
@@ -1,0 +1,106 @@
+package org.cru.godtools.ui.dashboard
+
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
+import androidx.activity.viewModels
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import org.cru.godtools.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
+import org.cru.godtools.base.ui.createDashboardIntent
+import org.cru.godtools.base.ui.dashboard.Page
+import org.cru.godtools.ui.dashboard.tools.ToolsFragment
+import org.cru.godtools.ui.tools.ToolsListFragment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Config(application = HiltTestApplication::class)
+class DashboardActivityTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val context get() = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun <R> scenario(
+        intent: Intent = context.createDashboardIntent(null),
+        block: (ActivityScenario<DashboardActivity>) -> R
+    ): R = ActivityScenario.launch<DashboardActivity>(intent).use(block)
+
+    // region Intent Processing
+    @Test
+    fun `Intent Processing - Normal Launch`() {
+        scenario(intent = context.createDashboardIntent(null)) {
+            it.onActivity {
+                assertEquals(Page.FAVORITE_TOOLS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsListFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Normal Launch - Lessons`() {
+        scenario(intent = context.createDashboardIntent(Page.LESSONS)) {
+            it.onActivity {
+                assertEquals(Page.LESSONS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsListFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Normal Launch - Tools`() {
+        scenario(intent = context.createDashboardIntent(Page.ALL_TOOLS)) {
+            it.onActivity {
+                assertEquals(Page.ALL_TOOLS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Deep Link - Custom Uri Scheme - Home`() {
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/dashboard/home"))) {
+            it.onActivity {
+                assertEquals(Page.FAVORITE_TOOLS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsListFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Deep Link - Custom Uri Scheme - Lessons`() {
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/dashboard/lessons"))) {
+            it.onActivity {
+                assertEquals(Page.LESSONS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsListFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Deep Link - Custom Uri Scheme - Tools`() {
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/dashboard/tools"))) {
+            it.onActivity {
+                assertEquals(Page.ALL_TOOLS, it.savedState.selectedPage)
+                assertTrue(it.supportFragmentManager.primaryNavigationFragment is ToolsFragment)
+            }
+        }
+    }
+    // endregion Intent Processing
+
+    private val DashboardActivity.savedState get() = viewModels<DashboardSavedState>().value
+}

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -1,5 +1,7 @@
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestedExtension
+import com.android.build.gradle.internal.core.InternalBaseVariant
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.gradle.internal.dsl.DynamicFeatureExtension
 import org.gradle.api.JavaVersion
@@ -34,7 +36,7 @@ fun LibraryExtension.baseConfiguration(project: Project) {
 // TODO: provide Project using the new multiple context receivers functionality.
 //       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
 //context(Project)
-private fun <T : BaseExtension> T.configureAndroidCommon(project: Project) {
+private fun TestedExtension.configureAndroidCommon(project: Project) {
     configureSdk()
     configureCompilerOptions()
     configureTestOptions()
@@ -72,7 +74,7 @@ fun BaseExtension.configureFlavorDimensions() {
     }
 }
 
-private fun BaseExtension.configureTestOptions() {
+private fun TestedExtension.configureTestOptions() {
     testOptions.unitTests {
         isIncludeAndroidResources = true
 
@@ -82,6 +84,13 @@ private fun BaseExtension.configureTestOptions() {
             it.maxHeapSize = "2g"
         }
     }
+
+    testVariants.all { configureTestManifestPlaceholders() }
+    unitTestVariants.all { configureTestManifestPlaceholders() }
+}
+
+private fun InternalBaseVariant.configureTestManifestPlaceholders() {
+    mergedFlavor.manifestPlaceholders += "hostGodtoolsCustomUri" to "org.cru.godtools.test"
 }
 
 private fun BaseExtension.filterStageVariants() =

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
@@ -94,7 +94,7 @@ class AppsFlyerAnalyticsService @VisibleForTesting internal constructor(
 
         override fun onAppOpenAttribution(data: Map<String, String?>) {
             Timber.tag(TAG).d("onAppOpenAttribution($data)")
-            val uri = data[AF_DP]?.let { Uri.parse(it) }
+            val uri = data[AF_DP]?.let { Uri.parse(it).normalizeScheme() }
             deepLinkResolvers.asSequence().mapNotNull { it.resolve(app, uri, data) }.firstOrNull()?.let { intent ->
                 activeActivity?.startActivity(intent)
             }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/Constants.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/Constants.kt
@@ -8,8 +8,12 @@ const val EXTRA_LANGUAGE = "language"
 const val EXTRA_LANGUAGES = "languages"
 const val EXTRA_PAGE = "page"
 
+const val SCHEME_GODTOOLS = "godtools"
 const val HOST_GODTOOLSAPP_COM = "godtoolsapp.com"
 const val HOST_GET_GODTOOLSAPP_COM = "get.godtoolsapp.com"
 const val HOST_KNOWGOD_COM = "knowgod.com"
 
 val URI_SHARE_BASE: Uri = Uri.parse("https://$HOST_KNOWGOD_COM/")
+
+// Dagger Qualifiers
+const val DAGGER_HOST_CUSTOM_URI = "godtoolsCustomUriHost"

--- a/ui/article-renderer/build.gradle.kts
+++ b/ui/article-renderer/build.gradle.kts
@@ -39,4 +39,10 @@ dependencies {
 
     kapt(libs.dagger.compiler)
     kapt(libs.hilt.compiler)
+
+    testImplementation(project(":library:model"))
+    testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.hilt.testing)
+
+    kaptTest(libs.hilt.compiler)
 }

--- a/ui/article-renderer/src/main/AndroidManifest.xml
+++ b/ui/article-renderer/src/main/AndroidManifest.xml
@@ -4,8 +4,20 @@
     <application>
         <activity
             android:name=".ui.ArticlesActivity"
+            android:exported="true"
             android:screenOrientation="@integer/default_screen_orientation"
-            android:theme="@style/Theme.GodTools.Tool" />
+            android:theme="@style/Theme.GodTools.Tool">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="godtools" />
+                <data android:host="${hostGodtoolsCustomUri}" />
+                <data android:pathPattern="/tool/article/.*/.*" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".aem.ui.AemArticleActivity"

--- a/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
+++ b/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
@@ -1,11 +1,16 @@
 package org.cru.godtools.article.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.cru.godtools.article.R
@@ -14,6 +19,8 @@ import org.cru.godtools.article.aem.ui.startAemArticleActivity
 import org.cru.godtools.article.ui.articles.ArticlesFragment
 import org.cru.godtools.article.ui.categories.CategoriesFragment
 import org.cru.godtools.article.ui.categories.CategorySelectedListener
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
+import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.base.tool.databinding.ToolGenericFragmentActivityBinding
 import org.cru.godtools.tool.model.Category
@@ -46,6 +53,32 @@ class ArticlesActivity :
         article?.let { startAemArticleActivity(tool, locale, it.uri) }
     }
     // endregion Lifecycle
+
+    // region Intent Processing
+    @Inject
+    @Named(DAGGER_HOST_CUSTOM_URI)
+    internal lateinit var hostCustomUriScheme: String
+
+    override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
+        super.processIntent(intent, savedInstanceState)
+        val data = intent.data?.normalizeScheme() ?: return
+        val path = data.pathSegments ?: return
+
+        when (intent.action) {
+            Intent.ACTION_VIEW -> when {
+                // Sample deep link: godtools://org.cru.godtools/tool/article/{tool}/{locale}
+                data.isCustomUriDeepLink() -> {
+                    dataModel.toolCode.value = path[2]
+                    dataModel.locale.value = Locale.forLanguageTag(path[3])
+                }
+            }
+        }
+    }
+
+    private fun Uri.isCustomUriDeepLink() = scheme == SCHEME_GODTOOLS &&
+        hostCustomUriScheme.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
+        pathSegments?.getOrNull(0) == "tool" && pathSegments?.getOrNull(1) == "article"
+    // endregion Intent Processing
 
     override fun updateToolbarTitle() {
         primaryNavigationFragmentTitle?.let {

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
@@ -1,0 +1,60 @@
+package org.cru.godtools.article
+
+import androidx.lifecycle.MutableLiveData
+import com.squareup.picasso.Picasso
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import io.mockk.every
+import io.mockk.mockk
+import javax.inject.Named
+import kotlinx.coroutines.Job
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
+import org.cru.godtools.base.Settings
+import org.cru.godtools.download.manager.DownloadManagerModule
+import org.cru.godtools.download.manager.GodToolsDownloadManager
+import org.cru.godtools.sync.task.SyncTaskModule
+import org.cru.godtools.sync.task.ToolSyncTasks
+import org.greenrobot.eventbus.EventBus
+import org.keynote.godtools.android.db.GodToolsDao
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [
+        DownloadManagerModule::class,
+        SyncTaskModule::class
+    ]
+)
+class ExternalSingletonsModule {
+    @get:Provides
+    @get:Named(DAGGER_HOST_CUSTOM_URI)
+    val hostCustomUri = "org.cru.godtools.test"
+
+    @get:Provides
+    val dao by lazy {
+        mockk<GodToolsDao> {
+            every { getLatestTranslationLiveData(any(), any(), any(), any(), any()) } answers { MutableLiveData(null) }
+            every { updateSharesDeltaAsync(any(), any()) } returns Job().apply { complete() }
+        }
+    }
+    @get:Provides
+    val downloadManager by lazy {
+        mockk<GodToolsDownloadManager> {
+            every { getDownloadProgressLiveData(any(), any()) } answers { MutableLiveData() }
+        }
+    }
+    @get:Provides
+    val eventBus by lazy { mockk<EventBus>(relaxUnitFun = true) }
+    @get:Provides
+    val picasso by lazy { mockk<Picasso>() }
+    @get:Provides
+    val settings by lazy {
+        mockk<Settings>(relaxUnitFun = true) {
+            every { isFeatureDiscovered(any()) } returns false
+        }
+    }
+    @get:Provides
+    val toolSyncTasks by lazy { mockk<ToolSyncTasks>() }
+}

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ui/ArticlesActivityTest.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ui/ArticlesActivityTest.kt
@@ -1,0 +1,65 @@
+package org.cru.godtools.article.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import java.util.Locale
+import org.cru.godtools.base.ui.createArticlesIntent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+private const val TOOL = "test"
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Config(application = HiltTestApplication::class)
+class ArticlesActivityTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val context get() = ApplicationProvider.getApplicationContext<Context>()
+
+    private fun <R> scenario(
+        intent: Intent = context.createArticlesIntent(TOOL, Locale.ENGLISH),
+        block: (ActivityScenario<ArticlesActivity>) -> R
+    ) = ActivityScenario.launch<ArticlesActivity>(intent).use(block)
+    private fun <R> deepLinkScenario(uri: Uri, block: (ActivityScenario<ArticlesActivity>) -> R) =
+        scenario(Intent(Intent.ACTION_VIEW, uri), block)
+
+    // region Intent processing
+    @Test
+    fun `processIntent() - Valid direct`() {
+        scenario(context.createArticlesIntent(TOOL, Locale.ENGLISH)) {
+            it.onActivity {
+                assertEquals(TOOL, it.tool)
+                assertEquals(Locale.ENGLISH, it.locale)
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
+    fun `processIntent() - Custom URI Deep Link`() {
+        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/article/$TOOL/en")) {
+            it.onActivity {
+                assertEquals(TOOL, it.tool)
+                assertEquals(Locale.ENGLISH, it.locale)
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+    // endregion Intent processing
+}

--- a/ui/article-renderer/src/test/resources/robolectric.properties
+++ b/ui/article-renderer/src/test/resources/robolectric.properties
@@ -1,0 +1,1 @@
+sdk=NEWEST_SDK

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -42,7 +42,7 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
     }
 
     override val isValidStartState get() = super.isValidStartState && (!requireTool || hasTool())
-    private fun hasTool() = dataModel.toolCode.value != null && dataModel.locale.value != null
+    private fun hasTool() = !dataModel.toolCode.value.isNullOrEmpty() && dataModel.locale.value != null
     // endregion Intent processing
 
     @VisibleForTesting(otherwise = PROTECTED)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -75,7 +75,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
 
     // region Intent Processing
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
-        if (dataModel.primaryLocales.value.isNullOrEmpty()) {
+        if (dataModel.locales.value.isNullOrEmpty()) {
             val extras = intent.extras ?: return
             val locales = extras.getLocaleArray(EXTRA_LANGUAGES)?.filterNotNull().orEmpty()
             dataModel.primaryLocales.value = locales.take(1)
@@ -83,9 +83,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
         }
     }
 
-    override val isValidStartState
-        get() = dataModel.toolCode.value != null &&
-            (!dataModel.primaryLocales.value.isNullOrEmpty() || !dataModel.parallelLocales.value.isNullOrEmpty())
+    override val isValidStartState get() = dataModel.toolCode.value != null && !dataModel.locales.value.isNullOrEmpty()
     // endregion Intent Processing
 
     // region UI

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -83,7 +83,8 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
         }
     }
 
-    override val isValidStartState get() = dataModel.toolCode.value != null && !dataModel.locales.value.isNullOrEmpty()
+    override val isValidStartState
+        get() = !dataModel.toolCode.value.isNullOrEmpty() && !dataModel.locales.value.isNullOrEmpty()
     // endregion Intent Processing
 
     // region UI

--- a/ui/cyoa-renderer/src/main/AndroidManifest.xml
+++ b/ui/cyoa-renderer/src/main/AndroidManifest.xml
@@ -5,8 +5,19 @@
     <application>
         <activity
             android:name=".ui.CyoaActivity"
-            android:exported="false"
+            android:exported="true"
             android:screenOrientation="@integer/default_screen_orientation"
-            android:theme="@style/Theme.GodTools.Tool" />
+            android:theme="@style/Theme.GodTools.Tool">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="godtools" />
+                <data android:host="${hostGodtoolsCustomUri}" />
+                <data android:pathPattern="/tool/cyoa/.*/.*" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -14,7 +14,6 @@ import javax.inject.Named
 import org.ccci.gto.android.common.androidx.fragment.app.backStackEntries
 import org.ccci.gto.android.common.androidx.fragment.app.hasPendingActions
 import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
-import org.cru.godtools.base.EXTRA_PAGE
 import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivity
 import org.cru.godtools.base.tool.model.Event
@@ -34,6 +33,8 @@ class CyoaActivity :
     MultiLanguageToolActivity<CyoaActivityBinding>(R.layout.cyoa_activity, Manifest.Type.CYOA),
     CyoaPageFragment.InvalidPageListener,
     ShowTipCallback {
+    private val savedState by viewModels<CyoaActivitySavedState>()
+
     // region Lifecycle
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -83,6 +84,7 @@ class CyoaActivity :
                 dataModel.toolCode.value = path.getOrNull(2)
                 dataModel.primaryLocales.value = listOfNotNull(path.getOrNull(3)?.let { Locale.forLanguageTag(it) })
                 dataModel.parallelLocales.value = emptyList()
+                savedState.initialPage = path.getOrNull(4)
             }
         }
     }
@@ -130,7 +132,7 @@ class CyoaActivity :
     private fun showInitialPageIfNecessary(manifest: Manifest) {
         if (pageFragment != null) return
 
-        (manifest.findPage(intent?.getStringExtra(EXTRA_PAGE)) ?: manifest.pages.firstOrNull { !it.isHidden })
+        (manifest.findPage(savedState.initialPage) ?: manifest.pages.firstOrNull { !it.isHidden })
             ?.let { showPage(it, true) }
     }
 

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.tool.cyoa.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
@@ -7,14 +8,20 @@ import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
 import org.ccci.gto.android.common.androidx.fragment.app.backStackEntries
 import org.ccci.gto.android.common.androidx.fragment.app.hasPendingActions
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.EXTRA_PAGE
+import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivity
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.tool.cyoa.R
 import org.cru.godtools.tool.cyoa.databinding.CyoaActivityBinding
 import org.cru.godtools.tool.model.Manifest
+import org.cru.godtools.tool.model.Uri
 import org.cru.godtools.tool.model.page.CardCollectionPage
 import org.cru.godtools.tool.model.page.ContentPage
 import org.cru.godtools.tool.model.page.Page
@@ -61,6 +68,30 @@ class CyoaActivity :
         checkForPageEvent(event)
     }
     // endregion Lifecycle
+
+    // region Intent Processing
+    @Inject
+    @Named(DAGGER_HOST_CUSTOM_URI)
+    internal lateinit var hostCustomUri: String
+
+    override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
+        super.processIntent(intent, savedInstanceState)
+        if (savedInstanceState == null || !isValidStartState) {
+            val data = intent.data
+            if (data?.isCustomUriSchemeDeepLink == true) {
+                val path = data.pathSegments
+                dataModel.toolCode.value = path.getOrNull(2)
+                dataModel.primaryLocales.value = listOfNotNull(path.getOrNull(3)?.let { Locale.forLanguageTag(it) })
+                dataModel.parallelLocales.value = emptyList()
+            }
+        }
+    }
+
+    private inline val Uri.isCustomUriSchemeDeepLink
+        get() = SCHEME_GODTOOLS.equals(scheme, true) &&
+            hostCustomUri.equals(host, true) &&
+            pathSegments.size >= 4 && path?.startsWith("/tool/cyoa/") == true
+    // endregion Intent Processing
 
     private fun setupBinding() {
         binding.activeLocale = dataModel.activeLocale

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivitySavedState.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivitySavedState.kt
@@ -1,0 +1,10 @@
+package org.cru.godtools.tool.cyoa.ui
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import org.ccci.gto.android.common.androidx.lifecycle.delegate
+import org.cru.godtools.base.EXTRA_PAGE
+
+class CyoaActivitySavedState(savedStateHandle: SavedStateHandle) : ViewModel() {
+    var initialPage by savedStateHandle.delegate<String?>(EXTRA_PAGE)
+}

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
@@ -5,9 +5,11 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.cru.godtools.analytics.AnalyticsModule
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.GodToolsDownloadManager
@@ -25,6 +27,10 @@ import org.mockito.kotlin.mock
     replaces = [AnalyticsModule::class]
 )
 class ExternalSingletonsModule {
+    @get:Provides
+    @get:Named(DAGGER_HOST_CUSTOM_URI)
+    val hostCustomUri = "org.cru.godtools.test"
+
     @get:Provides
     val dao by lazy {
         mock<GodToolsDao> {

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -2,7 +2,10 @@ package org.cru.godtools.tool.cyoa.ui
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.ACTION_VIEW
+import android.net.Uri
 import android.view.ViewGroup
+import androidx.activity.viewModels
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
@@ -13,6 +16,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import java.util.Locale
 import javax.inject.Inject
+import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.base.ui.createCyoaActivityIntent
@@ -132,6 +136,8 @@ class CyoaActivityTest {
 
         scenario(intent = context.createCyoaActivityIntent(TOOL, Locale.ENGLISH)) {
             it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale.ENGLISH), it.dataModel.primaryLocales.value)
                 assertEquals("page1", it.pageFragment!!.pageId)
             }
         }
@@ -141,6 +147,8 @@ class CyoaActivityTest {
     fun `Intent Processing - Normal Launch - Deferred Manifest`() {
         scenario(intent = context.createCyoaActivityIntent(TOOL, Locale.ENGLISH)) {
             it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale.ENGLISH), it.dataModel.primaryLocales.value)
                 assertNull(it.pageFragment)
                 manifestEnglish.value = manifest(listOf(page1, page2))
                 assertEquals("page1", it.pageFragment!!.pageId)
@@ -154,6 +162,8 @@ class CyoaActivityTest {
 
         scenario(intent = context.createCyoaActivityIntent(TOOL, Locale.ENGLISH, pageId = "page2")) {
             it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale.ENGLISH), it.dataModel.primaryLocales.value)
                 assertEquals("page2", it.pageFragment!!.pageId)
             }
         }
@@ -163,9 +173,24 @@ class CyoaActivityTest {
     fun `Intent Processing - Open Specific Page - Deferred Manifest`() {
         scenario(intent = context.createCyoaActivityIntent(TOOL, Locale.ENGLISH, pageId = "page2")) {
             it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale.ENGLISH), it.dataModel.primaryLocales.value)
                 assertNull(it.pageFragment)
                 manifestEnglish.value = manifest(listOf(page1, page2))
                 assertEquals("page2", it.pageFragment!!.pageId)
+            }
+        }
+    }
+
+    @Test
+    fun `Intent Processing - Uri Scheme Deep Link`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/cyoa/test/en"))) {
+            it.onActivity {
+                assertEquals("test", it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale("en")), it.dataModel.primaryLocales.value)
+                assertEquals("page1", it.pageFragment!!.pageId)
             }
         }
     }
@@ -522,6 +547,8 @@ class CyoaActivityTest {
         }
     }
     // endregion Update Manifest
+
+    private val CyoaActivity.dataModel get() = viewModels<MultiLanguageToolActivityDataModel>().value
 
     private fun CyoaActivity.assertPageStack(vararg pages: String) {
         supportFragmentManager.executePendingTransactions()

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -194,6 +194,19 @@ class CyoaActivityTest {
             }
         }
     }
+
+    @Test
+    fun `Intent Processing - Uri Scheme Deep Link - Specific Page`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/cyoa/test/en/page2"))) {
+            it.onActivity {
+                assertEquals("test", it.dataModel.toolCode.value)
+                assertEquals(listOf(Locale("en")), it.dataModel.primaryLocales.value)
+                assertEquals("page2", it.pageFragment!!.pageId)
+            }
+        }
+    }
     // endregion Intent Processing
 
     // region navigateToParentPage()

--- a/ui/lesson-renderer/src/main/AndroidManifest.xml
+++ b/ui/lesson-renderer/src/main/AndroidManifest.xml
@@ -18,6 +18,16 @@
                 <data android:host="godtoolsapp.com" />
                 <data android:pathPattern="/lessons/.*/.*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="godtools" />
+                <data android:host="${hostGodtoolsCustomUri}" />
+                <data android:pathPattern="/tool/lesson/.*/.*" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -14,6 +14,7 @@ import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -33,8 +34,6 @@ import org.cru.godtools.tool.lesson.analytics.model.LessonPageAnalyticsScreenEve
 import org.cru.godtools.tool.lesson.databinding.LessonActivityBinding
 import org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackDialogFragment
 import org.cru.godtools.tool.lesson.util.isLessonDeepLink
-import org.cru.godtools.tool.lesson.util.lessonDeepLinkCode
-import org.cru.godtools.tool.lesson.util.lessonDeepLinkLocale
 import org.cru.godtools.tool.model.Manifest
 import org.cru.godtools.tool.model.lesson.LessonPage
 import org.keynote.godtools.android.db.GodToolsDao
@@ -82,12 +81,15 @@ class LessonActivity :
     // region Intent Processing
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
-        val data = intent.data
+        val data = intent.data?.normalizeScheme() ?: return
+        val path = data.pathSegments ?: return
+
         when (intent.action) {
             ACTION_VIEW -> when {
-                data?.isLessonDeepLink() == true -> {
-                    dataModel.toolCode.value = data.lessonDeepLinkCode
-                    dataModel.locale.value = data.lessonDeepLinkLocale
+                // Sample Lesson deep link: https://godtoolsapp.com/lessons/lessonholyspirit/en
+                data.isLessonDeepLink() -> {
+                    dataModel.toolCode.value = path[1]
+                    dataModel.locale.value = Locale.forLanguageTag(path[2])
                 }
             }
         }

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.lesson.ui
 
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
+import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.OnBackPressedCallback
@@ -16,11 +17,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Locale
 import javax.inject.Inject
+import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.lifecycle.SetLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.viewpager2.widget.whileMaintainingVisibleCurrentItem
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
+import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.Settings.Companion.FEATURE_LESSON_FEEDBACK
 import org.cru.godtools.base.tool.activity.BaseSingleToolActivity
@@ -79,6 +83,10 @@ class LessonActivity :
     // endregion Lifecycle
 
     // region Intent Processing
+    @Inject
+    @Named(DAGGER_HOST_CUSTOM_URI)
+    internal lateinit var hostCustomUriScheme: String
+
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         val data = intent.data?.normalizeScheme() ?: return
@@ -91,9 +99,18 @@ class LessonActivity :
                     dataModel.toolCode.value = path[1]
                     dataModel.locale.value = Locale.forLanguageTag(path[2])
                 }
+                // Sample deep link: godtools://org.cru.godtools/tool/lesson/{tool}/{locale}
+                data.isCustomUriDeepLink() -> {
+                    dataModel.toolCode.value = path[2]
+                    dataModel.locale.value = Locale.forLanguageTag(path[3])
+                }
             }
         }
     }
+
+    private fun Uri.isCustomUriDeepLink() = scheme == SCHEME_GODTOOLS &&
+        hostCustomUriScheme.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
+        pathSegments?.getOrNull(0) == "tool" && pathSegments?.getOrNull(1) == "lesson"
     // endregion Intent Processing
 
     // region UI

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/util/LessonDeepLinkUtils.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/util/LessonDeepLinkUtils.kt
@@ -9,7 +9,3 @@ import org.cru.godtools.base.HOST_GODTOOLSAPP_COM
 internal fun Uri.isLessonDeepLink() = ("http".equals(scheme, true) || "https".equals(scheme, true)) &&
     host.equals(HOST_GODTOOLSAPP_COM, true) &&
     pathSegments.getOrNull(0) == "lessons" && pathSegments.size >= 3
-
-internal val Uri.lessonDeepLinkCode get() = pathSegments[1]?.takeIf { it.isNotEmpty() }
-internal val Uri.lessonDeepLinkLocale
-    get() = pathSegments[2]?.takeIf { it.isNotEmpty() }?.let { Locale.forLanguageTag(it) }

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
@@ -6,6 +6,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.download.manager.DownloadManagerModule
 import org.cru.godtools.download.manager.GodToolsDownloadManager
@@ -27,6 +29,10 @@ import org.mockito.kotlin.mock
     ]
 )
 class ExternalSingletonsModule {
+    @get:Provides
+    @get:Named(DAGGER_HOST_CUSTOM_URI)
+    val hostCustomUri = "org.cru.godtools.test"
+
     @get:Provides
     val dao by lazy {
         mock<GodToolsDao> {

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivityTest.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivityTest.kt
@@ -77,6 +77,18 @@ class LessonActivityTest {
     }
 
     @Test
+    fun `processIntent() - Custom URI Deep Link`() {
+        val intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/lesson/$TOOL/en"))
+        ActivityScenario.launch<LessonActivity>(intent).use {
+            it.onActivity {
+                assertEquals(TOOL, it.tool)
+                assertEquals(Locale.ENGLISH, it.locale)
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
     fun `processIntent() - Invalid deeplinks`() {
         listOf(
             "https://example.com/lessons/test/en",

--- a/ui/tract-renderer/src/main/AndroidManifest.xml
+++ b/ui/tract-renderer/src/main/AndroidManifest.xml
@@ -28,6 +28,16 @@
 <!--                <data android:pathPattern="/.*/thefour.*" />-->
                 <data android:pathPattern="/.*/.*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="godtools" />
+                <data android:host="${hostGodtoolsCustomUri}" />
+                <data android:pathPattern="/tool/tract/.*/.*" />
+            </intent-filter>
             <meta-data
                 android:name="default-url"
                 android:value="https://knowgod.com/en/kgp/?useDeviceLanguage=true" />

--- a/ui/tract-renderer/src/main/AndroidManifest.xml
+++ b/ui/tract-renderer/src/main/AndroidManifest.xml
@@ -17,15 +17,6 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="knowgod.com" />
-<!--                <data android:pathPattern="/.*/emojitool.*" />-->
-<!--                <data android:pathPattern="/.*/fourlaws.*" />-->
-<!--                <data android:pathPattern="/.*/honorrestored.*" />-->
-<!--                <data android:pathPattern="/.*/kgp.*" />-->
-<!--                <data android:pathPattern="/.*/kgp-us.*" />-->
-<!--                <data android:pathPattern="/.*/poweroverfear.*" />-->
-<!--                <data android:pathPattern="/.*/satisfied.*" />-->
-<!--                <data android:pathPattern="/.*/teachmetoshare.*" />-->
-<!--                <data android:pathPattern="/.*/thefour.*" />-->
                 <data android:pathPattern="/.*/.*" />
             </intent-filter>
             <intent-filter>

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -158,15 +158,19 @@ class TractActivity :
         if (savedInstanceState == null) initialPage = intent.getIntExtra(EXTRA_PAGE, initialPage)
         if (dataModel.primaryLocales.value.isNullOrEmpty() || savedInstanceState == null) {
             if (intent.action != Intent.ACTION_VIEW) return
-            val data = intent.data?.takeIf { it.isTractDeepLink() } ?: return
+            val data = intent.data?.normalizeScheme() ?: return
 
-            dataModel.toolCode.value = data.deepLinkTool
-            val (primary, parallel) = data.deepLinkLanguages
-            dataModel.primaryLocales.value = primary
-            dataModel.parallelLocales.value = parallel
-            if (savedInstanceState == null) {
-                dataModel.activeLocale.value = data.deepLinkSelectedLanguage
-                data.deepLinkPage?.let { initialPage = it }
+            when {
+                data.isTractDeepLink() -> {
+                    dataModel.toolCode.value = data.deepLinkTool
+                    val (primary, parallel) = data.deepLinkLanguages
+                    dataModel.primaryLocales.value = primary
+                    dataModel.parallelLocales.value = parallel
+                    if (savedInstanceState == null) {
+                        dataModel.activeLocale.value = data.deepLinkSelectedLanguage
+                        data.deepLinkPage?.let { initialPage = it }
+                    }
+                }
             }
         }
     }

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -156,7 +156,9 @@ class TractActivity :
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         if (savedInstanceState == null) initialPage = intent.getIntExtra(EXTRA_PAGE, initialPage)
-        if (dataModel.primaryLocales.value.isNullOrEmpty() || savedInstanceState == null) {
+
+        // deep link parsing
+        if (savedInstanceState == null || dataModel.locales.value.isNullOrEmpty()) {
             if (intent.action != Intent.ACTION_VIEW) return
             val data = intent.data?.normalizeScheme() ?: return
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -168,16 +168,16 @@ class TractActivity :
         if (savedInstanceState == null || dataModel.locales.value.isNullOrEmpty()) {
             if (intent.action != Intent.ACTION_VIEW) return
             val data = intent.data?.normalizeScheme() ?: return
+            val path = data.pathSegments ?: return
 
             when {
                 data.isCustomUriDeepLink() -> {
-                    val path = data.pathSegments ?: return
                     dataModel.toolCode.value = path[2]
                     dataModel.primaryLocales.value = LocaleUtils.getFallbacks(Locale.forLanguageTag(path[3])).toList()
                     path.getOrNull(4)?.toIntOrNull()?.let { initialPage = it }
                 }
                 data.isTractDeepLink() -> {
-                    dataModel.toolCode.value = data.deepLinkTool
+                    dataModel.toolCode.value = path[1]
                     val (primary, parallel) = data.deepLinkLanguages
                     dataModel.primaryLocales.value = primary
                     dataModel.parallelLocales.value = parallel
@@ -196,8 +196,6 @@ class TractActivity :
 
     @VisibleForTesting
     internal val Uri.deepLinkSelectedLanguage get() = Locale.forLanguageTag(pathSegments[0])
-    @VisibleForTesting
-    internal val Uri.deepLinkTool get() = pathSegments[1]
     @VisibleForTesting
     internal val Uri.deepLinkPage get() = pathSegments.getOrNull(2)?.toIntOrNull()
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/util/DeepLinkUtils.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/util/DeepLinkUtils.kt
@@ -3,5 +3,5 @@ package org.cru.godtools.tract.util
 import android.net.Uri
 import org.cru.godtools.base.HOST_KNOWGOD_COM
 
-internal fun Uri.isTractDeepLink() = ("http".equals(scheme, true) || "https".equals(scheme, true)) &&
-    host.equals(HOST_KNOWGOD_COM, true) && pathSegments.size >= 2
+internal fun Uri.isTractDeepLink() =
+    (scheme == "http" || scheme == "https") && host.equals(HOST_KNOWGOD_COM, true) && pathSegments.size >= 2

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import io.mockk.every
 import io.mockk.mockk
+import javax.inject.Named
 import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.db.findAsFlow
@@ -15,6 +16,7 @@ import org.ccci.gto.android.common.scarlet.ReferenceLifecycle
 import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.api.ApiModule
 import org.cru.godtools.api.TractShareService
+import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.DownloadManagerModule
@@ -43,6 +45,10 @@ import org.mockito.kotlin.mock
     ]
 )
 class ExternalSingletonsModule {
+    @get:Provides
+    @get:Named(DAGGER_HOST_CUSTOM_URI)
+    val hostCustomUri = "org.cru.godtools.test"
+
     @get:Provides
     val dao by lazy {
         mockk<GodToolsDao> {

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityDeepLinkTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityDeepLinkTest.kt
@@ -28,14 +28,6 @@ class TractActivityDeepLinkTest {
     }
 
     @Test
-    fun verifyDeepLinkTool() {
-        with(activity) {
-            assertEquals("kgp", Uri.parse("https://knowgod.com/en/kgp").deepLinkTool)
-            assertEquals("kgp", Uri.parse("https://knowgod.com/en/kgp/1").deepLinkTool)
-        }
-    }
-
-    @Test
     fun verifyDeepLinkPage() {
         with(activity) {
             assertNull(Uri.parse("https://knowgod.com/en/kgp").deepLinkPage)

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -9,8 +9,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
@@ -57,13 +57,20 @@ class TractActivityTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private val context: Context get() = getInstrumentation().context
+    private val context get() = ApplicationProvider.getApplicationContext<Context>()
     @Inject
     lateinit var dao: GodToolsDao
     @Inject
     lateinit var manifestManager: ManifestManager
 
     private lateinit var lottieUtils: MockedStatic<*>
+
+    private fun <R> scenario(
+        intent: Intent = context.createTractActivityIntent(TOOL, Locale.ENGLISH),
+        block: (ActivityScenario<TractActivity>) -> R
+    ) = ActivityScenario.launch<TractActivity>(intent).use(block)
+    private fun <R> deepLinkScenario(uri: Uri, block: (ActivityScenario<TractActivity>) -> R) =
+        scenario(Intent(Intent.ACTION_VIEW, uri), block)
 
     @Before
     fun setup() {
@@ -82,7 +89,7 @@ class TractActivityTest {
     // region Intent Processing
     @Test
     fun `processIntent() - Valid direct`() {
-        ActivityScenario.launch<TractActivity>(context.createTractActivityIntent(TOOL, Locale.ENGLISH)).use {
+        scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH)) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.ENGLISH, it.dataModel.primaryLocales.value!!.single())
@@ -93,8 +100,7 @@ class TractActivityTest {
 
     @Test
     fun `processIntent() - Valid direct with parallel language`() {
-        val intent = context.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH)
-        ActivityScenario.launch<TractActivity>(intent).use {
+        scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH)) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.ENGLISH, it.dataModel.primaryLocales.value!!.single())
@@ -106,29 +112,21 @@ class TractActivityTest {
 
     @Test
     fun `processIntent() - Invalid missing tool`() {
-        val intent = context.createTractActivityIntent(TOOL, Locale.ENGLISH)
-        intent.removeExtra(EXTRA_TOOL)
-        ActivityScenario.launch<TractActivity>(intent).use {
+        scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH).apply { removeExtra(EXTRA_TOOL) }) {
             assertEquals(Lifecycle.State.DESTROYED, it.state)
         }
     }
 
     @Test
     fun `processIntent() - Invalid missing locales`() {
-        val intent = context.createTractActivityIntent(TOOL, Locale.ENGLISH)
-        intent.removeExtra(EXTRA_LANGUAGES)
-        ActivityScenario.launch<TractActivity>(intent).use {
+        scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH).apply { removeExtra(EXTRA_LANGUAGES) }) {
             assertEquals(Lifecycle.State.DESTROYED, it.state)
         }
     }
 
     @Test
-    fun `processIntent() - Valid deeplink`() {
-        val intent = Intent(
-            Intent.ACTION_VIEW,
-            Uri.parse("https://knowgod.com/fr/test?primaryLanguage=en&parallelLanguage=es,fr")
-        )
-        ActivityScenario.launch<TractActivity>(intent).use {
+    fun `processIntent() - Deep Link - knowgod_com`() {
+        deepLinkScenario(Uri.parse("https://knowgod.com/fr/test?primaryLanguage=en&parallelLanguage=es,fr")) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.ENGLISH, it.dataModel.primaryLocales.value!!.single())
@@ -140,9 +138,22 @@ class TractActivityTest {
     }
 
     @Test
+    fun `processIntent() - Deep Link - knowgod_com - With Page Num`() {
+        deepLinkScenario(Uri.parse("https://knowgod.com/fr/test/3?primaryLanguage=en&parallelLanguage=es,fr")) {
+            it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(Locale.ENGLISH, it.dataModel.primaryLocales.value!!.single())
+                assertEquals(listOf(Locale("es"), Locale.FRENCH), it.dataModel.parallelLocales.value)
+                assertEquals(Locale.FRENCH, it.dataModel.activeLocale.value)
+                assertEquals(3, it.initialPage)
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
     fun `processIntent() - Preserve tool and language changes - Direct`() {
-        val intent = context.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH)
-        ActivityScenario.launch<TractActivity>(intent).use {
+        scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH)) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.ENGLISH, it.dataModel.primaryLocales.value!!.single())
@@ -169,12 +180,8 @@ class TractActivityTest {
     }
 
     @Test
-    fun `processIntent() - Preserve tool and language changes - Deeplink`() {
-        val intent = Intent(
-            Intent.ACTION_VIEW,
-            Uri.parse("https://knowgod.com/fr/test?primaryLanguage=en&parallelLanguage=es,fr")
-        )
-        ActivityScenario.launch<TractActivity>(intent).use {
+    fun `processIntent() - Preserve tool and language changes - Deep Link`() {
+        deepLinkScenario(Uri.parse("https://knowgod.com/fr/test?primaryLanguage=en&parallelLanguage=es,fr")) {
             // initially parse deep link
             it.onActivity {
                 assertEquals("test", it.dataModel.toolCode.value)
@@ -210,7 +217,7 @@ class TractActivityTest {
         everyGetTranslation() returns MutableLiveData(Translation())
         whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
-        ActivityScenario.launch<TractActivity>(context.createTractActivityIntent("test", Locale.ENGLISH)).use {
+        scenario {
             it.moveToState(Lifecycle.State.RESUMED)
             it.onActivity {
                 with(it.findViewById<Toolbar>(R.id.appbar)!!.menu!!.findItem(R.id.action_share)!!) {
@@ -227,11 +234,7 @@ class TractActivityTest {
         everyGetTranslation() returns MutableLiveData(Translation())
         whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
-        val intent = Intent(context, TractActivity::class.java).apply {
-            action = Intent.ACTION_VIEW
-            data = Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en")
-        }
-        ActivityScenario.launch<TractActivity>(intent).use {
+        deepLinkScenario(Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en")) {
             it.moveToState(Lifecycle.State.RESUMED)
             it.onActivity {
                 with(it.findViewById<Toolbar>(R.id.appbar)!!.menu!!.findItem(R.id.action_share)!!) {
@@ -248,7 +251,7 @@ class TractActivityTest {
         everyGetTranslation() returns MutableLiveData(Translation())
         whenGetManifest().thenReturn(ImmutableLiveData(null))
 
-        ActivityScenario.launch<TractActivity>(context.createTractActivityIntent("test", Locale.ENGLISH)).use {
+        scenario {
             it.moveToState(Lifecycle.State.RESUMED)
             it.onActivity {
                 with(it.findViewById<Toolbar>(R.id.appbar)!!.menu!!.findItem(R.id.action_share)!!) {
@@ -266,8 +269,7 @@ class TractActivityTest {
         whenGetManifest()
             .thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH, tips = { listOf(Tip()) })))
 
-        val intent = context.createTractActivityIntent("test", Locale.ENGLISH, showTips = true)
-        ActivityScenario.launch<TractActivity>(intent).use {
+        scenario(context.createTractActivityIntent("test", Locale.ENGLISH, showTips = true)) {
             it.moveToState(Lifecycle.State.RESUMED)
             it.onActivity {
                 with(it.findViewById<Toolbar>(R.id.appbar)!!.menu!!.findItem(R.id.action_share)!!) {
@@ -284,11 +286,7 @@ class TractActivityTest {
         everyGetTranslation() returns MutableLiveData(Translation())
         whenGetManifest().thenReturn(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH)))
 
-        val intent = Intent(context, TractActivity::class.java).apply {
-            action = Intent.ACTION_VIEW
-            data = Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en&$PARAM_LIVE_SHARE_STREAM=asdf")
-        }
-        ActivityScenario.launch<TractActivity>(intent).use {
+        deepLinkScenario(Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en&$PARAM_LIVE_SHARE_STREAM=asdf")) {
             it.moveToState(Lifecycle.State.RESUMED)
             it.onActivity {
                 with(it.findViewById<Toolbar>(R.id.appbar)!!.menu!!.findItem(R.id.action_share)!!) {

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -152,6 +152,36 @@ class TractActivityTest {
     }
 
     @Test
+    fun `processIntent() - Deep Link - Custom Uri Scheme`() {
+        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/fr")) {
+            it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(Locale.FRENCH, it.dataModel.primaryLocales.value!!.single())
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
+    fun `processIntent() - Deep Link - Custom Uri Scheme - Missing Language`() {
+        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/")) {
+            assertEquals(Lifecycle.State.DESTROYED, it.state)
+        }
+    }
+
+    @Test
+    fun `processIntent() - Deep Link - Custom Uri Scheme - With Page Num`() {
+        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/fr/3")) {
+            it.onActivity {
+                assertEquals(TOOL, it.dataModel.toolCode.value)
+                assertEquals(Locale.FRENCH, it.dataModel.primaryLocales.value!!.single())
+                assertEquals(3, it.initialPage)
+                assertFalse(it.isFinishing)
+            }
+        }
+    }
+
+    @Test
     fun `processIntent() - Preserve tool and language changes - Direct`() {
         scenario(context.createTractActivityIntent(TOOL, Locale.ENGLISH, Locale.FRENCH)) {
             it.onActivity {


### PR DESCRIPTION
Adds support for deep links using a custom URI scheme. This will be used for fallback URLs for AppsFlyer.

example urls:
```
godtools://org.cru.godtools/dashboard
godtools://org.cru.godtools/tool/cyoa/openers/en
godtools://org.cru.godtools/tool/cyoa/openers/en/family
```