### PR TITLE
Various Build Adjustments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 android {
     baseConfiguration(project)
     configureCompose(project)
-    configureQaBuildType()
+    configureQaBuildType(project)
 
     defaultConfig {
         applicationId = "org.keynote.godtools.android"
@@ -119,18 +119,6 @@ android {
         language.enableSplit = false
     }
     dynamicFeatures += ":feature:bundledcontent"
-
-    sourceSets {
-        getByName("qa") {
-            kotlin.srcDir("src/debug/kotlin")
-            res.srcDir("src/debug/res/values")
-            manifest.srcFile("src/debug/AndroidManifest.xml")
-        }
-    }
-}
-
-configurations {
-    named("qaImplementation") { extendsFrom(getByName("debugImplementation")) }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,22 +52,22 @@ android {
     }
 
     productFlavors {
-        val stage by existing {
+        named("stage") {
             buildConfigField("String", "MOBILE_CONTENT_API", "\"$URI_MOBILE_CONTENT_API_STAGE\"")
         }
-        val production by existing {
+        named("production") {
             buildConfigField("String", "MOBILE_CONTENT_API", "\"$URI_MOBILE_CONTENT_API_PRODUCTION\"")
         }
     }
 
     signingConfigs {
-        val firebaseAppDistribution by creating {
+        register("firebaseAppDistribution") {
             storeFile = project.properties["firebaseAppDistributionKeystorePath"]?.let { rootProject.file(it) }
             storePassword = project.properties["firebaseAppDistributionKeystoreStorePassword"]?.toString()
             keyAlias = project.properties["firebaseAppDistributionKeystoreKeyAlias"]?.toString()
             keyPassword = project.properties["firebaseAppDistributionKeystoreKeyPassword"]?.toString()
         }
-        val release by creating {
+        register("release") {
             storeFile = project.properties["androidKeystorePath"]?.let { rootProject.file(it) }
             storePassword = project.properties["androidKeystoreStorePassword"]?.toString()
             keyAlias = project.properties["androidKeystoreKeyAlias"]?.toString()

--- a/build.gradle
+++ b/build.gradle
@@ -46,13 +46,6 @@ subprojects {
 
                 implementation libs.timber
 
-                testImplementation libs.androidx.test.junit
-                testImplementation libs.junit
-                testImplementation libs.mockito
-                testImplementation libs.mockito.kotlin
-                testImplementation libs.mockk
-                testImplementation libs.robolectric
-
                 // HACK: Fix Manifest merge errors for any classpath that contains the Okta module
                 androidTestImplementation(testFixtures(libs.gtoSupport.okta))
                 testImplementation(testFixtures(libs.gtoSupport.okta))

--- a/build.gradle
+++ b/build.gradle
@@ -98,15 +98,3 @@ allprojects {
         tasks.withType(Test).all { gradle.startParameter.excludedTaskNames += it.name }
     }
 }
-
-if (project.hasProperty('gradleEnterprise')) {
-    gradleEnterprise {
-        buildScan {
-            // automatically accept the scans.gradle.com TOS when running in GHA
-            if (System.getenv("GITHUB_ACTIONS")) {
-                termsOfServiceUrl = "https://gradle.com/terms-of-service"
-                termsOfServiceAgree = "yes"
-            }
-        }
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ plugins {
 allprojects {
     configurations.all { configuration ->
         configuration.resolutionStrategy {
-            force libs.androidx.lifecycle.viewmodel.ktx
-
             dependencySubstitution {
                 // use the new condensed version of hamcrest
                 substitute module('org.hamcrest:hamcrest-core') with module("${libs.hamcrest.get()}")

--- a/build.gradle
+++ b/build.gradle
@@ -19,19 +19,6 @@ plugins {
     alias libs.plugins.ktlint
 }
 
-// configure dependency resolution
-allprojects {
-    configurations.all { configuration ->
-        configuration.resolutionStrategy {
-            dependencySubstitution {
-                // use the new condensed version of hamcrest
-                substitute module('org.hamcrest:hamcrest-core') with module("${libs.hamcrest.get()}")
-                substitute module('org.hamcrest:hamcrest-library') with module("${libs.hamcrest.get()}")
-            }
-        }
-    }
-}
-
 // common config
 subprojects {
     afterEvaluate { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
 allprojects {
     configurations.all { configuration ->
         configuration.resolutionStrategy {
-            force libs.androidx.annotation
             force libs.androidx.lifecycle.viewmodel.ktx
 
             dependencySubstitution {
@@ -40,8 +39,6 @@ subprojects {
     afterEvaluate { project ->
         if (project.hasProperty('android')) {
             dependencies {
-                compileOnly libs.androidx.annotation
-
                 implementation libs.kotlin.stdlib
 
                 implementation libs.timber

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -8,20 +8,9 @@ import com.android.build.gradle.internal.dsl.DynamicFeatureExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.findByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-
-fun Project.configureAndroidFeature() = extensions.configure<DynamicFeatureExtension> {
-    configureAndroidCommon(project)
-    configureFlavorDimensions()
-    configureQaBuildType()
-
-    dependencies {
-        add("implementation", project(":app"))
-    }
-}
 
 // TODO: provide Project using the new multiple context receivers functionality.
 //       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
@@ -36,6 +25,19 @@ fun BaseAppModuleExtension.baseConfiguration(project: Project) {
 //context(Project)
 fun LibraryExtension.baseConfiguration(project: Project) {
     configureAndroidCommon(project)
+}
+
+// TODO: provide Project using the new multiple context receivers functionality.
+//       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
+//context(Project)
+fun DynamicFeatureExtension.baseConfiguration(project: Project) {
+    configureAndroidCommon(project)
+    configureQaBuildType()
+    configureFlavorDimensions()
+
+    project.dependencies {
+        add("implementation", project.project(":app"))
+    }
 }
 
 // TODO: provide Project using the new multiple context receivers functionality.

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -10,6 +10,7 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 // TODO: provide Project using the new multiple context receivers functionality.
@@ -32,7 +33,7 @@ fun LibraryExtension.baseConfiguration(project: Project) {
 //context(Project)
 fun DynamicFeatureExtension.baseConfiguration(project: Project) {
     configureAndroidCommon(project)
-    configureQaBuildType()
+    configureQaBuildType(project)
     configureFlavorDimensions()
 
     project.dependencies {
@@ -97,12 +98,27 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
     }
 }
 
-fun CommonExtension<*,*,*,*>.configureQaBuildType() {
+// TODO: provide Project using the new multiple context receivers functionality.
+//       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
+//context(Project)
+fun CommonExtension<*,*,*,*>.configureQaBuildType(project: Project) {
     buildTypes {
         register("qa") {
             initWith(getByName("debug"))
             matchingFallbacks += listOf("debug")
         }
+    }
+
+    sourceSets {
+        named("qa") {
+            kotlin.srcDir("src/debug/kotlin")
+            res.srcDir("src/debug/res/values")
+            manifest.srcFile("src/debug/AndroidManifest.xml")
+        }
+    }
+
+    project.configurations {
+        named("qaImplementation") { extendsFrom(getByName("debugImplementation")) }
     }
 }
 

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -140,6 +140,15 @@ private fun TestedExtension.configureTestOptions(project: Project) {
     unitTestVariants.all { configureTestManifestPlaceholders() }
 
     project.dependencies.addProvider("testImplementation", project.libs.findBundle("test-framework").get())
+
+    project.configurations.configureEach {
+        resolutionStrategy.dependencySubstitution {
+            // use the new condensed version of hamcrest
+            val hamcrest = project.libs.findLibrary("hamcrest").get().get().toString()
+            substitute(module("org.hamcrest:hamcrest-core")).using(module(hamcrest))
+            substitute(module("org.hamcrest:hamcrest-library")).using(module(hamcrest))
+        }
+    }
 }
 
 private fun InternalBaseVariant.configureTestManifestPlaceholders() {

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -99,7 +99,7 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
 
 fun CommonExtension<*,*,*,*>.configureQaBuildType() {
     buildTypes {
-        create("qa") {
+        register("qa") {
             initWith(getByName("debug"))
             matchingFallbacks += listOf("debug")
         }

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -46,7 +46,7 @@ fun DynamicFeatureExtension.baseConfiguration(project: Project) {
 private fun TestedExtension.configureAndroidCommon(project: Project) {
     configureSdk()
     configureCompilerOptions()
-    configureTestOptions()
+    configureTestOptions(project)
 
     lintOptions.lintConfig = project.rootProject.file("analysis/lint/lint.xml")
 
@@ -106,7 +106,10 @@ fun CommonExtension<*,*,*,*>.configureQaBuildType() {
     }
 }
 
-private fun TestedExtension.configureTestOptions() {
+// TODO: provide Project using the new multiple context receivers functionality.
+//       this is prototyped in 1.6.20 and will probably reach beta in Kotlin 1.8 or 1.9
+//context(Project)
+private fun TestedExtension.configureTestOptions(project: Project) {
     testOptions.unitTests {
         isIncludeAndroidResources = true
 
@@ -119,6 +122,8 @@ private fun TestedExtension.configureTestOptions() {
 
     testVariants.all { configureTestManifestPlaceholders() }
     unitTestVariants.all { configureTestManifestPlaceholders() }
+
+    project.dependencies.addProvider("testImplementation", project.libs.findBundle("test-framework").get())
 }
 
 private fun InternalBaseVariant.configureTestManifestPlaceholders() {

--- a/feature/bundledcontent/build.gradle.kts
+++ b/feature/bundledcontent/build.gradle.kts
@@ -4,7 +4,9 @@ plugins {
     kotlin("kapt")
 }
 
-configureAndroidFeature()
+android {
+    baseConfiguration(project)
+}
 
 dependencies {
     implementation(project(":library:initial-content"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -194,6 +194,7 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling-preview"]
 androidx-compose-debug = ["androidx-compose-ui-test-manifest", "androidx-compose-ui-tooling"]
 androidx-compose-testing = ["androidx-compose-ui-test"]
+test-framework = ["junit", "androidx-test-junit", "mockk", "robolectric", "mockito", "mockito-kotlin"]
 
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     baseConfiguration(project)
-    configureFlavorDimensions()
+    configureFlavorDimensions(project)
 
     libraryVariants.configureEach {
         val mobileContentApi =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,3 +60,13 @@ include("ui:tutorial-renderer")
 include("app")
 
 include("feature:bundledcontent")
+
+// automatically accept the scans.gradle.com TOS when running in GHA
+if (System.getenv("GITHUB_ACTIONS")?.toBoolean() == true) {
+    extensions.findByName("gradleEnterprise")?.withGroovyBuilder {
+        getProperty("buildScan").withGroovyBuilder {
+            setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
+            setProperty("termsOfServiceAgree", "yes")
+        }
+    }
+}

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     api(libs.androidx.appcompat)
     compileOnly(libs.androidx.fragment.ktx)
+    implementation(libs.androidx.annotation)
     implementation(libs.androidx.browser)
     implementation(libs.androidx.compose.material3)
 


### PR DESCRIPTION
- tweak how DynamicFeatures are configured via buildSrc
- configure the default test framework dependencies via the test configuration in buildSrc
- auto-accept build scans on GHA via settings.gradle.kts
- there is no need to configure androidx-annotations for every module anymore
- we no longer need to force the version of androidx-lifecycle-viewmodel-ktx
- use register instead of create for lazy creation
- there is no need to use delegates for productFlavors or signingConfigs
- consolidate the firebase app distribution configuration
- Move common QA buildType configuration to buildSrc
- force the newer version of hamcrest in our Android Test config
- use new APIs for filtering stage flavors when flavors are configured
