### PR TITLE
GT-1604 Support triggering VISIBLE analytics events on accordion sections

### DIFF
--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     kapt(libs.hilt.compiler)
 
     testImplementation(libs.androidx.arch.core.testing)
+    testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.kotlin.coroutines.test)
     kaptTest(libs.androidx.databinding.compiler)
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionController.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.base.tool.ui.controller
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -11,7 +12,7 @@ import org.cru.godtools.base.tool.databinding.ToolContentAccordionSectionBinding
 import org.cru.godtools.base.tool.ui.controller.cache.UiControllerCache
 import org.cru.godtools.tool.model.Accordion
 
-class AccordionController private constructor(
+class AccordionController @VisibleForTesting internal constructor(
     private val binding: ToolContentAccordionBinding,
     parentController: BaseController<*>,
     private val sectionFactory: SectionController.Factory
@@ -91,4 +92,8 @@ class AccordionController private constructor(
 
         override val childContainer get() = binding.content
     }
+
+    @VisibleForTesting
+    internal fun isActiveSection(section: Accordion.Section?) =
+        section?.id.let { it != null && it == activeSection.value }
 }

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionControllerTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionControllerTest.kt
@@ -1,0 +1,45 @@
+package org.cru.godtools.base.tool.ui.controller
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.every
+import io.mockk.mockk
+import org.cru.godtools.base.tool.databinding.ToolContentAccordionBinding
+import org.cru.godtools.tool.model.Accordion
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AccordionControllerTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var controller: AccordionController
+
+    @Before
+    fun setup() {
+        controller = AccordionController(
+            mockkToolContentAccordionBinding(),
+            mockk(),
+            mockk()
+        )
+    }
+
+    @Test
+    fun testIsActiveSection() {
+        val activeSection = mockk<Accordion.Section> { every { id } returns "active" }
+        val inactiveSection = mockk<Accordion.Section> { every { id } returns "inactive" }
+
+        assertFalse(controller.isActiveSection(null))
+        assertFalse(controller.isActiveSection(activeSection))
+        assertFalse(controller.isActiveSection(inactiveSection))
+
+        controller.activeSection.value = "active"
+        assertFalse(controller.isActiveSection(null))
+        assertTrue(controller.isActiveSection(activeSection))
+        assertFalse(controller.isActiveSection(inactiveSection))
+    }
+}
+
+internal fun mockkToolContentAccordionBinding() = mockk<ToolContentAccordionBinding> { every { root } returns mockk() }

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionSectionControllerTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionSectionControllerTest.kt
@@ -1,0 +1,89 @@
+package org.cru.godtools.base.tool.ui.controller
+
+import android.widget.LinearLayout
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.ccci.gto.android.common.util.getDeclaredFieldOrNull
+import org.cru.godtools.base.tool.databinding.ToolContentAccordionSectionBinding
+import org.cru.godtools.tool.model.Accordion
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccordionSectionControllerTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val baseLifecycleOwner = TestLifecycleOwner()
+    private val accordionController = AccordionController(
+        mockkToolContentAccordionBinding(),
+        mockk { every { lifecycleOwner } returns baseLifecycleOwner },
+        mockk()
+    )
+
+    private lateinit var controller: AccordionController.SectionController
+
+    @Before
+    fun setup() {
+        controller = AccordionController.SectionController(
+            mockk<ToolContentAccordionSectionBinding>(relaxed = true) {
+                every { root } returns mockk(relaxed = true)
+                getDeclaredFieldOrNull<ToolContentAccordionSectionBinding>("content")
+                    ?.set(this, mockk<LinearLayout>())
+            },
+            accordionController,
+            mockk()
+        )
+    }
+
+    @After
+    fun cleanup() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun testLifecycleState() = runTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
+        assertEquals(Lifecycle.State.CREATED, controller.lifecycleOwner!!.lifecycle.currentState)
+
+        // active section
+        controller.model = createSection("section1")
+        assertEquals(Lifecycle.State.STARTED, controller.lifecycleOwner!!.lifecycle.currentState)
+        accordionController.activeSection.value = "section1"
+        assertEquals(Lifecycle.State.RESUMED, controller.lifecycleOwner!!.lifecycle.currentState)
+
+        // stop & restart accordion
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.CREATED
+        assertEquals(Lifecycle.State.CREATED, controller.lifecycleOwner!!.lifecycle.currentState)
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
+        assertEquals(Lifecycle.State.RESUMED, controller.lifecycleOwner!!.lifecycle.currentState)
+
+        // inactive section
+        controller.model = createSection("section2")
+        assertEquals(Lifecycle.State.STARTED, controller.lifecycleOwner!!.lifecycle.currentState)
+        accordionController.activeSection.value = null
+        assertEquals(Lifecycle.State.STARTED, controller.lifecycleOwner!!.lifecycle.currentState)
+
+        // reset controller
+        controller.model = null
+        assertEquals(Lifecycle.State.CREATED, controller.lifecycleOwner!!.lifecycle.currentState)
+    }
+
+    private fun createSection(id: String): Accordion.Section = mockk(relaxed = true) {
+        every { manifest } returns mockk(relaxed = true) { every { locale } returns null }
+        every { this@mockk.id } returns id
+    }
+}

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionSectionControllerTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionSectionControllerTest.kt
@@ -4,17 +4,28 @@ import android.widget.LinearLayout
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
+import io.mockk.Called
+import io.mockk.clearMocks
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.ccci.gto.android.common.util.getDeclaredFieldOrNull
+import org.cru.godtools.base.tool.analytics.model.ContentAnalyticsEventAnalyticsActionEvent
 import org.cru.godtools.base.tool.databinding.ToolContentAccordionSectionBinding
 import org.cru.godtools.tool.model.Accordion
