### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Run Lint Checks
         uses: gradle/gradle-build-action@v2
         with:
-          cache-read-only: false
-#          cache-read-only: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/heads/feature/') }}
           arguments: lint --scan
       - name: Archive lint results
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 android {
     baseConfiguration(project)
-    configureCompose(project, enableTesting = true)
+    configureCompose(project)
 
     defaultConfig {
         applicationId = "org.keynote.godtools.android"

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
@@ -9,19 +9,19 @@ import org.ccci.gto.android.common.androidx.fragment.app.findListener
 import org.cru.godtools.R
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.base.ui.fragment.BaseFragment
-import org.cru.godtools.databinding.DashboardHomeFragmentBinding
+import org.cru.godtools.databinding.ComposeLayoutBinding
 import org.cru.godtools.ui.dashboard.DashboardActivity
 import org.cru.godtools.ui.tools.ToolsAdapterCallbacks
 
 @AndroidEntryPoint
-class HomeFragment : BaseFragment<DashboardHomeFragmentBinding>(R.layout.dashboard_home_fragment) {
+class HomeFragment : BaseFragment<ComposeLayoutBinding>(R.layout.compose_layout) {
     override fun onCreateBinding(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?) =
-        DashboardHomeFragmentBinding.inflate(inflater, container, false)
+        ComposeLayoutBinding.inflate(inflater, container, false)
 
     @CallSuper
-    override fun onBindingCreated(binding: DashboardHomeFragmentBinding, savedInstanceState: Bundle?) {
+    override fun onBindingCreated(binding: ComposeLayoutBinding, savedInstanceState: Bundle?) {
         super.onBindingCreated(binding, savedInstanceState)
-        binding.frame.setContent {
+        binding.compose.setContent {
             HomeLayout(
                 onOpenTool = { tool, tr1, tr2 -> findListener<ToolsAdapterCallbacks>()?.openTool(tool, tr1, tr2) },
                 onOpenToolDetails = { findListener<ToolsAdapterCallbacks>()?.showToolDetails(it) },

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -104,7 +104,7 @@ internal fun HomeLayout(
                 if (hasFavoriteTools) {
                     item("favorites", "favorites") {
                         FavoriteTools(
-                            { favoriteTools },
+                            { favoriteTools?.take(3) },
                             modifier = Modifier
                                 .animateItemPlacement()
                                 .fillMaxWidth()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
@@ -31,7 +31,7 @@ class HomeViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
     val favoriteTools = toolsRepository.favoriteTools
-        .map { it.mapNotNull { it.code }.take(3) }
+        .map { it.mapNotNull { it.code } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     // region Sync logic

--- a/app/src/main/res/layout/compose_layout.xml
+++ b/app/src/main/res/layout/compose_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/frame"
+    android:id="@+id/compose"
     android:layout_width="match_parent"
     android:layout_height="match_parent" />

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,8 @@ subprojects {
                 testImplementation libs.robolectric
 
                 // HACK: Fix Manifest merge errors for any classpath that contains the Okta module
-                androidTestImplementation libs.gtoSupport.testing.okta
-                testImplementation libs.gtoSupport.testing.okta
+                androidTestImplementation(testFixtures(libs.gtoSupport.okta))
+                testImplementation(testFixtures(libs.gtoSupport.okta))
             }
         }
     }

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -81,24 +81,16 @@ fun BaseExtension.configureFlavorDimensions() {
 // TODO: provide Project using the new multiple context receivers functionality.
 //       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
 //context(Project)
-fun CommonExtension<*, *, *, *>.configureCompose(project: Project, enableTesting: Boolean = false) {
+fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
     buildFeatures.compose = true
     composeOptions.kotlinCompilerExtensionVersion =
         project.libs.findVersion("androidx-compose-compiler").get().requiredVersion
 
     // add our base compose dependencies
-    project.dependencies.addProvider("implementation", project.libs.findBundle("androidx-compose").get())
-    project.dependencies.addProvider("debugImplementation", project.libs.findBundle("androidx-compose-debug").get())
-
-    if (enableTesting) {
-        project.dependencies.addProvider(
-            "testImplementation",
-            project.libs.findBundle("androidx-compose-testing").get()
-        )
-        project.dependencies.addProvider(
-            "debugImplementation",
-            project.libs.findLibrary("androidx-compose-ui-test-manifest").get()
-        )
+    project.dependencies.apply {
+        addProvider("implementation", project.libs.findBundle("androidx-compose").get())
+        addProvider("debugImplementation", project.libs.findBundle("androidx-compose-debug").get())
+        addProvider("testDebugImplementation", project.libs.findBundle("androidx-compose-testing").get())
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -191,7 +191,7 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
 [bundles]
 androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling-preview"]
-androidx-compose-debug = ["androidx-compose-ui-tooling"]
+androidx-compose-debug = ["androidx-compose-ui-test-manifest", "androidx-compose-ui-tooling"]
 androidx-compose-testing = ["androidx-compose-ui-test"]
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -132,7 +132,6 @@ gtoSupport-scarlet-actioncable = { module = "org.ccci.gto.android:gto-support-sc
 gtoSupport-snowplow = { module = "org.ccci.gto.android:gto-support-snowplow", version.ref = "gtoSupport" }
 gtoSupport-sync = { module = "org.ccci.gto.android:gto-support-sync", version.ref = "gtoSupport" }
 gtoSupport-testing-dagger = { module = "org.ccci.gto.android.testing:gto-support-dagger", version.ref = "gtoSupport" }
-gtoSupport-testing-okta = { module = "org.ccci.gto.android.testing:gto-support-okta", version.ref = "gtoSupport" }
 gtoSupport-testing-picasso = { module = "org.ccci.gto.android.testing:gto-support-picasso", version.ref = "gtoSupport" }
 gtoSupport-testing-timber = { module = "org.ccci.gto.android.testing:gto-support-timber", version.ref = "gtoSupport" }
 gtoSupport-util = { module = "org.ccci.gto.android:gto-support-util", version.ref = "gtoSupport" }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/ToolsRepository.kt
@@ -17,9 +17,9 @@ import org.keynote.godtools.android.db.GodToolsDao
 class ToolsRepository @Inject constructor(private val dao: GodToolsDao) {
     val favoriteTools get() = Query.select<Tool>()
         .where(
-            ToolTable.FIELD_ADDED.eq(true) and
+            ToolTable.FIELD_TYPE.`in`(*constants(Tool.Type.TRACT, Tool.Type.ARTICLE, Tool.Type.CYOA)) and
                 ToolTable.FIELD_HIDDEN.ne(true) and
-                ToolTable.FIELD_TYPE.`in`(*constants(Tool.Type.TRACT, Tool.Type.ARTICLE, Tool.Type.CYOA))
+                ToolTable.FIELD_ADDED.eq(true)
         )
         .orderBy(ToolTable.SQL_ORDER_BY_ORDER)
         .getAsFlow(dao)


### PR DESCRIPTION
- use the default gradle build action cache mode for lint checks
- simplify the compose testing config
- use the testFixtures artifact for gto-support-okta
- move the limit on horizontal favorite cards into the layout itself
