### PR TITLE
enable caching of several DB queries

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
@@ -9,18 +9,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.ccci.gto.android.common.db.Query
-import org.ccci.gto.android.common.db.getAsFlow
 import org.cru.godtools.base.Settings
-import org.cru.godtools.model.Tool
 import org.cru.godtools.sync.GodToolsSyncService
-import org.keynote.godtools.android.db.Contract.ToolTable
-import org.keynote.godtools.android.db.GodToolsDao
+import org.keynote.godtools.android.db.repository.LessonsRepository
 import org.keynote.godtools.android.db.repository.ToolsRepository
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    dao: GodToolsDao,
+    lessonsRepository: LessonsRepository,
     settings: Settings,
     private val syncService: GodToolsSyncService,
     toolsRepository: ToolsRepository
@@ -29,10 +25,7 @@ class HomeViewModel @Inject constructor(
         .map { !it }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
-    val spotlightLessons = Query.select<Tool>()
-        .where(ToolTable.FIELD_TYPE.eq(Tool.Type.LESSON) and ToolTable.FIELD_SPOTLIGHT.eq(true))
-        .orderBy(ToolTable.COLUMN_DEFAULT_ORDER)
-        .getAsFlow(dao)
+    val spotlightLessons = lessonsRepository.spotlightLessons
         .map { it.mapNotNull { it.code } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 

--- a/library/db/build.gradle.kts
+++ b/library/db/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     api(libs.gtoSupport.db.coroutines)
     api(libs.gtoSupport.db.livedata)
     implementation(libs.gtoSupport.androidx.lifecycle)
+    implementation(libs.gtoSupport.base)
     implementation(libs.gtoSupport.util)
 
     implementation(libs.dagger)

--- a/library/db/build.gradle.kts
+++ b/library/db/build.gradle.kts
@@ -12,11 +12,10 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.livedata.ktx)
 
-    implementation(libs.gtoSupport.androidx.lifecycle)
-    implementation(libs.gtoSupport.core)
     api(libs.gtoSupport.db)
     api(libs.gtoSupport.db.coroutines)
     api(libs.gtoSupport.db.livedata)
+    implementation(libs.gtoSupport.androidx.lifecycle)
     implementation(libs.gtoSupport.util)
 
     implementation(libs.dagger)

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/Constants.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/Constants.kt
@@ -1,0 +1,5 @@
+package org.keynote.godtools.android.db.repository
+
+import org.ccci.gto.android.common.base.TimeConstants.MIN_IN_MS
+
+internal const val REPLAY_EXPIRATION = MIN_IN_MS

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LessonsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LessonsRepository.kt
@@ -1,0 +1,24 @@
+package org.keynote.godtools.android.db.repository
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
+import org.ccci.gto.android.common.db.Query
+import org.ccci.gto.android.common.db.getAsFlow
+import org.cru.godtools.model.Tool
+import org.keynote.godtools.android.db.Contract
+import org.keynote.godtools.android.db.GodToolsDao
+
+@Singleton
+class LessonsRepository @Inject constructor(dao: GodToolsDao) {
+    val spotlightLessons = Query.select<Tool>()
+        .where(
+            Contract.ToolTable.FIELD_TYPE.eq(Tool.Type.LESSON) and
+                Contract.ToolTable.FIELD_HIDDEN.ne(true) and
+                Contract.ToolTable.FIELD_SPOTLIGHT.eq(true)
+        )
+        .orderBy(Contract.ToolTable.COLUMN_DEFAULT_ORDER)
+        .getAsFlow(dao)
+        .shareIn(dao.coroutineScope, SharingStarted.WhileSubscribed(replayExpirationMillis = REPLAY_EXPIRATION), 1)
+}

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/ToolsRepository.kt
@@ -4,6 +4,8 @@ import androidx.annotation.AnyThread
 import androidx.annotation.WorkerThread
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.db.Expression.Companion.constants
@@ -15,7 +17,7 @@ import org.keynote.godtools.android.db.GodToolsDao
 
 @Singleton
 class ToolsRepository @Inject constructor(private val dao: GodToolsDao) {
-    val favoriteTools get() = Query.select<Tool>()
+    val favoriteTools = Query.select<Tool>()
         .where(
             ToolTable.FIELD_TYPE.`in`(*constants(Tool.Type.TRACT, Tool.Type.ARTICLE, Tool.Type.CYOA)) and
                 ToolTable.FIELD_HIDDEN.ne(true) and
@@ -23,6 +25,7 @@ class ToolsRepository @Inject constructor(private val dao: GodToolsDao) {
         )
         .orderBy(ToolTable.SQL_ORDER_BY_ORDER)
         .getAsFlow(dao)
+        .shareIn(dao.coroutineScope, SharingStarted.WhileSubscribed(replayExpirationMillis = REPLAY_EXPIRATION), 1)
 
     suspend fun pinTool(code: String) {
         val tool = Tool().also {


### PR DESCRIPTION
- cleanup db dependencies
- use a SharedFlow for favoriteTools
- move spotlightLessons query into LessonsRepository
