### PR TITLE
GT-1828 Configure OneSky gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,14 @@ GodTools Android
 
 [![codecov](https://codecov.io/gh/CruGlobal/godtools-android/branch/develop/graph/badge.svg)](https://codecov.io/gh/CruGlobal/godtools-android)
 
-The Android native version of the GodTools mobile application.
+# OneSky
+
+To enable OneSky translation downloads/uploads configure the following [gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties):
+```
+ONESKY_API_KEY={apiKey}
+ONESKY_API_SECRET={apiSecret}
+```
+
+Once those properties are configured you can use the following commands:
+- Download the latest translations: `./gradlew downloadTranslations --no-parallel`
+- Upload the latest base strings: `./gradlew uploadTranslations`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,6 +118,17 @@ android {
     dynamicFeatures += ":feature:bundledcontent"
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings.xml",
+        "strings_about.xml",
+        "strings_dashboard.xml",
+        "strings_features.xml",
+        "strings_profile.xml",
+        "strings_tool_details.xml",
+    )
+}
+
 dependencies {
     coreLibraryDesugaring(libs.android.desugaring)
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 repositories {
     google()
     mavenCentral()
+    gradlePluginPortal()
 }
 
 configurations.configureEach {
@@ -20,4 +21,5 @@ dependencies {
     implementation(libs.gradleDownloadTask)
     implementation(libs.json)
     implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.onesky.gradlePlugin)
 }

--- a/buildSrc/src/main/kotlin/OneSkyConfiguration.kt
+++ b/buildSrc/src/main/kotlin/OneSkyConfiguration.kt
@@ -1,5 +1,6 @@
 import co.brainly.onesky.OneSkyPluginExtension
 import co.brainly.onesky.task.DEPRECATE_STRINGS_FLAG
+import co.brainly.onesky.task.DownloadTranslationsTask
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
@@ -21,5 +22,26 @@ fun Project.onesky(configuration: OneSkyPluginExtension.() -> Unit) {
         // downloadBaseLanguage = true
 
         configuration()
+
+        // handle legacy locales for Hebrew & Indonesian
+        tasks.named("downloadTranslations", DownloadTranslationsTask::class.java) {
+            doLast {
+                val valuesHe = file(sourcePath).resolve("values-he")
+                val valuesIw = file(sourcePath).resolve("values-iw")
+                val valuesIn = file(sourcePath).resolve("values-in")
+                val valuesId = file(sourcePath).resolve("values-id")
+
+                sourceStringFiles.forEach { file ->
+                    // copy Locale(he) to legacy Locale(iw)
+                    valuesHe.resolve(file).takeIf { it.exists() }
+                        ?.copyTo(valuesIw.resolve(file), overwrite = true)
+
+                    // copy legacy Locale(in) to Locale(id)
+                    // the onesky plugin internally changes Locale(id) to Locale(in), so we need to reverse this copy
+                    valuesIn.resolve(file).takeIf { it.exists() }
+                        ?.copyTo(valuesId.resolve(file), overwrite = true)
+                }
+            }
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/OneSkyConfiguration.kt
+++ b/buildSrc/src/main/kotlin/OneSkyConfiguration.kt
@@ -1,0 +1,25 @@
+import co.brainly.onesky.OneSkyPluginExtension
+import co.brainly.onesky.task.DEPRECATE_STRINGS_FLAG
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.extra
+
+private const val PROP_API_KEY = "ONESKY_API_KEY"
+private const val PROP_API_SECRET = "ONESKY_API_SECRET"
+
+fun Project.onesky(configuration: OneSkyPluginExtension.() -> Unit) {
+    extra.set(DEPRECATE_STRINGS_FLAG, true)
+    apply(plugin = "co.brainly.onesky")
+
+    configure<OneSkyPluginExtension> {
+        apiKey = findProperty(PROP_API_KEY)?.toString().orEmpty()
+        apiSecret = findProperty(PROP_API_SECRET)?.toString().orEmpty()
+        projectId = 253275
+
+        // TODO: enable this after https://github.com/brainly/onesky-gradle-plugin/pull/6 is merged & released
+        // downloadBaseLanguage = true
+
+        configuration()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -171,6 +171,7 @@ okta-auth-foundation = { module = "com.okta.kotlin:auth-foundation", version.ref
 okta-auth-foundation-bootstrap = { module = "com.okta.kotlin:auth-foundation-bootstrap", version.ref = "okta" }
 okta-legacy-tokens = { module = "com.okta.kotlin:legacy-token-migration", version.ref = "okta" }
 okta-web-authentication-ui = { module = "com.okta.kotlin:web-authentication-ui", version.ref = "okta" }
+onesky-gradlePlugin = "co.brainly:plugin:1.3.0"
 picasso = "com.squareup.picasso:picasso:2.8"
 picasso-transformations = "jp.wasabeef:picasso-transformations:2.4.0"
 play-core = "com.google.android.play:core:1.10.3"

--- a/library/base/build.gradle.kts
+++ b/library/base/build.gradle.kts
@@ -10,6 +10,12 @@ android {
     baseConfiguration(project)
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_language_names.xml",
+    )
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.livedata.ktx)

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -19,6 +19,12 @@ android {
     }
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_tool_renderer.xml",
+    )
+}
+
 dependencies {
     api(project(":library:analytics"))
     api(project(":library:db"))

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -19,6 +19,12 @@ android {
     }
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_base_ui.xml",
+    )
+}
+
 dependencies {
     api(project(":library:base"))
     implementation(project(":library:model"))

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -13,6 +13,12 @@ android {
     buildFeatures.dataBinding = true
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_cyoa_renderer.xml",
+    )
+}
+
 dependencies {
     api(project(":ui:base-tool"))
     implementation(project(":ui:tips-renderer"))

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -13,6 +13,12 @@ android {
     buildFeatures.dataBinding = true
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_lesson_feedback.xml",
+    )
+}
+
 dependencies {
     api(project(":ui:base-tool"))
 

--- a/ui/tips-renderer/build.gradle.kts
+++ b/ui/tips-renderer/build.gradle.kts
@@ -14,6 +14,12 @@ android {
     buildFeatures.dataBinding = true
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_tips_renderer.xml",
+    )
+}
+
 dependencies {
     api(project(":ui:base-tool"))
     implementation(project(":library:model"))

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -19,6 +19,12 @@ android {
     }
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_tract_renderer.xml"
+    )
+}
+
 dependencies {
     api(project(":ui:base-tool"))
     api(project(":ui:tutorial-renderer"))

--- a/ui/tutorial-renderer/build.gradle.kts
+++ b/ui/tutorial-renderer/build.gradle.kts
@@ -16,6 +16,15 @@ android {
     }
 }
 
+onesky {
+    sourceStringFiles = listOf(
+        "strings_tutorial_features.xml",
+        "strings_tutorial_liveshare.xml",
+        "strings_tutorial_onboarding.xml",
+        "strings_tutorial_tips.xml",
+    )
+}
+
 dependencies {
     implementation(project(":library:analytics"))
     implementation(project(":library:base"))


### PR DESCRIPTION
This configures the `uploadTranslations` and `downloadTranslations` tasks for all subprojects that contain translation files.

There are a few outstanding issues that prevent us from using a GHA workflow for this currently:
- The plugin doesn't support downloading changes to the base language from OneSky. I have opened a PR with the plugin to address this use case
- OneSky currently uses an older version of the CLDR database than Android. This means that exporting French plurals from OneSky will not pass Android lint checks. Manual intervention is required in these cases to fix the broken French plurals
- You have to use the `--no-parallel` command line option when downloading translations to avoid hitting OneSky API rate limits. It might be possible to use `--max-workers #` to restrict the number of threads and not hit the rate limit, but I didn't test where the # of threads threshold should be