### PR TITLE
cleanup

### DIFF
--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
@@ -6,10 +6,12 @@ import io.mockk.coVerifyAll
 import io.mockk.just
 import io.mockk.mockk
 import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.article.aem.model.Article
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ArticleRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : ArticleRepository(db) {}
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/model/Event.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/model/Event.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.base.tool.model
 
 import java.util.Locale
 import org.cru.godtools.tool.model.EventId
+import org.cru.godtools.tool.model.Manifest
 
 class Event private constructor(builder: Builder) {
     val id = builder.id
@@ -9,10 +10,10 @@ class Event private constructor(builder: Builder) {
     val locale = builder.locale
     val fields = builder.fields.toMap()
 
-    class Builder {
+    class Builder(manifest: Manifest? = null) {
         internal lateinit var id: EventId
-        internal var tool: String? = null
-        internal var locale: Locale? = null
+        internal var tool: String? = manifest?.code
+        internal var locale: Locale? = manifest?.locale
         internal val fields = mutableMapOf<String, String>()
 
         fun id(id: EventId) = apply { this.id = id }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/BaseController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/BaseController.kt
@@ -93,13 +93,9 @@ abstract class BaseController<T : Base> protected constructor(
         if (ids.isNullOrEmpty()) return
         if (!validate(ids)) return
 
-        // try letting a parent build the event object
-        val builder = Event.Builder().apply {
-            tool = model?.manifest?.code
-            locale = model?.manifest?.locale
-        }
-
-        // populate the event with our local state if it wasn't populated by a parent
+        // build the event by walking up the controller hierarchy first in case a parent controller wants to build the
+        // event. If a parent controller doesn't build the event, then we populate the event with our own local state.
+        val builder = Event.Builder(model?.manifest)
         if (!buildEvent(builder)) onBuildEvent(builder, false)
 
         // trigger an event for every id provided

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/cache/UiControllerType.kt
@@ -11,7 +11,6 @@ annotation class UiControllerType(val value: KClass<out Base>, val variation: In
     companion object {
         const val DEFAULT_VARIATION = 0
 
-        fun create(value: KClass<out Base>, variation: Int = DEFAULT_VARIATION) =
-            UiControllerTypeCreator.createUiControllerType(value.java, variation)
+        fun create(value: KClass<out Base>, variation: Int = DEFAULT_VARIATION) = UiControllerType(value, variation)
     }
 }

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/databinding/TractPageCallToActionBindingTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/databinding/TractPageCallToActionBindingTest.kt
@@ -13,7 +13,6 @@ import org.cru.godtools.tool.model.tract.CallToAction
 import org.cru.godtools.tool.model.tract.TractPage
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -72,7 +71,6 @@ class TractPageCallToActionBindingTest {
     }
 
     @Test
-    @Ignore("AGP 7.3.0-alpha03 broke using Data Binding classes from library unit tests.")
     fun verifyArrowOnClickNoEvents() {
         binding.callToAction = callToAction
         binding.executePendingBindings()
@@ -83,7 +81,6 @@ class TractPageCallToActionBindingTest {
     }
 
     @Test
-    @Ignore("AGP 7.3.0-alpha03 broke using Data Binding classes from library unit tests.")
     fun verifyArrowColor() {
         binding.callToAction = CallToAction(controlColor = Color.GREEN)
         binding.executePendingBindings()
@@ -93,7 +90,6 @@ class TractPageCallToActionBindingTest {
     // endregion Arrow Tests
 
     @Test
-    @Ignore("AGP 7.3.0-alpha03 broke using Data Binding classes from library unit tests.")
     fun verifyLabel() {
         binding.callToAction = CallToAction(
             label = { Text(it, text = "Label Test", textAlign = Text.Align.START) }

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -52,7 +52,6 @@ private const val TOOL = "test"
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 @Config(application = HiltTestApplication::class)
-@Ignore("AGP 7.3.0-alpha03 broke using Data Binding classes from library unit tests.")
 class TractActivityTest {
     @get:Rule
     var hiltRule = HiltAndroidRule(this)

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ui/controller/PageControllerTest.kt
@@ -22,7 +22,6 @@ import org.greenrobot.eventbus.EventBus
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,7 +33,6 @@ import org.robolectric.annotation.Config
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 @Config(application = HiltTestApplication::class)
-@Ignore("AGP 7.3.0-alpha03 broke using Data Binding classes from library unit tests.")
 class PageControllerTest {
     @get:Rule
     var hiltRule = HiltAndroidRule(this)


### PR DESCRIPTION
- opt-in to the experimental coroutines APIs
- we no longer need to use auto value to create an instance of the UiControllerType annotation
- initialize the event builder with an optional manifest
- Revert "disable tests that broke in AGP 7.3"
