### PR TITLE
GT-1588 Add analytics events to shareables

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentEventAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentEventAnalyticsActionEvent.kt
@@ -1,18 +1,13 @@
 package org.cru.godtools.base.tool.analytics.model
 
-import android.os.Bundle
-import org.cru.godtools.analytics.model.AnalyticsActionEvent
+import androidx.core.os.bundleOf
 import org.cru.godtools.base.tool.model.Event
 
 private const val ACTION_CONTENT_EVENT = "content_event"
 private const val PARAM_EVENT_ID = "event_id"
 
 internal class ContentEventAnalyticsActionEvent(private val event: Event) :
-    AnalyticsActionEvent(ACTION_CONTENT_EVENT, locale = event.locale) {
+    ToolAnalyticsActionEvent(event.tool, ACTION_CONTENT_EVENT, locale = event.locale) {
 
-    override val appSection get() = event.tool
-
-    override val firebaseParams get() = Bundle().apply {
-        putString(PARAM_EVENT_ID, event.id.toString())
-    }
+    override val firebaseParams get() = bundleOf(PARAM_EVENT_ID to event.id.toString())
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ShareShareableAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ShareShareableAnalyticsActionEvent.kt
@@ -1,0 +1,12 @@
+package org.cru.godtools.base.tool.analytics.model
+
+import androidx.core.os.bundleOf
+import org.cru.godtools.tool.model.shareable.Shareable
+
+private const val ACTION_SHARE_SHAREABLE = "share_shareable"
+private const val PARAM_SHAREABLE_ID = "cru_shareable_id"
+
+class ShareShareableAnalyticsActionEvent(private val shareable: Shareable) :
+    ToolAnalyticsActionEvent(shareable.manifest.code, ACTION_SHARE_SHAREABLE, locale = shareable.manifest.locale) {
+    override val firebaseParams get() = bundleOf(PARAM_SHAREABLE_ID to shareable.id)
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsActionEvent.kt
@@ -1,0 +1,14 @@
+package org.cru.godtools.base.tool.analytics.model
+
+import java.util.Locale
+import org.cru.godtools.analytics.model.AnalyticsActionEvent
+import org.cru.godtools.analytics.model.AnalyticsSystem
+
+open class ToolAnalyticsActionEvent(
+    private val tool: String?,
+    action: String,
+    locale: Locale? = null,
+    systems: Collection<AnalyticsSystem> = DEFAULT_SYSTEMS
+) : AnalyticsActionEvent(action, locale = locale, systems = systems) {
+    override val appSection get() = tool
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolOpenedAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolOpenedAnalyticsActionEvent.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.base.tool.analytics.model
 
-import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.tool.model.Manifest
 
@@ -10,7 +9,7 @@ class ToolOpenedAnalyticsActionEvent(
     tool: String,
     private val type: Manifest.Type? = null,
     first: Boolean = false
-) : AnalyticsActionEvent(action = if (first) "first-tool-opened" else "tool-opened") {
+) : ToolAnalyticsActionEvent(tool, action = if (first) "first-tool-opened" else "tool-opened") {
     override fun isForSystem(system: AnalyticsSystem) = when (system) {
         AnalyticsSystem.APPSFLYER -> type in setOf(Manifest.Type.ARTICLE, Manifest.Type.CYOA, Manifest.Type.TRACT)
         AnalyticsSystem.USER -> true

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/shareable/ShareableImageBottomSheetDialogFragment.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/shareable/ShareableImageBottomSheetDialogFragment.kt
@@ -9,8 +9,10 @@ import javax.inject.Inject
 import org.ccci.gto.android.common.material.bottomsheet.BindingBottomSheetDialogFragment
 import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.base.tool.R
+import org.cru.godtools.base.tool.analytics.model.ShareShareableAnalyticsActionEvent
 import org.cru.godtools.base.tool.databinding.ToolShareableImageSheetBinding
 import org.cru.godtools.base.tool.model.shareable.buildShareIntent
+import org.greenrobot.eventbus.EventBus
 import splitties.fragmentargs.arg
 
 @AndroidEntryPoint
@@ -44,11 +46,15 @@ class ShareableImageBottomSheetDialogFragment() :
     // endregion Lifecycle
 
     @Inject
+    internal lateinit var eventBus: EventBus
+    @Inject
     internal lateinit var toolFileSystem: ToolFileSystem
 
     private fun shareShareable() {
         val context = context ?: return
-        val intent = dataModel.shareable.value?.buildShareIntent(context) ?: return
+        val shareable = dataModel.shareable.value ?: return
+        val intent = shareable.buildShareIntent(context) ?: return
+        eventBus.post(ShareShareableAnalyticsActionEvent(shareable))
         startActivity(Intent.createChooser(intent, null))
         dismissAllowingStateLoss()
     }

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonFeedbackAnalyticsEvent.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonFeedbackAnalyticsEvent.kt
@@ -2,13 +2,13 @@ package org.cru.godtools.tool.lesson.analytics.model
 
 import android.os.Bundle
 import java.util.Locale
-import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
+import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsActionEvent
 
 private const val ACTION_LESSON_FEEDBACK = "lesson_feedback"
 
-internal class LessonFeedbackAnalyticsEvent(lesson: String, locale: Locale, private val args: Bundle) :
-    AnalyticsActionEvent(ACTION_LESSON_FEEDBACK, locale = locale, systems = setOf(AnalyticsSystem.FIREBASE)) {
+internal class LessonFeedbackAnalyticsEvent(tool: String, locale: Locale, private val args: Bundle) :
+    ToolAnalyticsActionEvent(tool, ACTION_LESSON_FEEDBACK, locale = locale, systems = setOf(AnalyticsSystem.FIREBASE)) {
     companion object {
         const val PARAM_HELPFUL = "helpful"
         const val PARAM_READINESS = "readiness"
@@ -17,8 +17,6 @@ internal class LessonFeedbackAnalyticsEvent(lesson: String, locale: Locale, priv
         const val VALUE_HELPFUL_YES = "yes"
         const val VALUE_HELPFUL_NO = "no"
     }
-
-    override val appSection = lesson
 
     override val firebaseParams get() = Bundle().apply { putAll(args) }
 }


### PR DESCRIPTION
- introduce an intermediary ToolAnalyticsActionEvent that will handle common metadata for tool action events
- trigger analytics event for sharing a shareable
