### PR TITLE
cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,12 +38,6 @@ android {
         viewBinding = true
     }
 
-    packagingOptions {
-        // XXX: Exclude Kotlin metadata to reduce the size of the APK.
-        //      If we ever start utilizing kotlin reflection this will need to be removed.
-        resources.excludes += "**/*.kotlin_*"
-    }
-
     createEventBusIndex("org.cru.godtools.AppEventBusIndex")
     kapt {
         javacOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,9 @@ android {
         dataBinding = true
         viewBinding = true
     }
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 
     createEventBusIndex("org.cru.godtools.AppEventBusIndex")
     kapt {
@@ -116,6 +119,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.android.desugaring)
+
     api(project(":library:api"))
     api(project(":library:db"))
     api(project(":library:download-manager"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ accompanist-pager = { module = "com.google.accompanist:accompanist-pager", versi
 accompanist-pager-indicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "accompanist" }
 accompanist-swiperefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "accompanist" }
 advrecyclerview = "com.h6ah4i.android.widget.advrecyclerview:advrecyclerview:1.0.0"
+android-desugaring = "com.android.tools:desugar_jdk_libs:1.2.2"
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
 androidx-activity-compose = "androidx.activity:activity-compose:1.6.0"
 androidx-annotation = "androidx.annotation:annotation:1.5.0"

--- a/library/account/src/main/kotlin/org/cru/godtools/account/provider/okta/OktaModule.kt
+++ b/library/account/src/main/kotlin/org/cru/godtools/account/provider/okta/OktaModule.kt
@@ -30,7 +30,6 @@ import okhttp3.OkHttpClient
 import org.ccci.gto.android.common.okta.authfoundation.credential.ChangeAwareTokenStorage.Companion.makeChangeAware
 import org.ccci.gto.android.common.okta.authfoundation.credential.SharedPreferencesTokenStorage
 import org.ccci.gto.android.common.okta.authfoundation.credential.migrateTo
-import org.ccci.gto.android.common.okta.authfoundation.enableClockCompat
 import org.ccci.gto.android.common.okta.datastore.DataStoreTokenStorage
 import org.ccci.gto.android.common.okta.oidc.storage.security.NoopEncryptionManager
 import org.ccci.gto.android.common.okta.oidc.storage.security.createDefaultEncryptionManager
@@ -54,7 +53,6 @@ internal abstract class OktaModule {
             buildConfig: OktaBuildConfig,
             okhttp: OkHttpClient
         ): OidcClient {
-            AuthFoundationDefaults.enableClockCompat()
             AuthFoundationDefaults.cache = SharedPreferencesCache.create(context)
             AuthFoundationDefaults.okHttpClientFactory = { okhttp }
             val config = OidcConfiguration(buildConfig.clientId, OKTA_SCOPE)

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("com.android.library")
     kotlin("android")
@@ -19,10 +17,6 @@ android {
         dataBinding = true
         viewBinding = true
     }
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += listOf("-module-name", "base-ui")
 }
 
 dependencies {


### PR DESCRIPTION
- there shouldn't be a need to rename the kotlin module name anymore
- enable core library desugaring for the app
- now that we are desugaring java 8 time classes, we no longer need to enable a compat clock
