### PR TITLE
GT-1677 GT-1649 Fix several code shrinking related crashes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,9 @@ android {
             applicationIdSuffix = ".qa"
             versionNameSuffix = "-qa"
 
+            isMinifyEnabled = true
+            isShrinkResources = false
+
             manifestPlaceholders += mapOf(
                 "appAuthRedirectScheme" to "org.cru.godtools.qa.okta",
                 "hostGodtoolsCustomUri" to "org.cru.godtools.qa"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,6 @@ android {
             versionNameSuffix = "-debug"
 
             isMinifyEnabled = false
-            isShrinkResources = false
 
             manifestPlaceholders += mapOf(
                 "appAuthRedirectScheme" to "org.cru.godtools.debug.okta",
@@ -99,7 +98,6 @@ android {
             versionNameSuffix = "-qa"
 
             isMinifyEnabled = true
-            isShrinkResources = false
 
             manifestPlaceholders += mapOf(
                 "appAuthRedirectScheme" to "org.cru.godtools.qa.okta",
@@ -125,8 +123,8 @@ android {
         }
         val release by existing {
             isMinifyEnabled = true
-            isShrinkResources = true
-            signingConfigs.getByName("release").takeIf { it.storeFile?.exists() == true }
+            signingConfigs.getByName("release")
+                .takeIf { it.storeFile?.exists() == true }
                 ?.let { signingConfig = it }
 
             manifestPlaceholders += mapOf(

--- a/library/base/src/main/kotlin/org/cru/godtools/base/util/LocaleUtils.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/util/LocaleUtils.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.ConfigurationCompat
 import java.util.Locale
-import org.ccci.gto.android.common.util.content.localize
+import org.ccci.gto.android.common.util.content.localizeIfPossible
 import org.ccci.gto.android.common.util.getOptionalDisplayName
 import timber.log.Timber
 
@@ -31,8 +31,6 @@ fun Locale.getDisplayName(context: Context? = null, defaultName: String? = null,
             if (inLocale != null) getDisplayName(inLocale) else displayName
         }
 }
-
-fun Context.localizeIfPossible(locale: Locale?) = locale?.let { localize(it) } ?: this
 
 private fun Context.getLanguageNameStringRes(locale: Locale) =
     when (val stringId = resources.getIdentifier(locale.languageNameStringRes, "string", packageName)) {

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.DeprecatedSinceApi
 import java.util.Locale
-import org.cru.godtools.base.util.localizeIfPossible
+import org.ccci.gto.android.common.util.content.localizeIfPossible
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -122,7 +122,7 @@ class TractActivity :
 
     override fun onOptionsItemSelected(item: MenuItem) = when {
         item.itemId == R.id.action_install -> {
-            InstantApps.showInstallPrompt(this, -1, "instantapp")
+            InstantApps.showInstallPrompt(this, intent, -1, "instantapp")
             true
         }
         item.itemId == R.id.action_settings -> {


### PR DESCRIPTION
- enable minification for QA builds
- disable Facebook Flipper on Android Lollipop
- disable resource shrinking
- we no longer need to enable support vector drawables due to not supporting Android pre-Lollipop
- use the newer method for installing from the instant app
- utilize localizeIfPossible method from gto-support
- stop using deprecated LocaleUtils.getFallbacks
- use release build of gto-support library
