### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -21,7 +21,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.viewbinding.ViewBinding
 import com.google.android.material.navigation.NavigationView
 import com.okta.authfoundation.client.OidcClientResult
-import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundation.credential.Token
 import com.okta.authfoundationbootstrap.CredentialBootstrap
 import com.okta.webauthenticationui.WebAuthenticationClient
@@ -29,7 +28,6 @@ import dagger.Lazy
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.drawerlayout.widget.toggleDrawer
@@ -151,13 +149,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             lifecycleScope.launch {
                 with(oktaCredentials.defaultCredential()) {
                     try {
-                        coroutineScope {
-                            // TODO: use credential.revokeAllTokens() once okta-mobile-kotlin ships a version with it
-                            // credential.revokeAllTokens()
-                            launch { revokeToken(RevokeTokenType.REFRESH_TOKEN) }
-                            launch { revokeToken(RevokeTokenType.DEVICE_SECRET) }
-                            launch { revokeToken(RevokeTokenType.ACCESS_TOKEN) }
-                        }
+                        revokeAllTokens()
                     } finally {
                         delete()
                     }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -70,8 +70,6 @@ object Contract : BaseContract() {
         internal val SQL_CREATE_TABLE =
             create(TABLE_NAME, SQL_COLUMN_ROWID, SQL_COLUMN_CODE, SQL_COLUMN_NAME, SQL_PRIMARY_KEY)
         internal val SQL_DELETE_TABLE = drop(TABLE_NAME)
-
-        internal const val SQL_V39_ALTER_NAME = "ALTER TABLE $TABLE_NAME ADD COLUMN $SQL_COLUMN_NAME"
     }
 
     object ToolTable : BaseTable() {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/GodToolsDatabase.kt
@@ -29,8 +29,6 @@ private const val DATABASE_VERSION = 51
 /*
  * Version history
  *
- * v5.0.13 - v5.0.18
- * 39: 2018-10-24
  * v5.0.19 - v5.1.4
  * 40: 2019-11-12
  * 41: 2020-01-23
@@ -79,7 +77,6 @@ class GodToolsDatabase @Inject internal constructor(@ApplicationContext private 
             var upgradeTo = oldVersion + 1
             while (upgradeTo <= newVersion) {
                 when (upgradeTo) {
-                    39 -> db.execSQL(LanguageTable.SQL_V39_ALTER_NAME)
                     40 -> db.execSQL(ToolTable.SQL_V40_ALTER_DETAILS_BANNER_YOUTUBE)
                     41 -> db.execSQL(GlobalActivityAnalyticsTable.SQL_V41_CREATE_GLOBAL_ANALYTICS)
                     42 -> {

--- a/library/model/src/main/kotlin/org/cru/godtools/model/UserCounter.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/UserCounter.kt
@@ -21,9 +21,9 @@ class UserCounter @JvmOverloads constructor(@JsonApiId val id: String = "") {
 
     @JsonApiAttribute(JSON_COUNT, serialize = false)
     var apiCount: Int = 0
-    val count get() = apiCount + (delta ?: 0)
+    val count get() = apiCount + delta
 
     @JsonApiAttribute(JSON_DECAYED_COUNT, serialize = false)
     var apiDecayedCount: Double = 0.0
-    val decayedCount get() = apiDecayedCount + (delta ?: 0)
+    val decayedCount get() = apiDecayedCount + delta
 }


### PR DESCRIPTION
- utilize the new revokeAllTokens() method when logging a user out
- remove an old db migration
- UserCounter.delta is non-null, so no need to use the elvis operator
