### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolsAdapterViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolsAdapterViewModel.kt
@@ -34,6 +34,13 @@ class ToolsAdapterViewModel @Inject constructor(
     private val toolViewModels = mutableMapOf<String, ToolViewModel>()
     fun getToolViewModel(tool: String) = toolViewModels.getOrPut(tool) { ToolViewModel(tool) }
 
+    val primaryLanguage = settings.primaryLanguageFlow
+        .flatMapLatest { dao.findAsFlow<Language>(it) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+    val parallelLanguage = settings.parallelLanguageFlow
+        .flatMapLatest { it?.let { dao.findAsFlow<Language>(it) } ?: flowOf(null) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+
     inner class ToolViewModel(val code: String) {
         val tool = dao.findAsFlow<Tool>(code)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
@@ -62,12 +69,8 @@ class ToolsAdapterViewModel @Inject constructor(
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
-        val primaryLanguage = settings.primaryLanguageFlow
-            .flatMapLatest { dao.findAsFlow<Language>(it) }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
-        val parallelLanguage = settings.parallelLanguageFlow
-            .flatMapLatest { it?.let { dao.findAsFlow<Language>(it) } ?: flowOf(null) }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+        val primaryLanguage get() = this@ToolsAdapterViewModel.primaryLanguage
+        val parallelLanguage get() = this@ToolsAdapterViewModel.parallelLanguage
 
         val firstTranslation = combine(primaryTranslation, defaultTranslation) { p, d -> p ?: d }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
+import androidx.annotation.DeprecatedSinceApi
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.core.content.res.ResourcesCompat
@@ -33,8 +34,10 @@ private val typefaces = buildMap {
 private val FONT_SINHALA = FontFamily(Font(R.font.noto_sans_sinhala_regular))
 private val FONT_TIBETAN = FontFamily(Font(R.font.noto_sans_tibetan_regular))
 
+@DeprecatedSinceApi(Build.VERSION_CODES.M)
 fun Context.getTypeface(locale: Locale?) = typefaces[locale]?.let { ResourcesCompat.getFont(this, it) }
 
+@DeprecatedSinceApi(Build.VERSION_CODES.M)
 fun CharSequence.applyTypefaceSpan(typeface: Typeface?) = when {
     typeface == null -> this
     length == 0 -> this
@@ -45,6 +48,7 @@ fun CharSequence.applyTypefaceSpan(typeface: Typeface?) = when {
     }
 }
 
+@DeprecatedSinceApi(Build.VERSION_CODES.M)
 internal fun Locale.getFontFamilyOrNull() = sequenceOf(this).includeFallbacks()
     .mapNotNull {
         when (it) {

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
@@ -3,6 +3,8 @@
 package org.cru.godtools.base.ui.util
 
 import android.content.Context
+import android.os.Build
+import androidx.annotation.DeprecatedSinceApi
 import java.util.Locale
 import org.ccci.gto.android.common.util.content.localize
 import org.cru.godtools.model.Tool
@@ -20,6 +22,7 @@ fun Translation?.getDescription(tool: Tool?, context: Context?) =
 fun Translation?.getTagline(tool: Tool?, context: Context?) =
     this?.let { (tagline ?: description)?.applyTypefaceSpan(getTypeface(context)) } ?: tool?.description ?: ""
 
+@DeprecatedSinceApi(Build.VERSION_CODES.M)
 fun Translation.getFontFamilyOrNull() = languageCode.getFontFamilyOrNull()
 
 private fun Translation.getTypeface(context: Context?) = context?.getTypeface(languageCode)

--- a/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageSetTest.kt
+++ b/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageSetTest.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.tutorial
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.Locale
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
@@ -10,9 +9,7 @@ import org.hamcrest.Matchers.not
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class PageSetTest {
     @Test
     fun testTrainingSupportedLanguages() {

--- a/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageTest.kt
+++ b/ui/tutorial-renderer/src/test/java/org/cru/godtools/tutorial/PageTest.kt
@@ -1,13 +1,10 @@
 package org.cru.godtools.tutorial
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.Locale
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class PageTest {
     @Test
     fun testSupportsLocaleOnboarding() {


### PR DESCRIPTION
- share the same primaryLanguage and parallelLanguage StateFlow
- mark several of our custom font methods as deprecated since Marshmallow
- PageSetTest does not need to use Robolectric
- PageTest does not require robolectric
