### PR TITLE
GT-1600 Update how screen analytics events are recorded within compose

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -10,6 +10,13 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import org.ccci.gto.android.common.androidx.lifecycle.compose.OnResume
+import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
+import org.cru.godtools.analytics.firebase.model.ACTION_IAM_ALL_TOOLS
+import org.cru.godtools.analytics.firebase.model.ACTION_IAM_HOME
+import org.cru.godtools.analytics.firebase.model.ACTION_IAM_LESSONS
+import org.cru.godtools.analytics.firebase.model.FirebaseIamActionEvent
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
+import org.cru.godtools.base.ui.compose.LocalEventBus
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
@@ -25,7 +32,7 @@ internal fun DashboardLayout(
     onOpenToolDetails: (String) -> Unit
 ) {
     val currentPage by viewModel.currentPage.collectAsState()
-    OnResume(currentPage) { viewModel.trackPageInAnalytics(currentPage) }
+    DashboardLayoutAnalytics(currentPage)
 
     val hasBackStack by viewModel.hasBackStack.collectAsState()
     BackHandler(hasBackStack) { viewModel.popPageStack() }
@@ -59,6 +66,25 @@ internal fun DashboardLayout(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun DashboardLayoutAnalytics(page: Page) {
+    val eventBus = LocalEventBus.current
+    when (page) {
+        Page.LESSONS -> {
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_LESSONS))
+            OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_LESSONS)) }
+        }
+        Page.HOME, Page.FAVORITE_TOOLS -> {
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_HOME))
+            OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_HOME)) }
+        }
+        Page.ALL_TOOLS -> {
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_ALL_TOOLS))
+            OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_ALL_TOOLS)) }
         }
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardViewModel.kt
@@ -10,21 +10,14 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.cru.godtools.analytics.firebase.model.ACTION_IAM_ALL_TOOLS
-import org.cru.godtools.analytics.firebase.model.ACTION_IAM_HOME
-import org.cru.godtools.analytics.firebase.model.ACTION_IAM_LESSONS
-import org.cru.godtools.analytics.firebase.model.FirebaseIamActionEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.sync.GodToolsSyncService
-import org.greenrobot.eventbus.EventBus
 
 private const val KEY_PAGE_STACK = "pageStack"
 private val DEFAULT_PAGE = Page.HOME
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
-    private val eventBus: EventBus,
     private val syncService: GodToolsSyncService,
     private val savedState: SavedStateHandle
 ) : ViewModel() {
@@ -52,24 +45,6 @@ class DashboardViewModel @Inject constructor(
         pageStack = pageStack.dropLast(1)
     }
     // endregion Page Stack
-
-    // region Analytics
-    fun trackPageInAnalytics(page: Page) = when (page) {
-        Page.LESSONS -> {
-            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_LESSONS))
-            eventBus.post(FirebaseIamActionEvent(ACTION_IAM_LESSONS))
-        }
-        Page.HOME, Page.FAVORITE_TOOLS -> {
-            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_HOME))
-            eventBus.post(FirebaseIamActionEvent(ACTION_IAM_HOME))
-        }
-        Page.ALL_TOOLS -> {
-            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_ALL_TOOLS))
-            eventBus.post(FirebaseIamActionEvent(ACTION_IAM_ALL_TOOLS))
-        }
-        else -> Unit
-    }
-    // endregion Analytics
 
     // region Sync logic
     private val syncsRunning = MutableStateFlow(0)

