### PR TITLE
GT-1559 Handle Meta-tools within the All Tools UI

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
@@ -26,7 +26,8 @@ internal val QUERY_TOOLS = QUERY_TOOLS_BASE.join(ToolTable.SQL_JOIN_METATOOL.typ
         ToolTable.FIELD_META_TOOL.isNull() or
             (ToolTable.FIELD_CODE eq ToolTable.TABLE_META.field(ToolTable.COLUMN_DEFAULT_VARIANT))
     )
-private val QUERY_TOOLS_SPOTLIGHT = QUERY_TOOLS_BASE.andWhere(ToolTable.FIELD_SPOTLIGHT eq true)
+@VisibleForTesting
+internal val QUERY_TOOLS_SPOTLIGHT = QUERY_TOOLS_BASE.andWhere(ToolTable.FIELD_SPOTLIGHT eq true)
 
 @HiltViewModel
 class ToolsFragmentDataModel @Inject constructor(dao: GodToolsDao, savedState: SavedStateHandle) : ViewModel() {

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.ui.dashboard.tools
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
@@ -19,7 +20,8 @@ private val QUERY_TOOLS_BASE = Query.select<Tool>().where(
         (ToolTable.FIELD_HIDDEN ne true)
 ).orderBy(ToolTable.COLUMN_DEFAULT_ORDER)
 
-private val QUERY_TOOLS = QUERY_TOOLS_BASE.join(ToolTable.SQL_JOIN_METATOOL.type("LEFT"))
+@VisibleForTesting
+internal val QUERY_TOOLS = QUERY_TOOLS_BASE.join(ToolTable.SQL_JOIN_METATOOL.type("LEFT"))
     .andWhere(
         ToolTable.FIELD_META_TOOL.isNull() or
             (ToolTable.FIELD_CODE eq ToolTable.TABLE_META.field(ToolTable.COLUMN_DEFAULT_VARIANT))

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModel.kt
@@ -8,17 +8,23 @@ import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.db.Expression.Companion.constants
 import org.ccci.gto.android.common.db.Query
-import org.ccci.gto.android.common.db.getAsLiveData
 import org.cru.godtools.model.Tool
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
 
 private const val ATTR_SELECTED_CATEGORY = "selectedCategory"
 
-private val QUERY_TOOLS = Query.select<Tool>().where(
-    ToolTable.FIELD_TYPE.`in`(*constants(Tool.Type.TRACT, Tool.Type.ARTICLE, Tool.Type.CYOA))
-        .and(ToolTable.FIELD_HIDDEN.ne(true))
+private val QUERY_TOOLS_BASE = Query.select<Tool>().where(
+    ToolTable.FIELD_TYPE.`in`(*constants(Tool.Type.TRACT, Tool.Type.ARTICLE, Tool.Type.CYOA)) and
+        (ToolTable.FIELD_HIDDEN ne true)
 ).orderBy(ToolTable.COLUMN_DEFAULT_ORDER)
+
+private val QUERY_TOOLS = QUERY_TOOLS_BASE.join(ToolTable.SQL_JOIN_METATOOL.type("LEFT"))
+    .andWhere(
+        ToolTable.FIELD_META_TOOL.isNull() or
+            (ToolTable.FIELD_CODE eq ToolTable.TABLE_META.field(ToolTable.COLUMN_DEFAULT_VARIANT))
+    )
+private val QUERY_TOOLS_SPOTLIGHT = QUERY_TOOLS_BASE.andWhere(ToolTable.FIELD_SPOTLIGHT eq true)
 
 @HiltViewModel
 class ToolsFragmentDataModel @Inject constructor(dao: GodToolsDao, savedState: SavedStateHandle) : ViewModel() {
@@ -27,7 +33,7 @@ class ToolsFragmentDataModel @Inject constructor(dao: GodToolsDao, savedState: S
     val categories = tools.map { it.mapNotNull { it.category }.distinct() }
     val selectedCategory = savedState.getLiveData<String?>(ATTR_SELECTED_CATEGORY, null)
 
-    val spotlightTools = tools.map { it.filter { t -> t.isSpotlight } }
+    val spotlightTools = dao.getLiveData(QUERY_TOOLS_SPOTLIGHT)
     val filteredTools = tools.combineWith(selectedCategory) { tools, category ->
         tools.filter { category == null || it.category == category }
     }

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModelQueriesTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModelQueriesTest.kt
@@ -73,6 +73,34 @@ class ToolsFragmentDataModelQueriesTest {
     }
     // endregion QUERY_TOOLS
 
+    // region QUERY_TOOLS_SPOTLIGHT
+    @Test
+    fun `QUERY_TOOLS_SPOTLIGHT - returns only spotlighted tools`() {
+        val normal = createTool("normal")
+        val spotlight = createTool("spotlight") { isSpotlight = true }
+        val meta = createTool("meta") {
+            type = Tool.Type.META
+            defaultVariant = "normalVariant"
+        }
+        val spotlightVariant = createTool("spotlightVariant") {
+            metatoolCode = "meta"
+            isSpotlight = true
+        }
+        val normalVariant = createTool("normalVariant") { metatoolCode = "meta" }
+
+        val tools = dao.get(QUERY_TOOLS_SPOTLIGHT)
+        assertThat(
+            tools,
+            allOf(
+                containsInAnyOrder(tool(spotlight), tool(spotlightVariant)),
+                not(hasItem(tool(normal))),
+                not(hasItem(tool(meta))),
+                not(hasItem(tool(normalVariant))),
+            )
+        )
+    }
+    // endregion QUERY_TOOLS_SPOTLIGHT
+
     private fun createTool(code: String = "tool", config: Tool.() -> Unit = {}) = Tool().apply {
         id = Random.nextLong()
         this.code = code

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModelQueriesTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsFragmentDataModelQueriesTest.kt
@@ -1,0 +1,87 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import javax.inject.Inject
+import kotlin.random.Random
+import org.cru.godtools.model.Tool
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.hasProperty
+import org.hamcrest.Matchers.not
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.keynote.godtools.android.db.GodToolsDao
+import org.robolectric.annotation.Config
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Category(AndroidJUnit4::class)
+@Config(application = HiltTestApplication::class)
+class ToolsFragmentDataModelQueriesTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var dao: GodToolsDao
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    // region QUERY_TOOLS
+    @Test
+    fun `QUERY_TOOLS - return only supported types`() {
+        val tract = createTool("tract") { type = Tool.Type.TRACT }
+        val cyoa = createTool("cyoa") { type = Tool.Type.CYOA }
+        val article = createTool("article") { type = Tool.Type.ARTICLE }
+        val lesson = createTool("lesson") { type = Tool.Type.LESSON }
+        val meta = createTool("meta") { type = Tool.Type.META }
+
+        val tools = dao.get(QUERY_TOOLS)
+        assertThat(
+            tools,
+            allOf(
+                containsInAnyOrder(tool(tract), tool(cyoa), tool(article)),
+                not(hasItem(tool(lesson))),
+                not(hasItem(tool(meta)))
+            )
+        )
+    }
+
+    @Test
+    fun `QUERY_TOOLS - return only default variants`() {
+        val meta = createTool("meta") {
+            type = Tool.Type.META
+            defaultVariant = "variant2"
+        }
+        val variant1 = createTool("variant1") { metatoolCode = "meta" }
+        val variant2 = createTool("variant2") { metatoolCode = "meta" }
+
+        val tools = dao.get(QUERY_TOOLS)
+        assertThat(tools, allOf(contains(tool(variant2)), not(hasItem(tool(meta))), not(hasItem(tool(variant1)))))
+    }
+    // endregion QUERY_TOOLS
+
+    private fun createTool(code: String = "tool", config: Tool.() -> Unit = {}) = Tool().apply {
+        id = Random.nextLong()
+        this.code = code
+        type = Tool.Type.TRACT
+        config()
+    }.also { dao.insert(it) }
+
+    private fun tool(tool: Tool) = allOf<Tool>(
+        hasProperty("id", equalTo(tool.id)),
+        hasProperty("code", equalTo(tool.code))
+    )
+}

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -81,6 +81,7 @@ object Contract : BaseContract() {
     object ToolTable : BaseTable() {
         internal const val TABLE_NAME = "tools"
         internal val TABLE = Table.forClass<Tool>()
+        val TABLE_META = TABLE.`as`("meta")
 
         const val COLUMN_CODE = "code"
         const val COLUMN_TYPE = "type"
@@ -111,6 +112,7 @@ object Contract : BaseContract() {
         val FIELD_META_TOOL = TABLE.field(COLUMN_META_TOOL)
         val FIELD_ADDED = TABLE.field(COLUMN_ADDED)
         val FIELD_HIDDEN = TABLE.field(COLUMN_HIDDEN)
+        val FIELD_SPOTLIGHT = TABLE.field(COLUMN_SPOTLIGHT)
         private val FIELD_PENDING_SHARES = TABLE.field(COLUMN_PENDING_SHARES)
 
         internal val PROJECTION_ALL = arrayOf(
@@ -156,6 +158,9 @@ object Contract : BaseContract() {
         private const val SQL_COLUMN_HIDDEN = "$COLUMN_HIDDEN INTEGER"
         private const val SQL_COLUMN_SPOTLIGHT = "$COLUMN_SPOTLIGHT INTEGER"
         private val SQL_PRIMARY_KEY = uniqueIndex(COLUMN_CODE)
+
+        val SQL_JOIN_METATOOL =
+            TABLE.join(TABLE_META).on(TABLE_META.field(COLUMN_CODE).eq(TABLE.field(COLUMN_META_TOOL)))
 
         internal val SQL_WHERE_PRIMARY_KEY = FIELD_CODE.eq(bind())
         val SQL_WHERE_HAS_PENDING_SHARES = FIELD_PENDING_SHARES.gt(0)


### PR DESCRIPTION
- update all tools queries to filter based on meta-tools
- add a couple unit tests around `QUERY_TOOLS` behavior
- add a unit test to ensure spotlight tools can include non-default variants
