### PR TITLE
cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,7 +77,6 @@ android {
         val debug by getting {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
-            multiDexEnabled = true
 
             isMinifyEnabled = false
             isShrinkResources = false

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,6 @@
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 buildscript {
-    ext {
-        uris = [
-                mobileContentApi: [
-                        stage     : "https://mobile-content-api-stage.cru.org/",
-                        production: "https://mobile-content-api.cru.org/"
-                ]
-        ]
-    }
-
     repositories {
         google()
         mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ gtoSupport-androidx-databinding = { module = "org.ccci.gto.android:gto-support-a
 gtoSupport-androidx-drawerlayout = { module = "org.ccci.gto.android:gto-support-androidx-drawerlayout", version.ref = "gtoSupport" }
 gtoSupport-androidx-fragment = { module = "org.ccci.gto.android:gto-support-androidx-fragment", version.ref = "gtoSupport" }
 gtoSupport-androidx-lifecycle = { module = "org.ccci.gto.android:gto-support-androidx-lifecycle", version.ref = "gtoSupport" }
-gtoSupport-androidx-recyclerview = { module = "org.ccci.gto.android:gto-support-androidx-recyclerview", version.ref = "gtoSupport"}
+gtoSupport-androidx-recyclerview = { module = "org.ccci.gto.android:gto-support-androidx-recyclerview", version.ref = "gtoSupport" }
 gtoSupport-androidx-room = { module = "org.ccci.gto.android:gto-support-androidx-room", version.ref = "gtoSupport" }
 gtoSupport-androidx-viewpager2 = { module = "org.ccci.gto.android:gto-support-androidx-viewpager2", version.ref = "gtoSupport" }
 gtoSupport-androidx-work = { module = "org.ccci.gto.android:gto-support-androidx-work", version.ref = "gtoSupport" }

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/ModalActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/ModalActivity.kt
@@ -1,12 +1,12 @@
 package org.cru.godtools.tract.activity
 
 import android.app.Activity
+import android.app.ActivityOptions
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.MainThread
 import androidx.appcompat.widget.Toolbar
-import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,7 +42,7 @@ internal fun Activity.startModalActivity(modal: Modal) = startActivity(
             putString(EXTRA_MODAL, modal.id)
         }
     ),
-    ActivityOptionsCompat.makeCustomAnimation(
+    ActivityOptions.makeCustomAnimation(
         this,
         org.cru.godtools.base.ui.R.anim.activity_fade_in,
         org.cru.godtools.base.ui.R.anim.activity_fade_out


### PR DESCRIPTION
- the api urls defined here are no longer used
- there is no need to use ActivityOptionsCompat for the ModalActivity
- we no longer need to manually specify multiDex
- minor style tweak
