### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/account/globalactivity/GlobalActivityLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/globalactivity/GlobalActivityLayout.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import java.util.Calendar
+import java.time.Year
 import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
 import org.ccci.gto.android.common.androidx.compose.foundation.text.minLinesHeight
 import org.ccci.gto.android.common.androidx.compose.ui.text.computeHeightForDefaultText
@@ -35,7 +35,7 @@ fun AccountGlobalActivityLayout() = Column(modifier = Modifier.padding(horizonta
     val activity by viewModel.activity.collectAsState()
 
     Text(
-        stringResource(R.string.profile_global_activity_heading, Calendar.getInstance().get(Calendar.YEAR)),
+        stringResource(R.string.profile_global_activity_heading, Year.now().value),
         style = MaterialTheme.typography.titleLarge,
         modifier = Modifier.padding(top = 32.dp)
     )

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardViewModel.kt
@@ -23,11 +23,8 @@ class DashboardViewModel @Inject constructor(
 ) : ViewModel() {
     // region Page Stack
     private var pageStack: List<Page>
-        get() = savedState.get<ArrayList<Page>>(KEY_PAGE_STACK)?.toList()
-            ?: listOf(DEFAULT_PAGE)
-        set(value) {
-            savedState[KEY_PAGE_STACK] = ArrayList(value)
-        }
+        get() = savedState.get<List<Page>>(KEY_PAGE_STACK)?.toList() ?: listOf(DEFAULT_PAGE)
+        set(value) { savedState[KEY_PAGE_STACK] = ArrayList(value) }
     private val pageStackFlow = savedState.getStateFlow(KEY_PAGE_STACK, listOf(DEFAULT_PAGE))
 
     val hasBackStack = pageStackFlow

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,6 @@ org.gradle.parallel=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 
-# maven POM attributes
-POM_SCM_CONNECTION = git@github.com:CruGlobal/godtools-android.git
-
-
 # signing config
 androidKeystorePath=non-existant-keystore-dont-create-me.store
 androidKeystoreStorePassword=


### PR DESCRIPTION
- Lazily inject the WorkManager into the SyncService
- use the Java8 time APIs for determining the current year
- avoid a potential casting issue when reading the page stack from the savedState
- remove unused gradle property
