### PR TITLE
GT-1819 Migrate tests to use MockK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -206,7 +206,7 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling-preview"]
 androidx-compose-debug = ["androidx-compose-ui-test-manifest", "androidx-compose-ui-tooling"]
 androidx-compose-testing = ["androidx-compose-ui-test"]
-test-framework = ["junit", "androidx-test-junit", "mockk", "robolectric", "mockito", "mockito-kotlin"]
+test-framework = ["junit", "androidx-test-junit", "mockk", "robolectric", "mockito-kotlin"]
 
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -206,7 +206,7 @@ ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 androidx-compose = ["androidx-compose-runtime", "androidx-compose-ui", "androidx-compose-ui-tooling-preview"]
 androidx-compose-debug = ["androidx-compose-ui-test-manifest", "androidx-compose-ui-tooling"]
 androidx-compose-testing = ["androidx-compose-ui-test"]
-test-framework = ["junit", "androidx-test-junit", "mockk", "robolectric", "mockito-kotlin"]
+test-framework = ["junit", "androidx-test-junit", "mockk", "robolectric"]
 
 [plugins]
 grgit = { id = "org.ajoberstar.grgit", version = "5.0.0" }

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AbstractArticleRoomDatabaseTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AbstractArticleRoomDatabaseTest.kt
@@ -2,15 +2,14 @@ package org.cru.godtools.article.aem.db
 
 import io.mockk.every
 import io.mockk.mockk
-import org.mockito.kotlin.mock
 
 abstract class AbstractArticleRoomDatabaseTest {
-    internal val aemImportDao = mock<AemImportDao>()
-    internal val aemImportRepository = mockk<AemImportRepository>(relaxUnitFun = true)
+    internal val aemImportDao = mockk<AemImportDao>(relaxUnitFun = true)
+    internal val aemImportRepository = mockk<AemImportRepository>()
     internal val articleDao = mockk<ArticleDao>(relaxUnitFun = true)
-    internal val articleRepository = mock<ArticleRepository>()
-    internal val resourceDao = mock<ResourceDao>()
-    internal val resourceRepository = mock<ResourceRepository>()
+    internal val articleRepository = mockk<ArticleRepository>()
+    internal val resourceDao = mockk<ResourceDao>(relaxUnitFun = true)
+    internal val resourceRepository = mockk<ResourceRepository>()
     internal val translationDao = mockk<TranslationDao>(relaxUnitFun = true)
     protected val db = mockk<ArticleRoomDatabase> {
         every { aemImportDao() } returns aemImportDao

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
@@ -1,6 +1,9 @@
 package org.cru.godtools.article.aem.db
 
+import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.coVerifyAll
+import io.mockk.just
 import io.mockk.mockk
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
@@ -12,6 +15,7 @@ class ArticleRepositoryTest : AbstractArticleRoomDatabaseTest() {
 
     @Test
     fun `updateContent()`() = runTest {
+        coEvery { resourceRepository.storeResources(any(), any()) } just Runs
         val article = Article(mockk()).apply {
             contentUuid = UUID.randomUUID().toString()
             content = UUID.randomUUID().toString()

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
@@ -1,9 +1,11 @@
 package org.cru.godtools.article.aem.db
 
 import io.mockk.Called
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerifyAll
 import io.mockk.coVerifySequence
+import io.mockk.just
 import io.mockk.verify
 import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -77,6 +79,7 @@ class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
         }
         val translationRef2 = TranslationRef(translation2.toTranslationRefKey()!!)
         coEvery { translationDao.getAll() } returns listOf(translationRef, translationRef2)
+        coEvery { aemImportRepository.removeOrphanedAemImports() } just Runs
 
         repo.removeMissingTranslations(listOf(translation))
         coVerifySequence {

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -74,5 +74,6 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.mockito.kotlin)
     kaptTest(libs.androidx.databinding.compiler)
 }

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -53,4 +53,5 @@ dependencies {
     kapt(libs.hilt.compiler)
 
     testImplementation(project(":ui:tract-renderer"))
+    testImplementation(libs.mockito.kotlin)
 }

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -40,5 +40,6 @@ dependencies {
     testImplementation(libs.gtoSupport.testing.dagger)
     testImplementation(libs.hilt.testing)
     testImplementation(libs.mockito)
+    testImplementation(libs.mockito.kotlin)
     kaptTest(libs.hilt.compiler)
 }

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -39,5 +39,6 @@ dependencies {
     testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.gtoSupport.testing.dagger)
     testImplementation(libs.hilt.testing)
+    testImplementation(libs.mockito)
     kaptTest(libs.hilt.compiler)
 }

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -39,6 +39,6 @@ dependencies {
 
     testImplementation(project(":library:model"))
     testImplementation(libs.hilt.testing)
-
+    testImplementation(libs.mockito)
     kaptTest(libs.hilt.compiler)
 }

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -40,5 +40,6 @@ dependencies {
     testImplementation(project(":library:model"))
     testImplementation(libs.hilt.testing)
     testImplementation(libs.mockito)
+    testImplementation(libs.mockito.kotlin)
     kaptTest(libs.hilt.compiler)
 }

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyAll
 import java.util.EnumSet
@@ -38,7 +39,6 @@ import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.spy
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
@@ -79,7 +79,7 @@ class GodToolsShortcutManagerTest {
             }
             on { packageManager } doReturn pm
             it.getSystemService<ShortcutManager>()?.let { sm ->
-                shortcutManagerService = spy(sm)
+                shortcutManagerService = spyk(sm)
                 on { getSystemService(ShortcutManager::class.java) } doReturn shortcutManagerService
             }
         }
@@ -142,8 +142,10 @@ class GodToolsShortcutManagerTest {
                 assertTrue(isCancelled)
             }
         }
