### PR TITLE
Refactor the ShortcutManager Dispatcher to no longer use EventBus

### DIFF
--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -301,22 +301,16 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         @AnyThread
         @Subscribe
         fun onToolUpdate(event: ToolUpdateEvent) {
-            // Could change which tools are visible or the label for tools
-            updateShortcutsActor.trySend(Unit)
         }
 
         @AnyThread
         @Subscribe
         fun onAttachmentUpdate(event: AttachmentUpdateEvent) {
-            // Handles potential icon image changes.
-            updateShortcutsActor.trySend(Unit)
         }
 
         @AnyThread
         @Subscribe
         fun onTranslationUpdate(event: TranslationUpdateEvent) {
-            // Could change which tools are available or the label for tools
-            updateShortcutsActor.trySend(Unit)
         }
         // endregion Events
 
@@ -338,6 +332,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
             merge(
                 settings.primaryLanguageFlow,
                 settings.parallelLanguageFlow,
+                dao.invalidationFlow(Tool::class.java, Attachment::class.java, Translation::class.java),
                 channel.consumeAsFlow()
             ).conflate().collectLatest {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -55,10 +55,7 @@ import org.cru.godtools.base.ui.util.getName
 import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
-import org.cru.godtools.model.event.AttachmentUpdateEvent
-import org.cru.godtools.model.event.ToolUpdateEvent
 import org.cru.godtools.model.event.ToolUsedEvent
-import org.cru.godtools.model.event.TranslationUpdateEvent
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.keynote.godtools.android.db.Contract.ToolTable
@@ -285,7 +282,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     class Dispatcher @VisibleForTesting internal constructor(
         private val manager: GodToolsShortcutManager,
         private val dao: GodToolsDao,
-        eventBus: EventBus,
         settings: Settings,
         coroutineScope: CoroutineScope
     ) {
@@ -293,26 +289,8 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         constructor(
             manager: GodToolsShortcutManager,
             dao: GodToolsDao,
-            eventBus: EventBus,
             settings: Settings
-        ) : this(manager, dao, eventBus, settings, CoroutineScope(Dispatchers.Default + SupervisorJob()))
-
-        // region Events
-        @AnyThread
-        @Subscribe
-        fun onToolUpdate(event: ToolUpdateEvent) {
-        }
-
-        @AnyThread
-        @Subscribe
-        fun onAttachmentUpdate(event: AttachmentUpdateEvent) {
-        }
-
-        @AnyThread
-        @Subscribe
-        fun onTranslationUpdate(event: TranslationUpdateEvent) {
-        }
-        // endregion Events
+        ) : this(manager, dao, settings, CoroutineScope(Dispatchers.Default + SupervisorJob()))
 
         @VisibleForTesting
         internal val updatePendingShortcutsJob = coroutineScope.launch {
@@ -343,9 +321,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         }
 
         init {
-            // register event listeners
-            eventBus.register(this)
-
             // launch an initial update
             updateShortcutsActor.trySend(Unit)
         }

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -78,7 +78,7 @@ class GodToolsShortcutManagerDispatcherTest {
         verifyNoInteractions(shortcutManager)
 
         // trigger update
-        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(invalidations.tryEmit(Unit))
         verifyNoInteractions(shortcutManager)
         coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
         coroutineScope.runCurrent()
@@ -87,11 +87,11 @@ class GodToolsShortcutManagerDispatcherTest {
         clearInvocations(shortcutManager)
 
         // trigger multiple updates simultaneously, it should conflate to a single update
-        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(invalidations.tryEmit(Unit))
         coroutineScope.advanceTimeBy(1)
         coroutineScope.runCurrent()
         verifyNoInteractions(shortcutManager)
-        assertTrue(dispatcher.updatePendingShortcutsActor.trySend(Unit).isSuccess)
+        assertTrue(invalidations.tryEmit(Unit))
         coroutineScope.advanceTimeBy(DELAY_UPDATE_PENDING_SHORTCUTS)
         coroutineScope.runCurrent()
         verifyBlocking(shortcutManager) { updatePendingShortcuts() }
@@ -104,7 +104,7 @@ class GodToolsShortcutManagerDispatcherTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsOnPrimaryLanguageUpdate() {
-        dispatcher.updatePendingShortcutsActor.close()
+        dispatcher.updatePendingShortcutsJob.cancel()
         assertUpdateExistingShortcutsInitialUpdate()
 
         // trigger a primary language update
@@ -118,7 +118,7 @@ class GodToolsShortcutManagerDispatcherTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsOnParallelLanguageUpdate() {
-        dispatcher.updatePendingShortcutsActor.close()
+        dispatcher.updatePendingShortcutsJob.cancel()
         assertUpdateExistingShortcutsInitialUpdate()
 
         // trigger a primary language update
@@ -132,7 +132,7 @@ class GodToolsShortcutManagerDispatcherTest {
     @Test
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateExistingShortcutsAggregateMultiple() = runTest {
-        dispatcher.updatePendingShortcutsActor.close()
+        dispatcher.updatePendingShortcutsJob.cancel()
         assertUpdateExistingShortcutsInitialUpdate()
 
         // trigger multiple updates simultaneously, it should aggregate to a single update

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -13,22 +13,15 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.base.Settings
-import org.cru.godtools.model.event.AttachmentUpdateEvent
-import org.cru.godtools.model.event.ToolUpdateEvent
-import org.cru.godtools.model.event.TranslationUpdateEvent
-import org.greenrobot.eventbus.EventBus
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.keynote.godtools.android.db.GodToolsDao
-import org.mockito.kotlin.any
 import org.mockito.kotlin.clearInvocations
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -60,7 +53,7 @@ class GodToolsShortcutManagerDispatcherTest {
             on { parallelLanguageFlow } doReturn parallelLanguageFlow
         }
 
-        dispatcher = GodToolsShortcutManager.Dispatcher(shortcutManager, dao, mock(), settings, coroutineScope)
+        dispatcher = GodToolsShortcutManager.Dispatcher(shortcutManager, dao, settings, coroutineScope)
     }
 
     @After
@@ -174,22 +167,4 @@ class GodToolsShortcutManagerDispatcherTest {
         clearInvocations(shortcutManager)
     }
     // endregion updateShortcutsActor
-
-    @Test
-    fun `Initialization - EventBus events shouldn't race initialization`() {
-        val eventBus = mock<EventBus> {
-            on { register(any<GodToolsShortcutManager.Dispatcher>()) } doAnswer {
-                // trigger events immediately when the Dispatcher is registered
-                val dispatcher: GodToolsShortcutManager.Dispatcher = it.getArgument(0)
-                dispatcher.onToolUpdate(ToolUpdateEvent)
-                dispatcher.onAttachmentUpdate(AttachmentUpdateEvent)
-                dispatcher.onTranslationUpdate(TranslationUpdateEvent)
-            }
-        }
-
-        val dispatcher = GodToolsShortcutManager.Dispatcher(shortcutManager, dao, eventBus, settings, coroutineScope)
-        verify(eventBus).register(dispatcher)
-        verifyNoMoreInteractions(eventBus)
-        dispatcher.shutdown()
-    }
 }


### PR DESCRIPTION
- monitor db invalidations instead of relying on EventBus events for updating pending events
- we no longer need to use an actor to trigger pending shortcut updates
- use a dao invalidation flow instead of eventbus to monitor for changes to attachments, tools, and translations
- we no longer need to use eventbus with the shortcut manager dispatcher
- convert shortcut manager dispatcher tests to MockK
- utilize runTest for all the dispatcher tests
- model the fact that the various flows emit initial values when collecting
- updateShortcutsJob no longer needs to be an actor
