### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -38,6 +38,7 @@ internal fun ToolsLayout(
 ) {
     val banner by viewModel.banner.collectAsState()
     val spotlightTools by viewModel.spotlightTools.collectAsState()
+    val categories by viewModel.categories.collectAsState()
     val filteredTools by viewModel.filteredTools.collectAsState()
 
     val columnState = rememberLazyListState()
@@ -65,19 +66,22 @@ internal fun ToolsLayout(
             }
         }
 
-        item("tool-filters", "tool-filters") {
-            ToolFilters(
-                viewModel,
-                modifier = Modifier
-                    .animateItemPlacement()
-                    .padding(vertical = 16.dp)
-            )
+        if (categories.isNotEmpty()) {
+            item("tool-filters", "tool-filters") {
+                ToolFilters(
+                    viewModel,
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .padding(vertical = 16.dp)
+                )
+            }
         }
 
-        if (filteredTools.isNotEmpty()) {
+        if ((spotlightTools.isNotEmpty() || categories.isNotEmpty()) && filteredTools.isNotEmpty()) {
             item("tool-divider", "tool-divider") {
                 Divider(
                     modifier = Modifier
+                        .animateItemPlacement()
                         .padding(horizontal = 16.dp, top = 8.dp, bottom = 24.dp)
                         .alpha(0.12f)
                 )

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/firebase/FirebaseAnalyticsService.kt
@@ -95,6 +95,7 @@ class FirebaseAnalyticsService @VisibleForTesting internal constructor(
         }
         firebase.logEvent(event.firebaseEventName, params)
     }
+    // endregion Tracking Events
 
     @VisibleForTesting
     internal val userInfoJob = oktaUserProfileProvider.userInfoFlow(refreshIfStale = false)

--- a/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/Page.kt
+++ b/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/Page.kt
@@ -5,7 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.RawRes
 import androidx.annotation.StringRes
 import java.util.Locale
-import org.ccci.gto.android.common.util.LocaleUtils
+import org.ccci.gto.android.common.util.includeFallbacks
 
 private val ONBOARDING_EXTENDED_LOCALES = setOf(Locale.ENGLISH, Locale.FRENCH, Locale("es"), Locale("lv"), Locale("vi"))
 
@@ -140,6 +140,6 @@ internal enum class Page(
     );
 
     fun supportsLocale(locale: Locale) =
-        (supportedLocales.isEmpty() || LocaleUtils.getFallbacks(locale).any { it in supportedLocales }) &&
-            (disabledLocales.isEmpty() || LocaleUtils.getFallbacks(locale).none { it in disabledLocales })
+        (supportedLocales.isEmpty() || sequenceOf(locale).includeFallbacks().any { it in supportedLocales }) &&
+            (disabledLocales.isEmpty() || sequenceOf(locale).includeFallbacks().none { it in disabledLocales })
 }

--- a/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/layout/TutorialPageLayout.kt
+++ b/ui/tutorial-renderer/src/main/java/org/cru/godtools/tutorial/layout/TutorialPageLayout.kt
@@ -64,5 +64,4 @@ internal fun TutorialPageLayout(
         onTutorialAction = onTutorialAction,
         modifier = modifier,
     )
-    else -> Unit
 }


### PR DESCRIPTION
- only show filters if any actually exist
- add missing endregion
- use includeFallbacks() instead of deprecated getFallbacks()
- remove unnecessary else case
