### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragment.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragment.kt
@@ -158,8 +158,10 @@ class ToolDetailsFragment() :
     }
 
     override fun showToolDetails(code: String?) {
+        if (code == null) return
+
         eventBus.post(OpenAnalyticsActionEvent(ACTION_OPEN_TOOL_DETAILS, code, SOURCE_VARIANTS))
-        dataModel.toolCode.value = code
+        dataModel.setToolCode(code)
     }
 
     override fun pinTool(code: String?) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
@@ -32,6 +32,7 @@ import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
+import org.keynote.godtools.android.db.repository.ToolsRepository
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 
 @HiltViewModel
@@ -43,6 +44,7 @@ class ToolDetailsFragmentDataModel @Inject constructor(
     settings: Settings,
     private val shortcutManager: GodToolsShortcutManager,
     private val toolFileSystem: ToolFileSystem,
+    toolsRepository: ToolsRepository,
     translationsRepository: TranslationsRepository,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
@@ -50,7 +52,7 @@ class ToolDetailsFragmentDataModel @Inject constructor(
     fun setToolCode(code: String) = savedStateHandle.set(EXTRA_TOOL, code)
 
     val tool = toolCode
-        .flatMapLatest { it?.let { dao.findAsFlow<Tool>(it) } ?: flowOf(null) }
+        .flatMapLatest { it?.let { toolsRepository.getToolFlow(it) } ?: flowOf(null) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
     val banner = tool
         .map { it?.detailsBannerId }.distinctUntilChanged()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -15,7 +14,6 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import org.ccci.gto.android.common.androidx.lifecycle.getStateFlow
 import org.ccci.gto.android.common.androidx.lifecycle.orEmpty
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.ccci.gto.android.common.db.Query
@@ -46,9 +44,10 @@ class ToolDetailsFragmentDataModel @Inject constructor(
     private val shortcutManager: GodToolsShortcutManager,
     private val toolFileSystem: ToolFileSystem,
     translationsRepository: TranslationsRepository,
-    savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    val toolCode = savedStateHandle.getStateFlow<String?>(viewModelScope, EXTRA_TOOL, null)
+    val toolCode = savedStateHandle.getStateFlow<String?>(EXTRA_TOOL, null)
+    fun setToolCode(code: String) = savedStateHandle.set(EXTRA_TOOL, code)
 
     val tool = toolCode
         .flatMapLatest { it?.let { dao.findAsFlow<Tool>(it) } ?: flowOf(null) }

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -18,7 +18,7 @@ android {
             project,
             apiUrl = mobileContentApi,
             bundledTools = listOf("kgp", "fourlaws", "satisfied", "teachmetoshare"),
-            bundledAttachments = listOf("attr-banner", "attr-banner-about"),
+            bundledAttachments = listOf("attr-banner", "attr-banner-about", "attr-about-banner-animation"),
             bundledLanguages = listOf("en"),
             downloadTranslations = false
         )

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.base.ui.compose.CompositionLocals
 const val DisabledAlpha = 0.38f
 
 private val GT_BLUE = Color(red = 0x3B, green = 0xA4, blue = 0xDB)
+private val GRAY_BE = Color(red = 0xBE, green = 0xBE, blue = 0xBE)
 val GRAY_E6 = Color(red = 0xE6, green = 0xE6, blue = 0xE6)
 
 private val GodToolsLightColorScheme = lightColorScheme(
@@ -27,7 +28,8 @@ private val GodToolsLightColorScheme = lightColorScheme(
     onSurfaceVariant = Color(90, 90, 90),
     // HACK: We are currently disabling surface tint to avoid using tonal elevation on surfaces.
     //       When we transition to using tonal elevation we can revert this back to the default value
-    surfaceTint = Color.White
+    surfaceTint = Color.White,
+    outline = GRAY_BE,
 )
 
 private val GodToolsTypography = with(Typography()) {

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtils.kt
@@ -7,6 +7,7 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
 import androidx.annotation.DeprecatedSinceApi
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.core.content.res.ResourcesCompat
@@ -31,8 +32,10 @@ private val typefaces = buildMap {
     }
 }
 
-private val FONT_SINHALA = FontFamily(Font(R.font.noto_sans_sinhala_regular))
-private val FONT_TIBETAN = FontFamily(Font(R.font.noto_sans_tibetan_regular))
+@VisibleForTesting
+internal val FONT_SINHALA = FontFamily(Font(R.font.noto_sans_sinhala_regular))
+@VisibleForTesting
+internal val FONT_TIBETAN = FontFamily(Font(R.font.noto_sans_tibetan_regular))
 
 @DeprecatedSinceApi(Build.VERSION_CODES.M)
 fun Context.getTypeface(locale: Locale?) = typefaces[locale]?.let { ResourcesCompat.getFont(this, it) }

--- a/ui/base/src/test/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtilsTest.kt
+++ b/ui/base/src/test/kotlin/org/cru/godtools/base/ui/util/LocaleTypefaceUtilsTest.kt
@@ -1,0 +1,55 @@
+package org.cru.godtools.base.ui.util
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Config.NEWEST_SDK
+import org.robolectric.annotation.Config.OLDEST_SDK
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.LOLLIPOP_MR1, Build.VERSION_CODES.M, NEWEST_SDK])
+class LocaleTypefaceUtilsTest {
+    private val localeSinhala = Locale("si")
+    private val localeSinhalaRegion = Locale("si", "US")
+    private val localeTibetan = Locale("bo")
+    private val localeTibetanRegion = Locale("bo", "US")
+
+    @Test
+    fun `getFontFamilyOrNull() - Locales without compat font`() {
+        assertNull(Locale.ENGLISH.getFontFamilyOrNull())
+        assertNull(Locale.FRENCH.getFontFamilyOrNull())
+    }
+
+    @Test
+    @Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.LOLLIPOP_MR1])
+    fun `getFontFamilyOrNull() - Sinhala Compat`() {
+        assertEquals(FONT_SINHALA, localeSinhala.getFontFamilyOrNull())
+        assertEquals(FONT_SINHALA, localeSinhalaRegion.getFontFamilyOrNull())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M, NEWEST_SDK])
+    fun `getFontFamilyOrNull() - Sinhala Native`() {
+        assertNull(localeSinhala.getFontFamilyOrNull())
+        assertNull(localeSinhalaRegion.getFontFamilyOrNull())
+    }
+
+    @Test
+    @Config(sdk = [OLDEST_SDK, Build.VERSION_CODES.LOLLIPOP_MR1])
+    fun `getFontFamilyOrNull() - Tibetan Compat`() {
+        assertEquals(FONT_TIBETAN, localeTibetan.getFontFamilyOrNull())
+        assertEquals(FONT_TIBETAN, localeTibetanRegion.getFontFamilyOrNull())
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M, NEWEST_SDK])
+    fun `getFontFamilyOrNull() - Tibetan Native`() {
+        assertNull(localeTibetan.getFontFamilyOrNull())
+        assertNull(localeTibetanRegion.getFontFamilyOrNull())
+    }
+}


### PR DESCRIPTION
- Move away from our deprecated getStateFlow method
- bundle about animations in the APK
- add unit tests for getFontFamilyOrNull resolving compat fonts
- define a lighter outline color
- use the ToolsRepository in ToolDetailsFragmentDataModel
