### PR TITLE
GT-1691 GT-1692 Include a source when recording open tool analytics events

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
@@ -32,7 +32,6 @@ import org.cru.godtools.tutorial.activity.startTutorialActivity
 import org.cru.godtools.ui.languages.paralleldialog.ParallelLanguageDialogFragment
 import org.cru.godtools.ui.languages.startLanguageSettingsActivity
 import org.cru.godtools.ui.tooldetails.startToolDetailsActivity
-import org.cru.godtools.ui.tools.analytics.model.ToolOpenTapAnalyticsActionEvent
 import org.cru.godtools.util.openToolActivity
 
 private const val TAG_PARALLEL_LANGUAGE_DIALOG = "parallelLanguageDialog"
@@ -134,7 +133,6 @@ class DashboardActivity : BasePlatformActivity<ActivityDashboardBinding>(R.layou
         if (languages.isEmpty()) return
 
         languages.forEach { manifestManager.preloadLatestPublishedManifest(code, it) }
-        eventBus.post(ToolOpenTapAnalyticsActionEvent)
         openToolActivity(code, tool.type, *languages.toTypedArray())
     }
     // endregion ToolsAdapterCallbacks

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/analytics/model/DashboardToolClickedAnalyticsActionEvent.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/analytics/model/DashboardToolClickedAnalyticsActionEvent.kt
@@ -1,0 +1,28 @@
+package org.cru.godtools.ui.dashboard.analytics.model
+
+import android.os.Bundle
+import org.cru.godtools.analytics.model.AnalyticsActionEvent
+import org.cru.godtools.analytics.model.AnalyticsSystem
+
+private const val PARAM_SOURCE = "cru_source"
+private const val PARAM_TOOL = "cru_tool"
+
+internal class DashboardToolClickedAnalyticsActionEvent(
+    action: String,
+    private val tool: String?,
+    private val source: String? = null
+) : AnalyticsActionEvent(action = action, system = AnalyticsSystem.FIREBASE) {
+    companion object {
+        const val ACTION_OPEN_LESSON = "dashboard_open_lesson"
+        const val ACTION_OPEN_TOOL = "tool_open_tap"
+        const val ACTION_OPEN_TOOL_DETAILS = "dashboard_open_details"
+
+        const val SOURCE_FEATURED = "featured"
+        const val SOURCE_SPOTLIGHT = "spotlight"
+    }
+
+    override val firebaseParams get() = Bundle().apply {
+        if (source != null) putString(PARAM_SOURCE, source)
+        if (tool != null) putString(PARAM_TOOL, tool)
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -44,6 +44,7 @@ import org.cru.godtools.R
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.banner.Banners
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.SOURCE_FEATURED
 import org.cru.godtools.ui.tools.LessonToolCard
 import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.SquareToolCard
@@ -102,7 +103,10 @@ internal fun HomeContent(
             items(spotlightLessons, key = { it }, contentType = { "lesson-tool-card" }) {
                 LessonToolCard(
                     it,
-                    onClick = { tool, translation -> onOpenTool(tool, translation, null) },
+                    onClick = { tool, translation ->
+                        viewModel.recordLessonClickInAnalytics(tool?.code, SOURCE_FEATURED)
+                        onOpenTool(tool, translation, null)
+                    },
                     modifier = Modifier
                         .animateItemPlacement()
                         .padding(horizontal = PADDING_HORIZONTAL)
@@ -128,8 +132,14 @@ internal fun HomeContent(
                 item("favorites", "favorites") {
                     HorizontalFavoriteTools(
                         { favoriteTools.orEmpty().take(5) },
-                        onOpenTool = onOpenTool,
-                        onOpenToolDetails = onOpenToolDetails,
+                        onOpenTool = { tool, trans1, trans2 ->
+                            viewModel.recordToolClickInAnalytics(tool?.code)
+                            onOpenTool(tool, trans1, trans2)
+                        },
+                        onOpenToolDetails = {
+                            viewModel.recordToolDetailsClickInAnalytics(it)
+                            onOpenToolDetails(it)
+                        },
                         modifier = Modifier
                             .animateItemPlacement()
                             .fillMaxWidth()
@@ -210,7 +220,7 @@ private fun HorizontalFavoriteTools(
         SquareToolCard(
             toolCode = it.code.orEmpty(),
             confirmRemovalFromFavorites = true,
-            onOpenTool = { tool, trans1, trans2 -> onOpenTool(tool, trans1, trans2) },
+            onOpenTool = onOpenTool,
             onOpenToolDetails = onOpenToolDetails,
             modifier = Modifier.animateItemPlacement()
         )
@@ -300,8 +310,14 @@ internal fun AllFavoritesList(
                     toolCode = tool.code.orEmpty(),
                     confirmRemovalFromFavorites = true,
                     interactionSource = interactionSource,
-                    onOpenTool = { tool, trans1, trans2 -> onOpenTool(tool, trans1, trans2) },
-                    onOpenToolDetails = onOpenToolDetails,
+                    onOpenTool = { tool, trans1, trans2 ->
+                        viewModel.recordToolClickInAnalytics(tool?.code)
+                        onOpenTool(tool, trans1, trans2)
+                    },
+                    onOpenToolDetails = {
+                        viewModel.recordToolDetailsClickInAnalytics(it)
+                        onOpenToolDetails(it)
+                    },
                     modifier = Modifier
                         .padding(top = 16.dp)
                         .fillMaxWidth()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
@@ -16,12 +16,18 @@ import org.cru.godtools.base.Settings
 import org.cru.godtools.model.Tool
 import org.cru.godtools.tutorial.PageSet
 import org.cru.godtools.ui.banner.BannerType
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.ACTION_OPEN_LESSON
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
+import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.repository.LessonsRepository
 import org.keynote.godtools.android.db.repository.ToolsRepository
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModel @Inject constructor(
+    private val eventBus: EventBus,
     lessonsRepository: LessonsRepository,
     settings: Settings,
     private val toolsRepository: ToolsRepository
@@ -59,4 +65,18 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch { toolsRepository.updateToolOrder(favoriteToolsOrder.value.mapNotNull { it.code }) }
     }
     // endregion Favorite Tools
+
+    // region Analytics
+    fun recordLessonClickInAnalytics(tool: String?, source: String? = null) {
+        eventBus.post(DashboardToolClickedAnalyticsActionEvent(ACTION_OPEN_LESSON, tool, source))
+    }
+
+    fun recordToolClickInAnalytics(tool: String?) {
+        eventBus.post(DashboardToolClickedAnalyticsActionEvent(ACTION_OPEN_TOOL, tool))
+    }
+
+    fun recordToolDetailsClickInAnalytics(tool: String?) {
+        eventBus.post(DashboardToolClickedAnalyticsActionEvent(ACTION_OPEN_TOOL_DETAILS, tool))
+    }
+    // endregion Analytics
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -34,7 +34,10 @@ fun LessonsLayout(
         items(lessons.orEmpty(), { it }, { "lesson" }) {
             LessonToolCard(
                 it,
-                onClick = { tool, translation -> onOpenLesson(tool, translation) },
+                onClick = { tool, translation ->
+                    viewModel.recordLessonClickInAnalytics(tool?.code)
+                    onOpenLesson(tool, translation)
+                },
                 modifier = Modifier
                     .animateItemPlacement()
                     .padding(top = 16.dp)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsViewModel.kt
@@ -7,11 +7,23 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.ACTION_OPEN_LESSON
+import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.repository.LessonsRepository
 
 @HiltViewModel
-class LessonsViewModel @Inject constructor(lessonsRepository: LessonsRepository) : ViewModel() {
+class LessonsViewModel @Inject constructor(
+    private val eventBus: EventBus,
+    lessonsRepository: LessonsRepository,
+) : ViewModel() {
     val lessons = lessonsRepository.lessons
         .map { it.mapNotNull { it.code } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+
+    // region Analytics
+    fun recordLessonClickInAnalytics(tool: String?) {
+        eventBus.post(DashboardToolClickedAnalyticsActionEvent(ACTION_OPEN_LESSON, tool))
+    }
+    // endregion Analytics
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
 import org.cru.godtools.R
 import org.cru.godtools.ui.banner.Banners
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.SOURCE_SPOTLIGHT
 import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.SquareToolCard
 import org.cru.godtools.ui.tools.ToolCard
@@ -88,7 +89,10 @@ internal fun ToolsLayout(
             ToolCard(
                 tool.code.orEmpty(),
                 showActions = false,
-                onClick = { it, _, _ -> it?.code?.let(onToolClicked) },
+                onClick = { it, _, _ ->
+                    viewModel.recordToolClickInAnalytics(it?.code)
+                    it?.code?.let(onToolClicked)
+                },
                 modifier = Modifier
                     .animateItemPlacement()
                     .padding(bottom = 16.dp, horizontal = 16.dp)
@@ -99,7 +103,7 @@ internal fun ToolsLayout(
 
 @Composable
 internal fun ToolSpotlight(
-    viewModel: ToolsViewModel = viewModel(),
+    viewModel: ToolsViewModel,
     modifier: Modifier = Modifier,
     onToolClicked: (String) -> Unit = {}
 ) = Column(modifier = modifier.fillMaxWidth()) {
@@ -134,7 +138,10 @@ internal fun ToolSpotlight(
                 showActions = false,
                 floatParallelLanguageUp = false,
                 confirmRemovalFromFavorites = false,
-                onClick = { tool, _, _ -> tool?.code?.let(onToolClicked) }
+                onClick = { tool, _, _ ->
+                    viewModel.recordToolClickInAnalytics(tool?.code, SOURCE_SPOTLIGHT)
+                    tool?.code?.let(onToolClicked)
+                }
             )
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsViewModel.kt
@@ -17,6 +17,9 @@ import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.base.Settings
 import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.banner.BannerType
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent
+import org.cru.godtools.ui.dashboard.analytics.model.DashboardToolClickedAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
+import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
 
@@ -40,6 +43,7 @@ internal val QUERY_TOOLS_SPOTLIGHT = QUERY_TOOLS_BASE.andWhere(ToolTable.FIELD_S
 @OptIn(ExperimentalCoroutinesApi::class)
 class ToolsViewModel @Inject constructor(
     dao: GodToolsDao,
+    private val eventBus: EventBus,
     settings: Settings,
     private val savedState: SavedStateHandle,
 ) : ViewModel() {
@@ -67,4 +71,10 @@ class ToolsViewModel @Inject constructor(
         tools.filter { category == null || it.category == category }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), emptyList())
     // endregion Filters
+
+    // region Analytics
+    fun recordToolClickInAnalytics(tool: String?, source: String? = null) {
+        eventBus.post(DashboardToolClickedAnalyticsActionEvent(ACTION_OPEN_TOOL_DETAILS, tool, source))
+    }
+    // endregion Analytics
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/analytics/model/AboutToolButtonAnalyticsActionEvent.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/analytics/model/AboutToolButtonAnalyticsActionEvent.kt
@@ -3,6 +3,5 @@ package org.cru.godtools.ui.tools.analytics.model
 import org.cru.godtools.analytics.model.AnalyticsActionEvent
 import org.cru.godtools.analytics.model.AnalyticsSystem
 
-object ToolOpenTapAnalyticsActionEvent : AnalyticsActionEvent("tool_open_tap", system = AnalyticsSystem.FIREBASE)
 object AboutToolButtonAnalyticsActionEvent :
     AnalyticsActionEvent("about_tool_open_button", system = AnalyticsSystem.FIREBASE)


### PR DESCRIPTION
- track clicks on lesson cards and on the tools UI in analytics
- record tool clicks in analytics for the home UI
- remove old open tool analytics event object