+import org.cru.godtools.tool.model.AnalyticsEvent
+import org.greenrobot.eventbus.EventBus
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -27,9 +38,13 @@ class AccordionSectionControllerTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private val baseLifecycleOwner = TestLifecycleOwner()
+    private val eventBus = mockk<EventBus>(relaxUnitFun = true)
     private val accordionController = AccordionController(
         mockkToolContentAccordionBinding(),
-        mockk { every { lifecycleOwner } returns baseLifecycleOwner },
+        mockk {
+            every { eventBus } returns this@AccordionSectionControllerTest.eventBus
+            every { lifecycleOwner } returns baseLifecycleOwner
+        },
         mockk()
     )
 
@@ -37,6 +52,7 @@ class AccordionSectionControllerTest {
 
     @Before
     fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         controller = AccordionController.SectionController(
             mockk<ToolContentAccordionSectionBinding>(relaxed = true) {
                 every { root } returns mockk(relaxed = true)
@@ -55,7 +71,6 @@ class AccordionSectionControllerTest {
 
     @Test
     fun testLifecycleState() = runTest {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
         baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
         assertEquals(Lifecycle.State.CREATED, controller.lifecycleOwner!!.lifecycle.currentState)
 
@@ -80,6 +95,47 @@ class AccordionSectionControllerTest {
         // reset controller
         controller.model = null
         assertEquals(Lifecycle.State.CREATED, controller.lifecycleOwner!!.lifecycle.currentState)
+    }
+
+    @Test
+    fun testVisibleAnalyticsEvents() = runTest {
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.STARTED
+        val event = AnalyticsEvent()
+        val delayedEvent1 = AnalyticsEvent(delay = 1)
+        val delayedEvent2 = AnalyticsEvent(delay = 2)
+        val section = createSection("section")
+        every { section.getAnalyticsEvents(any()) } returns listOf(event, delayedEvent1, delayedEvent2)
+        controller.model = section
+        accordionController.activeSection.value = "section"
+        advanceUntilIdle()
+
+        // no analytics events should have been triggered since we haven't been resumed yet
+        verify(exactly = 0) { section.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE) }
+        verify { eventBus wasNot Called }
+
+        // trigger events by entering resumed state
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
+        verify(exactly = 1) { section.getAnalyticsEvents(AnalyticsEvent.Trigger.VISIBLE) }
+        verifyAll {
+            eventBus.post(match<ContentAnalyticsEventAnalyticsActionEvent> { it.event === event })
+        }
+        confirmVerified(eventBus)
+
+        // check delayed event executes
+        advanceTimeBy(1000)
+        runCurrent()
+        verifyAll {
+            eventBus.post(match<ContentAnalyticsEventAnalyticsActionEvent> { it.event === event })
+            eventBus.post(match<ContentAnalyticsEventAnalyticsActionEvent> { it.event === delayedEvent1 })
+        }
+        confirmVerified(eventBus)
+        clearMocks(eventBus)
+
+        // check cancelling delayedEvent2
+        advanceTimeBy(999)
+        baseLifecycleOwner.lifecycle.currentState = Lifecycle.State.STARTED
+        advanceUntilIdle()
+        verify { eventBus wasNot Called }
     }
 
     private fun createSection(id: String): Accordion.Section = mockk(relaxed = true) {


### PR DESCRIPTION
- add an isActiveSection method to the AccordionController
- utilize a ConstrainedLifecycleOwner for accordion sections to reflect whether the section is selected or not
- trigger visible analytics events for accordion sections
