### PR TITLE
GT-1540 Fix Crash caused by misconfigured Facebook SDK

### DIFF
--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -18,10 +18,12 @@ android {
     buildTypes {
         debug {
             resValue("string", "facebook_app_id", "448969905944197")
+            resValue("string", "facebook_client_token", "be1edf48d86ed54a24951ededa62eda2")
             buildConfigField("String", "SNOWPLOW_APP_ID", "\"godtools-dev\"")
         }
         release {
             resValue("string", "facebook_app_id", "2236701616451487")
+            resValue("string", "facebook_client_token", "3b6bf5b7c128a970337c4fa1860ffa6e")
             buildConfigField("String", "SNOWPLOW_APP_ID", "\"godtools\"")
         }
     }

--- a/library/analytics/src/main/AndroidManifest.xml
+++ b/library/analytics/src/main/AndroidManifest.xml
@@ -32,11 +32,17 @@
         </service>
         <!-- endregion AppsFlyer -->
 
-        <meta-data
-            android:name="google_analytics_automatic_screen_reporting_enabled"
-            android:value="false" />
+        <!-- region Facebook -->
         <meta-data
             android:name="com.facebook.sdk.ApplicationId"
             android:value="@string/facebook_app_id" />
+        <meta-data
+            android:name="com.facebook.sdk.ClientToken"
+            android:value="@string/facebook_client_token" />
+        <!-- endregion Facebook -->
+
+        <meta-data
+            android:name="google_analytics_automatic_screen_reporting_enabled"
+            android:value="false" />
     </application>
 </manifest>


### PR DESCRIPTION
the client_token is required starting with Facebook SDK 13.2.0