### PR TITLE
cleanup

### DIFF
--- a/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import org.ccci.gto.android.common.dagger.eager.EagerModule
 import org.ccci.gto.android.common.sync.SyncRegistry
 import org.ccci.gto.android.common.sync.SyncTask
+import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.dagger.EventBusModule
 import org.cru.godtools.dagger.ServicesModule
 import org.cru.godtools.sync.GodToolsSyncService
@@ -22,7 +23,11 @@ import org.greenrobot.eventbus.EventBus
 @Module(includes = [EagerModule::class])
 @TestInstallIn(
     components = [SingletonComponent::class],
-    replaces = [EventBusModule::class, ServicesModule::class]
+    replaces = [
+        AnalyticsModule::class,
+        EventBusModule::class,
+        ServicesModule::class,
+    ]
 )
 class ExternalSingletonsModule {
     @get:Provides

--- a/library/api/src/main/kotlin/org/cru/godtools/api/UserCountersApi.kt
+++ b/library/api/src/main/kotlin/org/cru/godtools/api/UserCountersApi.kt
@@ -8,7 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.Path
 
-private const val PATH_USER_COUNTERS = "user/me/counters"
+private const val PATH_USER_COUNTERS = "users/me/counters"
 
 private const val PARAM_COUNTER_ID = "counter_id"
 


### PR DESCRIPTION
- update the user counters API location
- don't wire the AnalyticsModule into the app test dagger graph