-        verifyAll { dao.get(any<Query<Tool>>()) }
-        verifyNoInteractions(shortcutManagerService)
+        verifyAll {
+            dao.get(any<Query<Tool>>())
+            shortcutManagerService wasNot Called
+        }
     }
     // endregion Update Existing Shortcuts
 

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -35,9 +35,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.keynote.godtools.android.db.GodToolsDao
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Config.NEWEST_SDK
@@ -67,18 +64,18 @@ class GodToolsShortcutManagerTest {
     fun setup() {
         val rawApp = ApplicationProvider.getApplicationContext<Application>()
         Shadows.shadowOf(rawApp).grantPermissions(INSTALL_SHORTCUT_PERMISSION)
-        app = spy(rawApp) {
-            val pm = spyk(it.packageManager) {
+        app = spyk(rawApp) {
+            val pm = spyk(packageManager) {
                 val shortcutReceiver = ResolveInfo().apply {
                     activityInfo = ActivityInfo().apply { permission = INSTALL_SHORTCUT_PERMISSION }
                 }
                 every { queryBroadcastReceivers(match { it.action == ACTION_INSTALL_SHORTCUT }, 0) }
                     .returns(listOf(shortcutReceiver))
             }
-            on { packageManager } doReturn pm
-            it.getSystemService<ShortcutManager>()?.let { sm ->
+            every { packageManager } returns pm
+            getSystemService<ShortcutManager>()?.let { sm ->
                 shortcutManagerService = spyk(sm)
-                on { getSystemService(ShortcutManager::class.java) } doReturn shortcutManagerService
+                every { getSystemService(ShortcutManager::class.java) } returns shortcutManagerService
             }
         }
     }
@@ -152,7 +149,7 @@ class GodToolsShortcutManagerTest {
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun verifyUpdateDynamicShortcutsOnInstantAppIsANoop() = runTest {
         // Instant Apps don't have access to the system ShortcutManager
-        whenever(app.getSystemService<ShortcutManager>()).thenReturn(null)
+        every { app.getSystemService<ShortcutManager>() } returns null
         val shortcutManager = createShortcutManager()
 
         shortcutManager.updateDynamicShortcuts(emptyMap())

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -35,9 +35,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.keynote.godtools.android.db.GodToolsDao
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import org.robolectric.Shadows
@@ -70,12 +68,12 @@ class GodToolsShortcutManagerTest {
         val rawApp = ApplicationProvider.getApplicationContext<Application>()
         Shadows.shadowOf(rawApp).grantPermissions(INSTALL_SHORTCUT_PERMISSION)
         app = spy(rawApp) {
-            val pm = spy(it.packageManager) { pm ->
+            val pm = spyk(it.packageManager) {
                 val shortcutReceiver = ResolveInfo().apply {
                     activityInfo = ActivityInfo().apply { permission = INSTALL_SHORTCUT_PERMISSION }
                 }
-                doReturn(listOf(shortcutReceiver))
-                    .whenever(pm).queryBroadcastReceivers(argThat { action == ACTION_INSTALL_SHORTCUT }, eq(0))
+                every { queryBroadcastReceivers(match { it.action == ACTION_INSTALL_SHORTCUT }, 0) }
+                    .returns(listOf(shortcutReceiver))
             }
             on { packageManager } doReturn pm
             it.getSystemService<ShortcutManager>()?.let { sm ->

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     testImplementation(libs.hilt.testing)
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.mockito)
+    testImplementation(libs.mockito.kotlin)
     kaptTest(libs.androidx.databinding.compiler)
     kaptTest(libs.hilt.compiler)
 }

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     testImplementation(libs.gtoSupport.testing.picasso)
     testImplementation(libs.hilt.testing)
     testImplementation(libs.kotlin.coroutines.test)
-
+    testImplementation(libs.mockito)
     kaptTest(libs.androidx.databinding.compiler)
     kaptTest(libs.hilt.compiler)
 }


### PR DESCRIPTION
- update Dao mock to utilize MockK
- use MockK to provide the ShortcutManager spy
- use MockK for the PackageManager spy
- use MockK to provide the Application spy
- update article-aem-renderer tests to use MockK
- move Mockito dependency to only projects that still depend on it
- move Mockito Kotlin dependency to projects that still depend on it