--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 android {
     baseConfiguration(project)
+    configureCompose(project)
     createEventBusIndex("org.cru.godtools.analytics.AnalyticsEventBusIndex")
 
     defaultConfig {

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/compose/RecordAnalyticsScreen.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/compose/RecordAnalyticsScreen.kt
@@ -1,0 +1,12 @@
+package org.cru.godtools.analytics.compose
+
+import androidx.compose.runtime.Composable
+import org.ccci.gto.android.common.androidx.lifecycle.compose.OnResume
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
+import org.cru.godtools.base.ui.compose.LocalEventBus
+
+@Composable
+fun RecordAnalyticsScreen(event: AnalyticsScreenEvent) {
+    val eventBus = LocalEventBus.current
+    OnResume(event) { eventBus.post(event) }
+}

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsBaseEvent.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsBaseEvent.kt
@@ -29,4 +29,14 @@ abstract class AnalyticsBaseEvent internal constructor(
             .scheme(SNOWPLOW_CONTENT_SCORING_URI_SCHEME)
 
     open val userCounterName: String? get() = null
+
+    override fun equals(other: Any?) = when {
+        this === other -> true
+        javaClass != other?.javaClass -> false
+        other !is AnalyticsBaseEvent -> false
+        locale != other.locale -> false
+        else -> true
+    }
+
+    override fun hashCode() = locale?.hashCode() ?: 0
 }

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
@@ -65,4 +65,15 @@ open class AnalyticsScreenEvent(val screen: String, locale: Locale? = null) : An
             .appendPath(screen)
 
     override val userCounterName get() = screen
+
+    override fun equals(other: Any?) = when {
+        this === other -> true
+        javaClass != other?.javaClass -> false
+        !super.equals(other) -> false
+        other !is AnalyticsScreenEvent -> false
+        screen != other.screen -> false
+        else -> true
+    }
+
+    override fun hashCode() = (super.hashCode() * 31) + screen.hashCode()
 }

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/compose/CompositionLocals.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/compose/CompositionLocals.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import dagger.hilt.EntryPoint
@@ -20,8 +21,11 @@ val LocalEventBus = staticCompositionLocalOf<EventBus> { error("No EventBus avai
 @Composable
 internal fun CompositionLocals(content: @Composable () -> Unit) {
     val context = LocalContext.current
-    val daggerComponents = remember(context.applicationContext) {
-        EntryPointAccessors.fromApplication<ComposeEntryPoint>(context)
+    val daggerComponents = when {
+        LocalInspectionMode.current -> object : ComposeEntryPoint {
+            override val eventBus = EventBus()
+        }
+        else -> remember { EntryPointAccessors.fromApplication<ComposeEntryPoint>(context) }
     }
 
     val uriHandler = remember(context) {

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/compose/CompositionLocals.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/compose/CompositionLocals.kt
@@ -1,0 +1,46 @@
+package org.cru.godtools.base.ui.compose
+
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import org.cru.godtools.base.ui.util.openUrl
+import org.greenrobot.eventbus.EventBus
+
+val LocalEventBus = staticCompositionLocalOf<EventBus> { error("No EventBus available") }
+
+@Composable
+internal fun CompositionLocals(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val daggerComponents = remember(context.applicationContext) {
+        EntryPointAccessors.fromApplication<ComposeEntryPoint>(context)
+    }
+
+    val uriHandler = remember(context) {
+        object : UriHandler {
+            override fun openUri(uri: String) {
+                context.openUrl(Uri.parse(uri))
+            }
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalEventBus provides daggerComponents.eventBus,
+        LocalUriHandler provides uriHandler,
+        content = content
+    )
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface ComposeEntryPoint {
+    val eventBus: EventBus
+}

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.base.ui.theme
 
-import android.net.Uri
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
@@ -9,13 +8,9 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.unit.sp
-import org.cru.godtools.base.ui.util.openUrl
+import org.cru.godtools.base.ui.compose.CompositionLocals
 
 const val DisabledAlpha = 0.38f
 
@@ -49,7 +44,7 @@ fun GodToolsTheme(content: @Composable () -> Unit) {
         colorScheme = GodToolsLightColorScheme,
         typography = GodToolsTypography
     ) {
-        CompositionLocalUtils {
+        CompositionLocals {
             CompositionLocalProvider(
                 LocalContentColor provides contentColorFor(MaterialTheme.colorScheme.background),
                 content = content
@@ -65,21 +60,3 @@ val GodToolsAppBarColors @Composable get() = TopAppBarDefaults.smallTopAppBarCol
     titleContentColor = MaterialTheme.colorScheme.onPrimary,
     actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
 )
-
-@Composable
-private fun CompositionLocalUtils(content: @Composable () -> Unit) {
-    val context = LocalContext.current
-
-    val uriHandler = remember {
-        object : UriHandler {
-            override fun openUri(uri: String) {
-                context.openUrl(Uri.parse(uri))
-            }
-        }
-    }
-
-    CompositionLocalProvider(
-        LocalUriHandler provides uriHandler,
-        content = content
-    )
-}


### PR DESCRIPTION
- create an EventBus composition local for use within Compose
- provide an EventBus object when in Android Studio Preview mode
- create a RecordAnalyticsScreen composable that will record screen analytics events when the composable is resumed
- update DashboardLayout to use RecordAnalyticsEvent composable
