### PR TITLE
GT-1529 Adjust the composables for the Home UI

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -29,6 +29,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.drawerlayout.widget.toggleDrawer
+import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.base.Constants.INVALID_LAYOUT_RES
 import org.ccci.gto.android.common.base.Constants.INVALID_STRING_RES
 import org.ccci.gto.android.common.okta.oidc.clients.web.signOut
@@ -224,17 +225,15 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
     private var drawerToggle: ActionBarDrawerToggle? = null
 
     private val showLoginItems by lazy { resources.getBoolean(R.bool.show_login_menu_items) }
-    protected open val isShowNavigationDrawerIndicator get() = false
+    protected open val isShowNavigationDrawerIndicator: LiveData<Boolean> = ImmutableLiveData(false)
 
     private fun setupNavigationDrawer() {
-        drawerLayout?.let {
-            drawerToggle = ActionBarDrawerToggle(this, it, INVALID_STRING_RES, INVALID_STRING_RES)
-                .apply {
-                    isDrawerIndicatorEnabled = isShowNavigationDrawerIndicator
-                    isDrawerSlideAnimationEnabled = false
-                }
+        drawerLayout?.let { layout ->
+            drawerToggle = ActionBarDrawerToggle(this, layout, INVALID_STRING_RES, INVALID_STRING_RES)
+                .apply { isDrawerSlideAnimationEnabled = false }
                 .also { toggle ->
-                    it.addDrawerListener(toggle)
+                    isShowNavigationDrawerIndicator.observe(this) { toggle.isDrawerIndicatorEnabled = it }
+                    layout.addDrawerListener(toggle)
                     toggle.syncState()
                 }
         }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.core.view.GravityCompat
 import androidx.fragment.app.commit
 import androidx.lifecycle.Observer
+import androidx.lifecycle.map
 import com.getkeepsafe.taptargetview.TapTarget
 import com.getkeepsafe.taptargetview.TapTargetView
 import dagger.Lazy
@@ -120,7 +121,9 @@ class DashboardActivity :
     override val drawerLayout get() = binding.drawerLayout
     override val drawerMenu get() = binding.drawerMenu
 
-    override val isShowNavigationDrawerIndicator get() = true
+    override val isShowNavigationDrawerIndicator by lazy {
+        savedState.selectedPageLiveData.map { it != Page.FAVORITE_TOOLS }
+    }
 
     internal fun showPage(page: Page) {
         // short-circuit if the page is already displayed
@@ -289,4 +292,12 @@ class DashboardActivity :
     }
     // endregion Language Settings
     // endregion Feature Discovery
+
+    override fun onSupportNavigateUp() = when {
+        onBackPressedDispatcher.hasEnabledCallbacks() -> {
+            onBackPressedDispatcher.onBackPressed()
+            true
+        }
+        else -> super.onSupportNavigateUp()
+    }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
@@ -8,7 +8,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.findListener
 import org.cru.godtools.R
-import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.base.ui.fragment.BaseFragment
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.databinding.ComposeLayoutBinding
@@ -32,8 +31,7 @@ class HomeFragment : BaseFragment<ComposeLayoutBinding>(R.layout.compose_layout)
                 HomeLayout(
                     onOpenTool = { tool, tr1, tr2 -> findListener<ToolsAdapterCallbacks>()?.openTool(tool, tr1, tr2) },
                     onOpenToolDetails = { findListener<ToolsAdapterCallbacks>()?.showToolDetails(it) },
-                    onViewAllFavorites = { findListener<DashboardActivity>()?.showPage(Page.FAVORITE_TOOLS) },
-                    onViewAllTools = { findListener<DashboardActivity>()?.showPage(Page.ALL_TOOLS) }
+                    onShowDashboardPage = { findListener<DashboardActivity>()?.showPage(it) }
                 )
             }
         }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
@@ -8,10 +8,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.fragment.app.findListener
 import org.cru.godtools.R
-import org.cru.godtools.analytics.firebase.model.ACTION_IAM_HOME
-import org.cru.godtools.analytics.firebase.model.FirebaseIamActionEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_HOME
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.base.ui.fragment.BaseFragment
 import org.cru.godtools.base.ui.theme.GodToolsTheme
