### PR TITLE
GT-1263 Update UserCounterSync logic to handle multiple users

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepository.kt
@@ -4,4 +4,5 @@ interface LastSyncTimeRepository {
     suspend fun getLastSyncTime(vararg key: Any): Long
     suspend fun isLastSyncStale(vararg key: Any, staleAfter: Long): Boolean
     suspend fun updateLastSyncTime(vararg key: Any)
+    suspend fun resetLastSyncTime(vararg key: Any, isPrefix: Boolean = false)
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/LastSyncTimeDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/LastSyncTimeDao.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.db.room.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -10,7 +11,15 @@ import org.cru.godtools.db.room.entity.LastSyncTimeEntity
 internal interface LastSyncTimeDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertOrReplace(lastSyncTime: LastSyncTimeEntity)
+    @Delete
+    suspend fun delete(lastSyncTimes: Collection<LastSyncTimeEntity>)
 
     @Query("SELECT * FROM last_sync_times WHERE id = :key")
     suspend fun findLastSyncTime(key: String): LastSyncTimeEntity?
+
+    @Query("SELECT * FROM last_sync_times WHERE id LIKE :like")
+    suspend fun getLastSyncTimes(like: String): List<LastSyncTimeEntity>
+
+    @Query("DELETE FROM last_sync_times WHERE id = :key")
+    suspend fun deleteLastSyncTime(key: String)
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/LastSyncTimeEntity.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/LastSyncTimeEntity.kt
@@ -8,6 +8,7 @@ internal class LastSyncTimeEntity(@PrimaryKey val id: String, val time: Long = S
     constructor(key: Array<out Any>) : this(flattenKey(key))
 
     companion object {
-        fun flattenKey(key: Array<out Any>) = key.joinToString(":")
+        const val KEY_SEPARATOR = ":"
+        fun flattenKey(key: Array<out Any>) = key.joinToString(KEY_SEPARATOR)
     }
 }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/SyncTaskModule.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/SyncTaskModule.kt
@@ -39,5 +39,5 @@ abstract class SyncTaskModule {
     @Binds
     @IntoMap
     @SyncTaskKey(UserCounterSyncTasks::class)
-    abstract fun userCounterSyncTasks(tasks: UserCounterSyncTasks): BaseSyncTasks
+    internal abstract fun userCounterSyncTasks(tasks: UserCounterSyncTasks): BaseSyncTasks
 }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
@@ -14,16 +14,18 @@ import org.cru.godtools.db.repository.LastSyncTimeRepository
 import org.cru.godtools.db.repository.UserCountersRepository
 import org.cru.godtools.model.UserCounter
 
-private const val SYNC_TIME_COUNTERS = "last_synced.user_counters"
-private const val STALE_DURATION_COUNTERS = TimeConstants.DAY_IN_MS
-
 @Singleton
-class UserCounterSyncTasks @Inject internal constructor(
+internal class UserCounterSyncTasks @Inject internal constructor(
     private val accountManager: GodToolsAccountManager,
     private val countersApi: UserCountersApi,
     private val lastSyncTimeRepository: LastSyncTimeRepository,
     private val userCountersRepository: UserCountersRepository,
 ) : BaseSyncTasks() {
+    companion object {
+        const val SYNC_TIME_COUNTERS = "last_synced.user_counters"
+        private const val STALE_DURATION_COUNTERS = TimeConstants.DAY_IN_MS
+    }
+
     private val countersMutex = Mutex()
     private val countersUpdateMutex = Mutex()
 

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.sync.task
 
-import android.os.Bundle
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.async
@@ -28,12 +27,12 @@ class UserCounterSyncTasks @Inject internal constructor(
     private val countersMutex = Mutex()
     private val countersUpdateMutex = Mutex()
 
-    suspend fun syncCounters(args: Bundle = Bundle.EMPTY): Boolean = countersMutex.withLock {
+    suspend fun syncCounters(force: Boolean): Boolean = countersMutex.withLock {
         if (!accountManager.isAuthenticated()) return true
         val userId = accountManager.userId().orEmpty()
 
         // short-circuit if we aren't forcing a sync and the data isn't stale
-        if (!isForced(args) &&
+        if (!force &&
             !lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, userId, staleAfter = STALE_DURATION_COUNTERS)
         ) return true
 

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasks.kt
@@ -47,6 +47,7 @@ class UserCounterSyncTasks @Inject internal constructor(
             counters.forEach { existing.remove(it.id) }
             userCountersRepository.resetCountersMissingFromSync(existing.values)
         }
+        lastSyncTimeRepository.resetLastSyncTime(SYNC_TIME_COUNTERS, isPrefix = true)
         lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_COUNTERS, userId)
 
         true

--- a/library/sync/src/test/kotlin/org/cru/godtools/db/repository/InMemoryLastSyncTimeRepository.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/db/repository/InMemoryLastSyncTimeRepository.kt
@@ -1,0 +1,25 @@
+package org.cru.godtools.db.repository
+
+// TODO: this should be a testFixture in :library:db once Kotlin Android Test Fixtures are supported
+//       see: https://youtrack.jetbrains.com/issue/KT-50667
+class InMemoryLastSyncTimeRepository : LastSyncTimeRepository {
+    val entries = mutableMapOf<List<Any>, Long>()
+
+    override suspend fun getLastSyncTime(vararg key: Any) = entries[key.toList()] ?: 0
+
+    override suspend fun isLastSyncStale(vararg key: Any, staleAfter: Long): Boolean {
+        val time = entries[key.toList()] ?: return true
+        return time + staleAfter < System.currentTimeMillis()
+    }
+
+    override suspend fun updateLastSyncTime(vararg key: Any) {
+        entries[key.toList()] = System.currentTimeMillis()
+    }
+
+    override suspend fun resetLastSyncTime(vararg key: Any, isPrefix: Boolean) {
+        entries.remove(key.toList())
+        if (isPrefix) {
+            entries.keys.removeIf { key.toList() == it.take(key.size) }
+        }
+    }
+}

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasksTest.kt
@@ -1,0 +1,98 @@
+package org.cru.godtools.sync.task
+
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coExcludeRecords
+import io.mockk.coVerify
+import io.mockk.coVerifyAll
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.ccci.gto.android.common.base.TimeConstants.WEEK_IN_MS
+import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
+import org.cru.godtools.account.GodToolsAccountManager
+import org.cru.godtools.api.UserCountersApi
+import org.cru.godtools.db.repository.InMemoryLastSyncTimeRepository
+import org.cru.godtools.db.repository.UserCountersRepository
+import org.cru.godtools.sync.task.UserCounterSyncTasks.Companion.SYNC_TIME_COUNTERS
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+private const val USER_ID = "user_id"
+private const val USER_ID_OTHER = "user_id_other"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserCounterSyncTasksTest {
+    private val accountManager: GodToolsAccountManager = mockk {
+        coEvery { isAuthenticated() } returns true
+        coEvery { userId() } returns USER_ID
+    }
+    private val countersApi: UserCountersApi = mockk {
+        coEvery { getCounters() } returns Response.success(JsonApiObject.of())
+    }
+    private val lastSyncTimeRepository = spyk(InMemoryLastSyncTimeRepository())
+    private val userCountersRepository: UserCountersRepository = mockk {
+        coEvery { transaction(any<suspend () -> Unit>()) } answers { callOriginal() }
+
+        coExcludeRecords { transaction(any()) }
+    }
+
+    private val tasks =
+        UserCounterSyncTasks(accountManager, countersApi, lastSyncTimeRepository, userCountersRepository)
+
+    // region syncCounters()
+    @Test
+    fun `syncCounters() - not authenticated`() = runTest {
+        coEvery { accountManager.isAuthenticated() } returns false
+
+        assertTrue(tasks.syncCounters(false))
+        coVerifyAll {
+            accountManager.isAuthenticated()
+            countersApi wasNot Called
+            lastSyncTimeRepository wasNot Called
+        }
+    }
+
+    @Test
+    fun `syncCounters(force = false) - already synced`() = runTest {
+        coEvery {
+            lastSyncTimeRepository.isLastSyncStale(key = anyVararg<String>(), staleAfter = any())
+        } returns false
+
+        assertTrue(tasks.syncCounters(force = false))
+        coVerifyAll {
+            accountManager.isAuthenticated()
+            accountManager.userId()
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, USER_ID, staleAfter = any())
+            countersApi wasNot Called
+        }
+    }
+
+    @Test
+    fun `syncCounters(force = true)`() = runTest {
+        assertTrue(tasks.syncCounters(force = true))
+        coVerifyAll {
+            accountManager.isAuthenticated()
+            accountManager.userId()
+            countersApi.getCounters()
+            lastSyncTimeRepository.resetLastSyncTime(any(), isPrefix = true)
+            lastSyncTimeRepository.updateLastSyncTime(any(), any())
+        }
+    }
+
+    @Test
+    fun `syncCounters() - reset LastSyncTime for other users`() = runTest {
+        lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_COUNTERS, USER_ID_OTHER)
+        assertTrue(lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, USER_ID, staleAfter = WEEK_IN_MS))
+        assertFalse(lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, USER_ID_OTHER, staleAfter = WEEK_IN_MS))
+
+        assertTrue(tasks.syncCounters(false))
+        coVerify { countersApi.getCounters() }
+        assertFalse(lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, USER_ID, staleAfter = WEEK_IN_MS))
+        assertTrue(lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_COUNTERS, USER_ID_OTHER, staleAfter = WEEK_IN_MS))
+    }
+    // endregion syncCounters()
+}


### PR DESCRIPTION
The main thing this PR is attempting to workaround is a corner-case with non-forced syncs when the app user switches which Okta account they are logged into between 2 accounts. This could lead to stale user counters being used for up to 24 hours until fresh data would be transparently synced.

Potential flow of events:
- app logged in as User A
- app syncs counters, app marks that counters for user A have been synced and don't attempt another sync for 24 hours
- app logs out of User A & into User B
- app syncs counters, replaces User A counters in the database, app marks User B counters as having been synced
- app logs out of User B & back into User A
- app attempts to sync counters, but short-circuits because user A counters were synced less than 24 hours ago