### PR TITLE
Update build script to use buildSrc for common configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,10 +4,13 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'com.google.gms.google-services'
 
+AndroidConfigurationKt.configureAndroidCommon(project)
+
 android {
     defaultConfig {
         applicationId rootProject.applicationId
         versionName rootProject.version
+        versionCode rootProject.versionCode
 
         proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
         proguardFile 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.firebase.firebase-perf'
 apply plugin: 'com.google.gms.google-services'
 
-AndroidConfigurationKt.configureAndroidCommon(project)
+AndroidConfigurationKt.configureAndroidApp(project)
 
 android {
     defaultConfig {
@@ -45,16 +45,11 @@ android {
         }
     }
 
-    flavorDimensions "env"
     productFlavors {
         stage {
-            dimension "env"
-
             buildConfigField "String", "MOBILE_CONTENT_API", "\"${uris.mobileContentApi.stage}\""
         }
         production {
-            dimension "env"
-
             buildConfigField "String", "MOBILE_CONTENT_API", "\"${uris.mobileContentApi.production}\""
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,6 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.dagger.hilt.android'
 apply plugin: 'com.google.firebase.appdistribution'
 apply plugin: 'com.google.firebase.crashlytics'

--- a/build.gradle
+++ b/build.gradle
@@ -133,10 +133,6 @@ subprojects {
     beforeEvaluate { project ->
         if (project.hasProperty('android')) {
             android {
-                lintOptions {
-                    lintConfig rootProject.file("analysis/lint/lint.xml")
-                }
-
                 // only include stage variants for the debug buildType
                 variantFilter { variant ->
                     if (variant.flavors*.name.contains("stage") && variant.buildType.name != "debug") setIgnore(true)

--- a/build.gradle
+++ b/build.gradle
@@ -86,13 +86,6 @@ allprojects {
     }
 }
 
-// base app plugins
-configure(subprojects.findAll { it.path == ":app" }) {
-    apply plugin: 'com.android.application'
-    apply plugin: 'kotlin-android'
-    apply plugin: 'kotlin-kapt'
-}
-
 // base library plugins
 configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.startsWith(":ui:") }) {
     apply plugin: 'com.android.library'
@@ -130,7 +123,7 @@ configure(subprojects.findAll { it.path.startsWith(":feature:") }) {
 
 // common config
 subprojects {
-    beforeEvaluate { project ->
+    afterEvaluate { project ->
         if (project.hasProperty('android')) {
             dependencies {
                 compileOnly libs.androidx.annotation

--- a/build.gradle
+++ b/build.gradle
@@ -86,18 +86,6 @@ allprojects {
     }
 }
 
-// base library plugins
-configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.startsWith(":ui:") }) {
-    apply plugin: 'com.android.library'
-    apply plugin: 'kotlin-android'
-    apply plugin: 'kotlin-kapt'
-
-    dependencies {
-        androidTestImplementation libs.gtoSupport.testing.okta
-        testImplementation libs.gtoSupport.testing.okta
-    }
-}
-
 // common config
 subprojects {
     afterEvaluate { project ->
@@ -115,6 +103,10 @@ subprojects {
                 testImplementation libs.mockito.kotlin
                 testImplementation libs.mockk
                 testImplementation libs.robolectric
+
+                // HACK: Fix Manifest merge errors for any classpath that contains the Okta module
+                androidTestImplementation libs.gtoSupport.testing.okta
+                testImplementation libs.gtoSupport.testing.okta
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         classpath libs.firebase.crashlytics.gradlePlugin
         classpath libs.firebase.perf.gradlePlugin
         classpath libs.google.services.gradlePlugin
-        classpath libs.kotlin.gradlePlugin
     }
 }
 
@@ -34,7 +33,6 @@ plugins {
     alias libs.plugins.hilt apply false
     alias libs.plugins.junitJacoco
     alias libs.plugins.ktlint
-    id "de.undercouch.download" version "5.0.2" apply false
 }
 
 version '6.0.0-SNAPSHOT'
@@ -43,9 +41,6 @@ ext.versionCode = grgit.log(includes:['HEAD']).size() + 4029265
 // define dependency versions for this project
 ext {
     applicationId = 'org.keynote.godtools.android'
-    compileSdk    = 32
-    minSdk        = 21
-    targetSdk     = 32
 }
 
 // configure dependency resolution
@@ -138,23 +133,6 @@ subprojects {
     beforeEvaluate { project ->
         if (project.hasProperty('android')) {
             android {
-                compileSdkVersion rootProject.compileSdk
-
-                defaultConfig {
-                    versionCode rootProject.versionCode
-
-                    minSdkVersion rootProject.minSdk
-                    targetSdkVersion rootProject.targetSdk
-                }
-
-                compileOptions {
-                    sourceCompatibility JavaVersion.VERSION_11
-                    targetCompatibility JavaVersion.VERSION_11
-                }
-                kotlinOptions {
-                    jvmTarget = JavaVersion.VERSION_11.toString()
-                    freeCompilerArgs += '-Xjvm-default=all'
-                }
                 lintOptions {
                     lintConfig rootProject.file("analysis/lint/lint.xml")
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,17 +98,6 @@ configure(subprojects.findAll { it.path.startsWith(":library:") || it.path.start
     }
 }
 
-// base feature plugins
-configure(subprojects.findAll { it.path.startsWith(":feature:") }) {
-    apply plugin: "com.android.dynamic-feature"
-    apply plugin: 'kotlin-android'
-    apply plugin: 'kotlin-kapt'
-
-    dependencies {
-        implementation project(":app")
-    }
-}
-
 // common config
 subprojects {
     afterEvaluate { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -132,13 +132,6 @@ configure(subprojects.findAll { it.path.startsWith(":feature:") }) {
 subprojects {
     beforeEvaluate { project ->
         if (project.hasProperty('android')) {
-            android {
-                // only include stage variants for the debug buildType
-                variantFilter { variant ->
-                    if (variant.flavors*.name.contains("stage") && variant.buildType.name != "debug") setIgnore(true)
-                }
-            }
-
             dependencies {
                 compileOnly libs.androidx.annotation
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libs.android.gradlePlugin
         classpath libs.firebase.appdistribution.gradlePlugin
         classpath libs.firebase.crashlytics.gradlePlugin
         classpath libs.firebase.perf.gradlePlugin

--- a/build.gradle
+++ b/build.gradle
@@ -136,16 +136,6 @@ subprojects {
                 lintOptions {
                     lintConfig rootProject.file("analysis/lint/lint.xml")
                 }
-                testOptions {
-                    unitTests {
-                        includeAndroidResources = true
-
-                        all {
-                            // increase unit tests max heap size
-                            jvmArgs "-Xmx2g"
-                        }
-                    }
-                }
 
                 // only include stage variants for the debug buildType
                 variantFilter { variant ->

--- a/build.gradle
+++ b/build.gradle
@@ -104,18 +104,6 @@ configure(subprojects.findAll { it.path.startsWith(":feature:") }) {
     apply plugin: 'kotlin-android'
     apply plugin: 'kotlin-kapt'
 
-    android {
-        flavorDimensions "env"
-        productFlavors {
-            stage {
-                dimension "env"
-            }
-            production {
-                dimension "env"
-            }
-        }
-    }
-
     dependencies {
         implementation project(":app")
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,10 +11,14 @@ configurations.configureEach {
     resolutionStrategy {
         // HACK: workaround a javapoet transitive dependency conflict between the android and hilt gradle plugins
         force(libs.javapoet)
+
+        // HACK: workaround a transitive dependency version conflict in the kotlin gradle plugin
+        force(libs.gradleDownloadTask)
     }
 }
 
 dependencies {
     compileOnly(gradleKotlinDsl())
     implementation(libs.android.gradlePlugin)
+    implementation(libs.kotlin.gradlePlugin)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+configurations.configureEach {
+    resolutionStrategy {
+        // HACK: workaround a javapoet transitive dependency conflict between the android and hilt gradle plugins
+        force(libs.javapoet)
+    }
+}
+
+dependencies {
+    compileOnly(gradleKotlinDsl())
+    implementation(libs.android.gradlePlugin)
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -15,6 +15,7 @@ fun Project.configureAndroidCommon() {
         configureSdk()
         configureCompilerOptions()
 
+        lintOptions.lintConfig = rootProject.file("analysis/lint/lint.xml")
         testOptions.unitTests.isIncludeAndroidResources = true
     }
 }

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -6,6 +6,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.findByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
@@ -17,6 +18,10 @@ fun Project.configureAndroidApp() = extensions.configure<BaseAppModuleExtension>
 fun Project.configureAndroidFeature() = extensions.configure<DynamicFeatureExtension> {
     configureAndroidCommon(project)
     configureFlavorDimensions()
+
+    dependencies {
+        add("implementation", project(":app"))
+    }
 }
 
 fun Project.configureAndroidLibrary(block: LibraryExtension.() -> Unit = {}) = extensions.configure<LibraryExtension> {

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -17,6 +17,8 @@ fun Project.configureAndroidCommon() {
 
         lintOptions.lintConfig = rootProject.file("analysis/lint/lint.xml")
         testOptions.unitTests.isIncludeAndroidResources = true
+
+        filterStageVariants()
     }
 }
 
@@ -39,3 +41,6 @@ private fun BaseExtension.configureCompilerOptions() {
         freeCompilerArgs += "-Xjvm-default=all"
     }
 }
+
+private fun BaseExtension.filterStageVariants() =
+    variantFilter { if (flavors.any { it.name.contains("stage") } && buildType.name != "debug") ignore = true }

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -14,6 +14,8 @@ fun Project.configureAndroidCommon() {
     extensions.configure<BaseExtension> {
         configureSdk()
         configureCompilerOptions()
+
+        testOptions.unitTests.isIncludeAndroidResources = true
     }
 }
 

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -1,0 +1,38 @@
+import com.android.build.gradle.BaseExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.findByType
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+
+fun Project.configureAndroidLibrary() {
+    configureAndroidCommon()
+}
+
+fun Project.configureAndroidCommon() {
+    extensions.configure<BaseExtension> {
+        configureSdk()
+        configureCompilerOptions()
+    }
+}
+
+private fun BaseExtension.configureSdk() {
+    compileSdkVersion(32)
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 32
+    }
+}
+
+private fun BaseExtension.configureCompilerOptions() {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    (this as ExtensionAware).extensions.findByType<KotlinJvmOptions>()?.apply {
+        jvmTarget = JavaVersion.VERSION_11.toString()
+        freeCompilerArgs += "-Xjvm-default=all"
+    }
+}

--- a/feature/bundledcontent/build.gradle.kts
+++ b/feature/bundledcontent/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.dynamic-feature")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidFeature()
 
 dependencies {

--- a/feature/bundledcontent/build.gradle.kts
+++ b/feature/bundledcontent/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidCommon()
+
 dependencies {
     implementation(project(":library:initial-content"))
 

--- a/feature/bundledcontent/build.gradle.kts
+++ b/feature/bundledcontent/build.gradle.kts
@@ -1,4 +1,4 @@
-configureAndroidCommon()
+configureAndroidFeature()
 
 dependencies {
     implementation(project(":library:initial-content"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,7 @@ hamcrest = "org.hamcrest:hamcrest:2.2"
 hilt = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "dagger" }
 hilt-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "dagger" }
+javapoet = "com.squareup:javapoet:1.13.0"
 json = "org.json:json:20220320"
 jsoup = "org.jsoup:jsoup:1.14.3"
 junit = "junit:junit:4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ godtoolsMpp-parser = { module = "org.cru.godtools.kotlin:parser", version.ref = 
 google-auto-value = { module = "com.google.auto.value:auto-value", version.ref = "google-auto-value" }
 google-auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "google-auto-value" }
 google-services-gradlePlugin = "com.google.gms:google-services:4.3.10"
+gradleDownloadTask = "de.undercouch:gradle-download-task:5.0.2"
 gtoSupport-androidx-constraintlayout = { module = "org.ccci.gto.android:gto-support-androidx-constraintlayout", version.ref = "gtoSupport" }
 gtoSupport-androidx-databinding = { module = "org.ccci.gto.android:gto-support-androidx-databinding", version.ref = "gtoSupport" }
 gtoSupport-androidx-drawerlayout = { module = "org.ccci.gto.android:gto-support-androidx-drawerlayout", version.ref = "gtoSupport" }

--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 android {

--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         consumerProguardFiles += file("proguard-rules-snowplow.pro")

--- a/library/api/build.gradle.kts
+++ b/library/api/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android.defaultConfig {
     buildConfigField("String", "CAMPAIGN_FORMS_API", "\"https://campaign-forms.cru.org/\"")
     buildConfigField("String", "CAMPAIGN_FORMS_ID", "\"3fb6022c-5ef9-458c-928a-0380c4a0e57b\"")

--- a/library/api/build.gradle.kts
+++ b/library/api/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 android.defaultConfig {

--- a/library/base/build.gradle.kts
+++ b/library/base/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android {
     defaultConfig.buildConfigField("int", "VERSION_CODE", "${rootProject.ext["versionCode"]}")
 }

--- a/library/base/build.gradle.kts
+++ b/library/base/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 android {

--- a/library/db/build.gradle.kts
+++ b/library/db/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 dependencies {

--- a/library/db/build.gradle.kts
+++ b/library/db/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 dependencies {
     api(project(":library:base"))
     implementation(project(":library:model"))

--- a/library/download-manager/build.gradle.kts
+++ b/library/download-manager/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 android {

--- a/library/download-manager/build.gradle.kts
+++ b/library/download-manager/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android {
     buildFeatures.dataBinding = true
 }

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary {
     configureFlavorDimensions()
 }

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -1,11 +1,5 @@
-configureAndroidLibrary()
-
-android {
-    flavorDimensions += "env"
-    productFlavors {
-        create("stage") { dimension = "env" }
-        create("production") { dimension = "env" }
-    }
+configureAndroidLibrary {
+    configureFlavorDimensions()
 }
 
 dependencies {

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android {
     flavorDimensions += "env"
     productFlavors {

--- a/library/model/build.gradle.kts
+++ b/library/model/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 dependencies {

--- a/library/model/build.gradle.kts
+++ b/library/model/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 dependencies {
     implementation(project(":library:base"))
 

--- a/library/sync/build.gradle.kts
+++ b/library/sync/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 dependencies {

--- a/library/sync/build.gradle.kts
+++ b/library/sync/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 dependencies {
     implementation(project(":library:api"))
     implementation(project(":library:db"))

--- a/library/user-data/build.gradle.kts
+++ b/library/user-data/build.gradle.kts
@@ -1,3 +1,5 @@
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         javaCompileOptions {

--- a/library/user-data/build.gradle.kts
+++ b/library/user-data/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
 configureAndroidLibrary()
 
 android {

--- a/ui/article-aem-renderer/build.gradle.kts
+++ b/ui/article-aem-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/article-aem-renderer/build.gradle.kts
+++ b/ui/article-aem-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         javaCompileOptions {

--- a/ui/article-renderer/build.gradle.kts
+++ b/ui/article-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/article-renderer/build.gradle.kts
+++ b/ui/article-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     buildFeatures {
         dataBinding = true

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("kotlin-parcelize")
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         javaCompileOptions {

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
-    alias(libs.plugins.hilt)
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     id("kotlin-parcelize")
+    alias(libs.plugins.hilt)
 }
 
 configureAndroidLibrary()

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -1,6 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig.vectorDrawables.useSupportLibrary = true
 

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     buildFeatures.dataBinding = true
 }

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     buildFeatures.dataBinding = true
 }

--- a/ui/shortcuts/build.gradle.kts
+++ b/ui/shortcuts/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/shortcuts/build.gradle.kts
+++ b/ui/shortcuts/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         javaCompileOptions {

--- a/ui/tips-renderer/build.gradle.kts
+++ b/ui/tips-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/tips-renderer/build.gradle.kts
+++ b/ui/tips-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig.vectorDrawables.useSupportLibrary = true
     buildFeatures.dataBinding = true

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
-    alias(libs.plugins.hilt)
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     id("kotlin-parcelize")
+    alias(libs.plugins.hilt)
 }
 
 configureAndroidLibrary()

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("kotlin-parcelize")
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true

--- a/ui/tutorial-renderer/build.gradle.kts
+++ b/ui/tutorial-renderer/build.gradle.kts
@@ -1,4 +1,7 @@
 plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
     alias(libs.plugins.hilt)
 }
 

--- a/ui/tutorial-renderer/build.gradle.kts
+++ b/ui/tutorial-renderer/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
+configureAndroidLibrary()
+
 android {
     defaultConfig {
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
- initial buildSrc gradle config
- start moving common android configuration to buildSrc
- move common test configuration into AndroidConfiguration
- move common lint config to AndroidConfiguration
- move stage variant filter into buildSrc
- move app plugins to app build.gradle file
- centralize flavor dimension configuration in buildSrc
- declare the dynamic feature plugins in the actual feature build scripts
- declare library build script plugins in each build script