@@ -41,15 +37,5 @@ class HomeFragment : BaseFragment<ComposeLayoutBinding>(R.layout.compose_layout)
                 )
             }
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        trackInAnalytics()
-    }
-
-    private fun trackInAnalytics() {
-        eventBus.post(AnalyticsScreenEvent(SCREEN_HOME))
-        eventBus.post(FirebaseIamActionEvent(ACTION_IAM_HOME))
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeFragment.kt
@@ -14,6 +14,7 @@ import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_HOME
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.base.ui.fragment.BaseFragment
+import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.databinding.ComposeLayoutBinding
 import org.cru.godtools.ui.dashboard.DashboardActivity
 import org.cru.godtools.ui.tools.ToolsAdapterCallbacks
@@ -31,12 +32,14 @@ class HomeFragment : BaseFragment<ComposeLayoutBinding>(R.layout.compose_layout)
     override fun onBindingCreated(binding: ComposeLayoutBinding, savedInstanceState: Bundle?) {
         super.onBindingCreated(binding, savedInstanceState)
         binding.compose.setContent {
-            HomeLayout(
-                onOpenTool = { tool, tr1, tr2 -> findListener<ToolsAdapterCallbacks>()?.openTool(tool, tr1, tr2) },
-                onOpenToolDetails = { findListener<ToolsAdapterCallbacks>()?.showToolDetails(it) },
-                onViewAllFavorites = { findListener<DashboardActivity>()?.showPage(Page.FAVORITE_TOOLS) },
-                onViewAllTools = { findListener<DashboardActivity>()?.showPage(Page.ALL_TOOLS) }
-            )
+            GodToolsTheme {
+                HomeLayout(
+                    onOpenTool = { tool, tr1, tr2 -> findListener<ToolsAdapterCallbacks>()?.openTool(tool, tr1, tr2) },
+                    onOpenToolDetails = { findListener<ToolsAdapterCallbacks>()?.showToolDetails(it) },
+                    onViewAllFavorites = { findListener<DashboardActivity>()?.showPage(Page.FAVORITE_TOOLS) },
+                    onViewAllTools = { findListener<DashboardActivity>()?.showPage(Page.ALL_TOOLS) }
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -43,7 +43,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import org.cru.godtools.R
-import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.banner.TutorialFeaturesBanner
@@ -61,7 +60,7 @@ internal fun HomeLayout(
     onOpenToolDetails: (String) -> Unit = {},
     onViewAllFavorites: () -> Unit = {},
     onViewAllTools: () -> Unit = {}
-) = GodToolsTheme {
+) {
     val favoriteTools by viewModel.favoriteTools.collectAsState()
     val spotlightLessons by viewModel.spotlightLessons.collectAsState()
     val favoriteToolsLoaded by remember { derivedStateOf { favoriteTools != null } }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import org.ccci.gto.android.common.androidx.lifecycle.compose.OnResume
 import org.cru.godtools.R
+import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.banner.TutorialFeaturesBanner
@@ -61,6 +63,8 @@ internal fun HomeLayout(
     onViewAllFavorites: () -> Unit = {},
     onViewAllTools: () -> Unit = {}
 ) {
+    OnResume { viewModel.trackPageInAnalytics(Page.HOME) }
+
     val favoriteTools by viewModel.favoriteTools.collectAsState()
     val spotlightLessons by viewModel.spotlightLessons.collectAsState()
     val favoriteToolsLoaded by remember { derivedStateOf { favoriteTools != null } }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -32,7 +32,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -55,13 +58,41 @@ private val PADDING_HORIZONTAL = 16.dp
 
 @Preview(showBackground = true)
 @Composable
-@OptIn(ExperimentalFoundationApi::class)
 internal fun HomeLayout(
     viewModel: HomeViewModel = viewModel(),
     onOpenTool: (Tool?, Translation?, Translation?) -> Unit = { _, _, _ -> },
     onOpenToolDetails: (String) -> Unit = {},
-    onViewAllFavorites: () -> Unit = {},
-    onViewAllTools: () -> Unit = {}
+    onShowDashboardPage: (Page) -> Unit = {},
+) {
+    var currentPage by rememberSaveable { mutableStateOf(Page.HOME) }
+
+    SwipeRefresh(
+        rememberSwipeRefreshState(viewModel.isSyncRunning.collectAsState().value),
+        onRefresh = { viewModel.triggerSync(true) }
+    ) {
+        when (currentPage) {
+            Page.HOME -> {
+                HomeContent(
+                    viewModel,
+                    onOpenTool = onOpenTool,
+                    onOpenToolDetails = onOpenToolDetails,
+                    onViewAllFavorites = { onShowDashboardPage(Page.ALL_TOOLS) },
+                    onViewAllTools = { onShowDashboardPage(Page.ALL_TOOLS) }
+                )
+            }
+            else -> Unit
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+private fun HomeContent(
+    viewModel: HomeViewModel,
+    onOpenTool: (Tool?, Translation?, Translation?) -> Unit,
+    onOpenToolDetails: (String) -> Unit,
+    onViewAllFavorites: () -> Unit,
+    onViewAllTools: () -> Unit
 ) {
     OnResume { viewModel.trackPageInAnalytics(Page.HOME) }
 
@@ -76,85 +107,80 @@ internal fun HomeLayout(
         if (showTutorialFeaturesBanner) columnState.animateScrollToItem(0)
     }
 
-    SwipeRefresh(
-        rememberSwipeRefreshState(viewModel.isSyncRunning.collectAsState().value),
-        onRefresh = { viewModel.triggerSync(true) }
-    ) {
-        LazyColumn(state = columnState, contentPadding = PaddingValues(bottom = 16.dp)) {
-            item("banners", "banners") {
-                Banners(
-                    viewModel,
-                    modifier = Modifier
-                        .animateItemPlacement()
-                        .fillMaxWidth()
-                )
-            }
+    LazyColumn(state = columnState, contentPadding = PaddingValues(bottom = 16.dp)) {
+        item("banners", "banners") {
+            Banners(
+                viewModel,
+                modifier = Modifier
+                    .animateItemPlacement()
+                    .fillMaxWidth()
+            )
+        }
 
-            item("welcome") {
-                WelcomeMessage(
+        item("welcome") {
+            WelcomeMessage(
+                modifier = Modifier
+                    .animateItemPlacement()
+                    .padding(horizontal = PADDING_HORIZONTAL)
+                    .padding(top = 16.dp)
+            )
+        }
+
+        // featured lessons
+        if (spotlightLessons.isNotEmpty()) {
+            item("lesson-header", "lesson-header") {
+                FeaturedLessonsHeader(
                     modifier = Modifier
                         .animateItemPlacement()
                         .padding(horizontal = PADDING_HORIZONTAL)
-                        .padding(top = 16.dp)
+                        .padding(top = 32.dp, bottom = 16.dp)
                 )
             }
 
-            // featured lessons
-            if (spotlightLessons.isNotEmpty()) {
-                item("lesson-header", "lesson-header") {
-                    FeaturedLessonsHeader(
-                        modifier = Modifier
-                            .animateItemPlacement()
-                            .padding(horizontal = PADDING_HORIZONTAL)
-                            .padding(top = 32.dp, bottom = 16.dp)
-                    )
-                }
+            items(spotlightLessons, key = { it }, contentType = { "lesson-tool-card" }) {
+                LessonToolCard(
+                    it,
+                    onClick = { tool, translation -> onOpenTool(tool, translation, null) },
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .padding(horizontal = PADDING_HORIZONTAL)
+                        .padding(bottom = 16.dp)
+                )
+            }
+        }
 
-                items(spotlightLessons, key = { it }, contentType = { "lesson-tool-card" }) {
-                    LessonToolCard(
-                        it,
-                        onClick = { tool, translation -> onOpenTool(tool, translation, null) },
-                        modifier = Modifier
-                            .animateItemPlacement()
-                            .padding(horizontal = PADDING_HORIZONTAL)
-                            .padding(bottom = 16.dp)
-                    )
-                }
+        // favorite tools
+        if (favoriteToolsLoaded) {
+            item("favorites-header") {
+                FavoritesHeader(
+                    showViewAll = { hasFavoriteTools },
+                    onViewAllFavorites = onViewAllFavorites,
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .padding(horizontal = PADDING_HORIZONTAL)
+                        .padding(top = 32.dp, bottom = 16.dp),
+                )
             }
 
-            // favorite tools
-            if (favoriteToolsLoaded) {
-                item("favorites-header") {
-                    FavoritesHeader(
-                        showViewAll = { hasFavoriteTools },
-                        onViewAllFavorites = onViewAllFavorites,
+            if (hasFavoriteTools) {
+                item("favorites", "favorites") {
+                    HorizontalFavoriteTools(
+                        { favoriteTools?.take(3) },
+                        onOpenTool = onOpenTool,
+                        onOpenToolDetails = onOpenToolDetails,
+                        modifier = Modifier
+                            .animateItemPlacement()
+                            .fillMaxWidth()
+                    )
+                }
+            } else {
+                item("favorites-empty", "favorites-empty") {
+                    NoFavoriteTools(
+                        onViewAllTools = onViewAllTools,
                         modifier = Modifier
                             .animateItemPlacement()
                             .padding(horizontal = PADDING_HORIZONTAL)
-                            .padding(top = 32.dp, bottom = 16.dp),
                     )
-                }
-
-                if (hasFavoriteTools) {
-                    item("favorites", "favorites") {
-                        FavoriteTools(
-                            { favoriteTools?.take(3) },
-                            onOpenTool = onOpenTool,
-                            onOpenToolDetails = onOpenToolDetails,
-                            modifier = Modifier
-                                .animateItemPlacement()
-                                .fillMaxWidth()
-                        )
-                    }
-                } else {
-                    item("favorites-empty", "favorites-empty") {
-                        NoFavoriteTools(
-                            onViewAllTools = onViewAllTools,
-                            modifier = Modifier
-                                .animateItemPlacement()
-                                .padding(horizontal = PADDING_HORIZONTAL)
-                        )
-                    }
                 }
             }
         }
@@ -223,7 +249,7 @@ private fun FavoritesHeader(
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
-private fun FavoriteTools(
+private fun HorizontalFavoriteTools(
     tools: () -> List<String>?,
     modifier: Modifier = Modifier,
     onOpenTool: (Tool?, Translation?, Translation?) -> Unit,

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
@@ -10,14 +10,21 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.cru.godtools.analytics.firebase.model.ACTION_IAM_HOME
+import org.cru.godtools.analytics.firebase.model.FirebaseIamActionEvent
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_HOME
 import org.cru.godtools.base.Settings
+import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.sync.GodToolsSyncService
 import org.cru.godtools.tutorial.PageSet
+import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.repository.LessonsRepository
 import org.keynote.godtools.android.db.repository.ToolsRepository
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    private val eventBus: EventBus,
     lessonsRepository: LessonsRepository,
     settings: Settings,
     private val syncService: GodToolsSyncService,
@@ -34,6 +41,16 @@ class HomeViewModel @Inject constructor(
     val favoriteTools = toolsRepository.favoriteTools
         .map { it.mapNotNull { it.code } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+
+    // region Analytics
+    fun trackPageInAnalytics(page: Page) = when (page) {
+        Page.HOME -> {
+            eventBus.post(AnalyticsScreenEvent(SCREEN_HOME))
+            eventBus.post(FirebaseIamActionEvent(ACTION_IAM_HOME))
+        }
+        else -> Unit
+    }
+    // endregion Analytics
 
     // region Sync logic
     private val syncsRunning = MutableStateFlow(0)

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/AvailableInLanguage.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/AvailableInLanguage.kt
@@ -1,0 +1,76 @@
+package org.cru.godtools.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisallowComposableCalls
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.cru.godtools.R
+import org.cru.godtools.model.Language
+import org.cru.godtools.model.Translation
+
+@Composable
+internal inline fun AvailableInLanguage(
+    language: Language?,
+    crossinline translation: @DisallowComposableCalls () -> Translation?,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+) {
+    val available by remember { derivedStateOf { translation() != null } }
+    AvailableInLanguage(
+        language,
+        available = available,
+        horizontalArrangement = horizontalArrangement,
+        modifier = modifier
+    )
+}
+
+@Composable
+internal fun AvailableInLanguage(
+    language: Language?,
+    available: Boolean = true,
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    alpha: Float = 0.6f
+) = Row(
+    horizontalArrangement = horizontalArrangement,
+    modifier = modifier
+        .widthIn(min = 50.dp)
+        .alpha(alpha)
+) {
+    val context = LocalContext.current
+    val languageName = remember(language, context) { language?.getDisplayName(context).orEmpty() }
+
+    Text(
+        if (available) languageName else stringResource(R.string.tool_card_label_language_unavailable, languageName),
+        style = toolCardInfoLabelStyle,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .alignByBaseline()
+            .weight(1f, false)
+    )
+    Icon(
+        painterResource(if (available) R.drawable.ic_language_available else R.drawable.ic_language_unavailable),
+        contentDescription = null,
+        modifier = Modifier
+            .padding(start = 4.dp)
+            .size(with(LocalDensity.current) { (toolCardInfoLabelStyle.fontSize * 0.65).toDp() })
+            .alignBy { it.measuredHeight }
+    )
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/DownloadProgressIndicator.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/DownloadProgressIndicator.kt
@@ -1,0 +1,33 @@
+package org.cru.godtools.ui.tools
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import org.cru.godtools.download.manager.DownloadProgress
+
+// TODO: this can be moved elsewhere when we need to use it outside of tool cards
+@Composable
+internal fun DownloadProgressIndicator(downloadProgress: () -> DownloadProgress?, modifier: Modifier = Modifier) {
+    val hasProgress by remember { derivedStateOf { downloadProgress() != null } }
+    val isIndeterminate by remember { derivedStateOf { downloadProgress()?.isIndeterminate == true } }
+
+    if (hasProgress) {
+        if (isIndeterminate) {
+            LinearProgressIndicator(modifier = modifier)
+        } else {
+            val progress by animateFloatAsState(
+                targetValue = downloadProgress()
+                    ?.takeIf { it.max > 0 }
+                    ?.let { it.progress.toFloat() / it.max }
+                    ?.coerceIn(0f, 1f) ?: 0f,
+                animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+            )
+            LinearProgressIndicator(progress, modifier = modifier)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/FavoriteAction.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/FavoriteAction.kt
@@ -1,0 +1,89 @@
+package org.cru.godtools.ui.tools
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
+import org.cru.godtools.R
+import org.cru.godtools.model.getName
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun FavoriteAction(
+    viewModel: ToolViewModels.ToolViewModel,
+    modifier: Modifier = Modifier,
+    confirmRemoval: Boolean = true
+) {
+    val tool by viewModel.tool.collectAsState()
+    val isAdded by remember { derivedStateOf { tool?.isAdded == true } }
+    var showRemovalConfirmation by rememberSaveable { mutableStateOf(false) }
+
+    Surface(
+        onClick = {
+            when {
+                !isAdded -> viewModel.pinTool()
+                confirmRemoval -> showRemovalConfirmation = true
+                else -> viewModel.unpinTool()
+            }
+        },
+        shape = Shapes.Full,
+        shadowElevation = 6.dp,
+        modifier = modifier
+    ) {
+        Icon(
+            painter = painterResource(if (isAdded) R.drawable.ic_favorite_24dp else R.drawable.ic_favorite_border_24dp),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .padding(top = 6.dp, horizontal = 5.dp, bottom = 4.dp)
+                .size(18.dp)
+        )
+    }
+
+    if (showRemovalConfirmation) {
+        val translation by viewModel.firstTranslation.collectAsState()
+
+        AlertDialog(
+            onDismissRequest = { showRemovalConfirmation = false },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.tools_list_remove_favorite_dialog_title,
+                        translation.getName(tool).orEmpty()
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.unpinTool()
+                        showRemovalConfirmation = false
+                    }
+                ) { Text(stringResource(R.string.tools_list_remove_favorite_dialog_confirm)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRemovalConfirmation = false }) {
+                    Text(stringResource(R.string.tools_list_remove_favorite_dialog_dismiss))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardActions.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardActions.kt
@@ -1,0 +1,71 @@
+package org.cru.godtools.ui.tools
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.cru.godtools.R
+import org.cru.godtools.model.Tool
+import org.cru.godtools.model.Translation
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun ToolCardActions(
+    viewModel: ToolViewModels.ToolViewModel,
+    modifier: Modifier = Modifier,
+    buttonModifier: Modifier = Modifier,
+    buttonWeightFill: Boolean = true,
+    onOpenTool: (Tool?, Translation?, Translation?) -> Unit = { _, _, _ -> },
+    onOpenToolDetails: (String) -> Unit = {},
+) = Row(modifier = modifier) {
+    val tool by viewModel.tool.collectAsState()
+    val firstTranslation by viewModel.firstTranslation.collectAsState()
+    val secondTranslation by viewModel.secondTranslation.collectAsState()
+
+    val buttonContentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
+    val buttonMinHeight = 30.dp
+
+    CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
+        OutlinedButton(
+            onClick = { onOpenToolDetails(viewModel.code) },
+            contentPadding = buttonContentPadding,
+            modifier = buttonModifier
+                .alignByBaseline()
+                .heightIn(min = buttonMinHeight)
+                .weight(1f, buttonWeightFill)
+        ) {
+            Text(
+                stringResource(R.string.action_tools_about),
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        Button(
+            onClick = { onOpenTool(tool, firstTranslation, secondTranslation) },
+            contentPadding = buttonContentPadding,
+            modifier = buttonModifier
+                .alignByBaseline()
+                .heightIn(min = buttonMinHeight)
+                .weight(1f, buttonWeightFill)
+        ) {
+            Text(
+                stringResource(R.string.action_tools_open),
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -113,7 +113,7 @@ fun LessonToolCard(
                     .fillMaxWidth()
                     .padding(16.dp)
             ) {
-                ToolName(viewModel, lines = 2, modifier = Modifier.fillMaxWidth())
+                ToolName(viewModel, minLines = 2, modifier = Modifier.fillMaxWidth())
 
                 val primaryTranslation by viewModel.primaryTranslation.collectAsState()
                 val primaryLanguage by viewModel.primaryLanguage.collectAsState()
@@ -276,7 +276,7 @@ private inline fun ToolName(
 private fun ToolName(
     viewModel: ToolViewModels.ToolViewModel,
     modifier: Modifier = Modifier,
-    minLines: Int = 0,
+    minLines: Int = 1,
     maxLines: Int = Int.MAX_VALUE
 ) {
     val tool by viewModel.tool.collectAsState()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -4,24 +4,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -31,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -39,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import org.ccci.gto.android.common.androidx.compose.foundation.text.minLinesHeight
-import org.cru.godtools.R
 import org.cru.godtools.base.ui.theme.GRAY_E6
 import org.cru.godtools.base.ui.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.base.ui.util.getCategory
@@ -200,40 +191,12 @@ fun SquareToolCard(
                     }
                 }
 
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ToolCardActions(
+                    viewModel,
+                    onOpenTool = onOpenTool,
+                    onOpenToolDetails = onOpenToolDetails,
                     modifier = Modifier.padding(top = 8.dp)
-                ) {
-                    val contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
-                    val minHeight = 30.dp
-
-                    CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
-                        OutlinedButton(
-                            onClick = { onOpenToolDetails(toolCode) },
-                            contentPadding = contentPadding,
-                            modifier = Modifier
-                                .weight(1f)
-                                .defaultMinSize(minHeight = minHeight)
-                        ) {
-                            Text(
-                                stringResource(R.string.action_tools_about),
-                                style = MaterialTheme.typography.labelMedium
-                            )
-                        }
-                        Button(
-                            onClick = { onOpenTool(tool, firstTranslation, secondTranslation) },
-                            contentPadding = contentPadding,
-                            modifier = Modifier
-                                .weight(1f)
-                                .defaultMinSize(minHeight = minHeight)
-                        ) {
-                            Text(
-                                stringResource(R.string.action_tools_open),
-                                style = MaterialTheme.typography.labelMedium
-                            )
-                        }
-                    }
-                }
+                )
             }
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -1,7 +1,5 @@
 package org.cru.godtools.ui.tools
 
-import android.text.TextUtils
-import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -48,20 +46,18 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
-import java.util.Locale
 import org.ccci.gto.android.common.androidx.compose.foundation.text.minLinesHeight
 import org.cru.godtools.R
 import org.cru.godtools.base.ui.theme.GRAY_E6
+import org.cru.godtools.base.ui.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.base.ui.util.getCategory
 import org.cru.godtools.base.ui.util.getFontFamilyOrNull
 import org.cru.godtools.download.manager.DownloadProgress
@@ -259,28 +255,6 @@ fun SquareToolCard(
             }
         }
     }
-}
-
-// TODO: Should this be moved to somewhere that is more re-usable?
-@Composable
-private fun ProvideLayoutDirectionFromLocale(locale: () -> Locale?, content: @Composable () -> Unit) {
-    val currentLayoutDirection = LocalLayoutDirection.current
-    val layoutDirection by remember {
-        derivedStateOf {
-            locale()?.let {
-                when (TextUtils.getLayoutDirectionFromLocale(it)) {
-                    View.LAYOUT_DIRECTION_RTL -> LayoutDirection.Rtl
-                    View.LAYOUT_DIRECTION_LTR -> LayoutDirection.Ltr
-                    else -> null
-                }
-            } ?: currentLayoutDirection
-        }
-    }
-
-    CompositionLocalProvider(
-        LocalLayoutDirection provides layoutDirection,
-        content = content
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -45,7 +44,6 @@ import org.cru.godtools.base.ui.theme.GRAY_E6
 import org.cru.godtools.base.ui.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.base.ui.util.getCategory
 import org.cru.godtools.base.ui.util.getFontFamilyOrNull
-import org.cru.godtools.download.manager.DownloadProgress
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.getName
@@ -129,7 +127,7 @@ fun SquareToolCard(
     val secondTranslation by viewModel.secondTranslation.collectAsState()
     val secondLanguage by viewModel.secondLanguage.collectAsState()
     val parallelLanguage by viewModel.parallelLanguage.collectAsState()
-    val downloadProgress = viewModel.downloadProgress.collectAsState()
+    val downloadProgress by viewModel.downloadProgress.collectAsState()
 
     ProvideLayoutDirectionFromLocale(locale = { firstTranslation?.languageCode }) {
         ElevatedCard(
@@ -150,7 +148,7 @@ fun SquareToolCard(
                     modifier = Modifier.align(Alignment.TopEnd)
                 )
                 DownloadProgressIndicator(
-                    downloadProgress,
+                    { downloadProgress },
                     modifier = Modifier
                         .fillMaxWidth()
                         .align(Alignment.BottomCenter)
@@ -290,28 +288,4 @@ private fun ToolCategory(viewModel: ToolViewModels.ToolViewModel, modifier: Modi
         maxLines = 1,
         modifier = modifier
     )
-}
-
-// TODO: this can be refactored & moved elsewhere when we need to use it outside of tool cards
-@Composable
-private fun DownloadProgressIndicator(downloadProgress: State<DownloadProgress?>, modifier: Modifier = Modifier) {
-    val hasProgress by remember { derivedStateOf { downloadProgress.value != null } }
-    val isIndeterminate by remember { derivedStateOf { downloadProgress.value?.isIndeterminate == true } }
-    val progress by remember {
-        derivedStateOf {
-            downloadProgress.value
-                ?.takeIf { it.max > 0 }
-                ?.let { it.progress.toFloat() / it.max }
-                ?.coerceIn(0f, 1f) ?: 0f
-        }
-    }
-
-    if (hasProgress) {
-        if (isIndeterminate) {
-            LinearProgressIndicator(modifier = modifier)
-        } else {
-            // TODO: figure out how to animate progress updates to make a more smooth UI
-            LinearProgressIndicator(progress, modifier = modifier)
-        }
-    }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.ui.tools
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,37 +11,27 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Shapes
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -324,70 +313,5 @@ private fun DownloadProgressIndicator(downloadProgress: State<DownloadProgress?>
             // TODO: figure out how to animate progress updates to make a more smooth UI
             LinearProgressIndicator(progress, modifier = modifier)
         }
-    }
-}
-
-@Composable
-@VisibleForTesting
-@OptIn(ExperimentalMaterial3Api::class)
-internal fun FavoriteAction(
-    viewModel: ToolViewModels.ToolViewModel,
-    modifier: Modifier = Modifier,
-    confirmRemoval: Boolean = true
-) {
-    val tool by viewModel.tool.collectAsState()
-    val isAdded by remember { derivedStateOf { tool?.isAdded == true } }
-    var showRemovalConfirmation by rememberSaveable { mutableStateOf(false) }
-
-    Surface(
-        onClick = {
-            when {
-                !isAdded -> viewModel.pinTool()
-                confirmRemoval -> showRemovalConfirmation = true
-                else -> viewModel.unpinTool()
-            }
-        },
-        shape = Shapes.Full,
-        shadowElevation = 6.dp,
-        modifier = modifier
-    ) {
-        Icon(
-            painter = painterResource(if (isAdded) R.drawable.ic_favorite_24dp else R.drawable.ic_favorite_border_24dp),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier
-                .padding(horizontal = 5.dp)
-                .padding(top = 6.dp, bottom = 4.dp)
-                .size(18.dp)
-        )
-    }
-
-    if (showRemovalConfirmation) {
-        val translation by viewModel.firstTranslation.collectAsState()
-
-        AlertDialog(
-            onDismissRequest = { showRemovalConfirmation = false },
-            text = {
-                Text(
-                    stringResource(
-                        R.string.tools_list_remove_favorite_dialog_title,
-                        translation.getName(tool).orEmpty()
-                    )
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        viewModel.unpinTool()
-                        showRemovalConfirmation = false
-                    }
-                ) { Text(stringResource(R.string.tools_list_remove_favorite_dialog_confirm)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showRemovalConfirmation = false }) {
-                    Text(stringResource(R.string.tools_list_remove_favorite_dialog_dismiss))
-                }
-            }
-        )
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
@@ -31,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -42,10 +40,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -61,7 +57,6 @@ import org.cru.godtools.base.ui.util.ProvideLayoutDirectionFromLocale
 import org.cru.godtools.base.ui.util.getCategory
 import org.cru.godtools.base.ui.util.getFontFamilyOrNull
 import org.cru.godtools.download.manager.DownloadProgress
-import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.getName
@@ -87,7 +82,7 @@ private fun toolNameStyle(viewModel: ToolViewModels.ToolViewModel): State<TextSt
     }
 }
 private val toolCategoryStyle @Composable get() = MaterialTheme.typography.bodySmall
-private val infoLabelStyle @Composable get() = MaterialTheme.typography.labelSmall
+internal val toolCardInfoLabelStyle @Composable get() = MaterialTheme.typography.labelSmall
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -194,7 +189,7 @@ fun SquareToolCard(
                                 Spacer(
                                     modifier = Modifier
                                         .padding(top = 2.dp)
-                                        .minLinesHeight(1, infoLabelStyle)
+                                        .minLinesHeight(1, toolCardInfoLabelStyle)
                                 )
                             }
                         }
@@ -212,7 +207,7 @@ fun SquareToolCard(
                             Spacer(
                                 modifier = Modifier
                                     .padding(top = 2.dp)
-                                    .minLinesHeight(1, infoLabelStyle)
+                                    .minLinesHeight(1, toolCardInfoLabelStyle)
                             )
                         }
                     }
@@ -395,55 +390,4 @@ internal fun FavoriteAction(
             }
         )
     }
-}
-
-@Composable
-private inline fun AvailableInLanguage(
-    language: Language?,
-    crossinline translation: @DisallowComposableCalls () -> Translation?,
-    modifier: Modifier = Modifier,
-    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
-) {
-    val available by remember { derivedStateOf { translation() != null } }
-    AvailableInLanguage(
-        language,
-        available = available,
-        horizontalArrangement = horizontalArrangement,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun AvailableInLanguage(
-    language: Language?,
-    available: Boolean = true,
-    modifier: Modifier = Modifier,
-    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
-    alpha: Float = 0.6f
-) = Row(
-    horizontalArrangement = horizontalArrangement,
-    modifier = modifier
-        .widthIn(min = 50.dp)
-        .alpha(alpha)
-) {
-    val context = LocalContext.current
-    val languageName = remember(language, context) { language?.getDisplayName(context).orEmpty() }
-
-    Text(
-        if (available) languageName else stringResource(R.string.tool_card_label_language_unavailable, languageName),
-        style = infoLabelStyle,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        modifier = Modifier
-            .alignByBaseline()
-            .weight(1f, false)
-    )
-    Icon(
-        painterResource(if (available) R.drawable.ic_language_available else R.drawable.ic_language_unavailable),
-        contentDescription = null,
-        modifier = Modifier
-            .padding(start = 4.dp)
-            .size(with(LocalDensity.current) { (infoLabelStyle.fontSize * 0.65).toDp() })
-            .alignBy { it.measuredHeight }
-    )
 }

--- a/app/src/main/res/drawable/ic_language_available.xml
+++ b/app/src/main/res/drawable/ic_language_available.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="8dp"
     android:height="8dp"
-    android:viewportWidth="9"
-    android:viewportHeight="9">
+    android:viewportWidth="8"
+    android:viewportHeight="8">
     <path
-        android:pathData="M1,5L3,7L8,2"
+        android:pathData="M0.5,4.5L2.5,6.5L7.5,1.5"
         android:strokeWidth="1"
         android:strokeColor="@color/tintable" />
 </vector>

--- a/app/src/main/res/drawable/ic_language_unavailable.xml
+++ b/app/src/main/res/drawable/ic_language_unavailable.xml
@@ -4,7 +4,7 @@
     android:viewportWidth="8"
     android:viewportHeight="8">
     <path
-        android:pathData="M1.5,6.5L6.5,1.5M6.5,6.5L1.5,1.5"
+        android:pathData="M0.5,7.5L7.5,0.5M7.5,7.5L0.5,0.5"
         android:strokeWidth="1"
         android:strokeColor="@color/tintable" />
 </vector>

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/tools/FavoriteActionTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/tools/FavoriteActionTest.kt
@@ -28,7 +28,7 @@ import org.robolectric.annotation.Config
 @RunWith(AndroidJUnit4::class)
 @Category(AndroidJUnit4::class)
 @Config(application = Application::class)
-class ToolCardLayoutsTest {
+class FavoriteActionTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ProvideLayoutDirectionFromLocale.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ProvideLayoutDirectionFromLocale.kt
@@ -1,0 +1,34 @@
+package org.cru.godtools.base.ui.util
+
+import android.text.TextUtils
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import java.util.Locale
+
+// TODO: Should this be moved to gto-support?
+@Composable
+fun ProvideLayoutDirectionFromLocale(locale: () -> Locale?, content: @Composable () -> Unit) {
+    val currentLayoutDirection = LocalLayoutDirection.current
+    val layoutDirection by remember {
+        derivedStateOf {
+            locale()?.let {
+                when (TextUtils.getLayoutDirectionFromLocale(it)) {
+                    View.LAYOUT_DIRECTION_RTL -> LayoutDirection.Rtl
+                    View.LAYOUT_DIRECTION_LTR -> LayoutDirection.Ltr
+                    else -> null
+                }
+            } ?: currentLayoutDirection
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalLayoutDirection provides layoutDirection,
+        content = content
+    )
+}


### PR DESCRIPTION
- apply the Theme in the Fragment, not in the HomeLayout
- update AvailableInLanguage Composable to fit better in multiple different layouts
- move ProvideLayoutDirectionFromLocale to :ui:base module
- trigger analytics events from within the HomeLayout
- allow lesson names to overflow 2 lines if necessary for a language or acccessibility settings
- move AvailableInLanguage Composable to it's own source file
- move FavoriteAction composable to it's own source file
- animate the download progress indicator
- display an up affordance when the user is on the list of favorites
- create a ToolCardActions composable that renders the open and tool details buttons
