### PR TITLE
cleanup

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -87,6 +87,7 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
 
     // add our base compose dependencies
     project.dependencies.addProvider("implementation", project.libs.findBundle("androidx-compose").get())
+    project.dependencies.addProvider("debugImplementation", project.libs.findBundle("androidx-compose-debug").get())
 }
 
 private fun TestedExtension.configureTestOptions() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ androidx-compose-material3 = "androidx.compose.material3:material3:1.0.0-alpha13
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-compose" }
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.4"
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
@@ -175,7 +176,8 @@ weakdelegate = "com.github.Karumi:WeakDelegate:1.0.1"
 youtubePlayer = "com.pierfrancescosoffritti.androidyoutubeplayer:core:11.0.1"
 
 [bundles]
-androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling"]
+androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling-preview"]
+androidx-compose-debug = ["androidx-compose-ui-tooling"]
 
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
@@ -1,5 +1,3 @@
-@file:JvmName("LocaleTypefaceUtils")
-
 package org.cru.godtools.base.ui.util
 
 import android.content.Context


### PR DESCRIPTION
- remove unnecessary JvmName annotation
- Only include preview ui tooling in release builds, but leave rest of ui tooling in debug builds
