### PR TITLE
cleanup

### DIFF
--- a/app/src/debug/kotlin/org/cru/godtools/dagger/FlipperModule.kt
+++ b/app/src/debug/kotlin/org/cru/godtools/dagger/FlipperModule.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.dagger
 
 import android.content.Context
+import android.os.Build
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.android.utils.FlipperUtils
 import com.facebook.flipper.core.FlipperClient
@@ -46,6 +47,10 @@ abstract class FlipperModule {
             @ApplicationContext context: Context,
             plugins: Lazy<Set<@JvmSuppressWildcards FlipperPlugin>>
         ): FlipperClient? {
+            // Flipper doesn't support Android Lollipop anymore
+            // see: https://github.com/facebook/flipper/issues/3572
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return null
+
             if (!FlipperUtils.shouldEnableFlipper(context)) return null
 
             SoLoader.init(context, false)

--- a/app/src/main/kotlin/org/cru/godtools/GodToolsApplication.kt
+++ b/app/src/main/kotlin/org/cru/godtools/GodToolsApplication.kt
@@ -3,7 +3,6 @@ package org.cru.godtools
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.google.android.instantapps.InstantApps
@@ -41,9 +40,6 @@ open class GodToolsApplication : Application(), Configuration.Provider {
         configureLanguageFallbacks()
 
         super.onCreate()
-
-        // enable compat vector images
-        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
     }
 
     override fun attachBaseContext(base: Context) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         maven {
-            setUrl("https://cruglobal.jfrog.io/artifactory/maven-mobile/")
+            url = uri("https://cruglobal.jfrog.io/artifactory/maven-mobile/")
             content {
                 includeGroup("org.ccci.gto.android")
                 includeGroup("org.ccci.gto.android.testing")
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
             }
         }
         maven {
-            setUrl("https://jitpack.io")
+            url = uri("https://jitpack.io")
             content {
                 includeGroupByRegex("com\\.github\\..*")
                 excludeGroup("com.github.ajalt.colormath")

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -23,7 +23,7 @@ import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
-import org.ccci.gto.android.common.util.LocaleUtils
+import org.ccci.gto.android.common.util.includeFallbacks
 import org.cru.godtools.api.model.NavigationEvent
 import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.EXTRA_PAGE
@@ -173,7 +173,8 @@ class TractActivity :
             when {
                 data.isCustomUriDeepLink() -> {
                     dataModel.toolCode.value = path[2]
-                    dataModel.primaryLocales.value = LocaleUtils.getFallbacks(Locale.forLanguageTag(path[3])).toList()
+                    dataModel.primaryLocales.value =
+                        sequenceOf(Locale.forLanguageTag(path[3])).includeFallbacks().toList()
                     path.getOrNull(4)?.toIntOrNull()?.let { initialPage = it }
                 }
                 data.isTractDeepLink() -> {
@@ -206,19 +207,21 @@ class TractActivity :
         val selected = deepLinkSelectedLanguage
 
         if (getQueryParameter(PARAM_USE_DEVICE_LANGUAGE)?.isNotEmpty() == true) {
-            primary += LocaleUtils.getFallbacks(Locale.getDefault())
+            primary += sequenceOf(Locale.getDefault()).includeFallbacks()
         }
-        primary += LocaleUtils.getFallbacks(*extractLanguagesFromDeepLinkParam(PARAM_PRIMARY_LANGUAGE).toTypedArray())
-        parallel += LocaleUtils.getFallbacks(*extractLanguagesFromDeepLinkParam(PARAM_PARALLEL_LANGUAGE).toTypedArray())
+        primary += extractLanguagesFromDeepLinkParam(PARAM_PRIMARY_LANGUAGE).includeFallbacks()
+        parallel += extractLanguagesFromDeepLinkParam(PARAM_PARALLEL_LANGUAGE).includeFallbacks()
 
-        if (selected !in primary && selected !in parallel) primary += LocaleUtils.getFallbacks(selected)
+        if (selected !in primary && selected !in parallel) primary += sequenceOf(selected).includeFallbacks()
 
         return Pair(primary.toList(), parallel.toList())
     }
 
     private fun Uri.extractLanguagesFromDeepLinkParam(param: String) = getQueryParameters(param)
+        .asSequence()
         .flatMap { it.split(",") }
-        .map { it.trim() }.filterNot { it.isEmpty() }
+        .map { it.trim() }
+        .filterNot { it.isEmpty() }
         .map { Locale.forLanguageTag(it) }
     // endregion Intent Processing
 


### PR DESCRIPTION
- stop using deprecated LocaleUtils.getFallbacks
- use a different syntax to set the URLs for maven repositories
- we no longer need to enable support vector drawables due to not supporting Android pre-Lollipop
- disable Facebook Flipper on Android Lollipop
