### PR TITLE
GT-1854 Track which languages are used to render tools

### DIFF
--- a/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
+++ b/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/ui/AemArticleActivity.kt
@@ -122,9 +122,7 @@ class AemArticleActivity :
         if (!pendingAnalyticsEvent) return
 
         article?.let {
-            eventBus.post(
-                ArticleAnalyticsScreenEvent(it, manifestDataModel.toolCode.value, manifestDataModel.locale.value)
-            )
+            eventBus.post(ArticleAnalyticsScreenEvent(it, dataModel.toolCode.value, dataModel.locale.value))
             pendingAnalyticsEvent = false
         }
     }

--- a/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
+++ b/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
@@ -7,11 +7,12 @@ import android.view.MenuItem
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.lifecycle.asLiveData
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
-import org.ccci.gto.android.common.androidx.lifecycle.notNull
+import kotlinx.coroutines.flow.filterNotNull
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.cru.godtools.article.aem.model.Article
 import org.cru.godtools.article.aem.ui.startAemArticleActivity
@@ -91,7 +92,7 @@ class ArticlesActivity :
         supportFragmentManager.addOnBackStackChangedListener { updateToolbarTitle() }
 
         // load the primaryNavigationFragment if one doesn't already exist
-        dataModel.manifest.notNull().observeOnce(this) {
+        dataModel.manifest.filterNotNull().asLiveData().observeOnce(this) {
             if (supportFragmentManager.primaryNavigationFragment != null) return@observeOnce
 
             when (it.categories.size) {

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     api(project(":library:db"))
     api(project(":library:download-manager"))
     api(project(":library:sync"))
+    api(project(":library:user-data"))
     api(project(":ui:base"))
     implementation(project(":library:base"))
     implementation(project(":library:model"))

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     kapt(libs.google.auto.value)
     kapt(libs.hilt.compiler)
 
+    testImplementation(kotlin("test"))
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.kotlin.coroutines.test)

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -80,5 +80,6 @@ dependencies {
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.turbine)
     kaptTest(libs.androidx.databinding.compiler)
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -18,7 +18,6 @@ import org.ccci.gto.android.common.util.os.getLocale
 import org.ccci.gto.android.common.util.os.putLocale
 import org.cru.godtools.base.EXTRA_LANGUAGE
 import org.cru.godtools.base.EXTRA_TOOL
-import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import org.cru.godtools.model.Language
 import org.cru.godtools.shared.tool.parser.model.Manifest
 
@@ -30,7 +29,6 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
     override val activeManifestLiveData get() = dataModel.manifest
 
     protected open val dataModel: BaseSingleToolActivityDataModel by viewModels()
-    protected val manifestDataModel: LatestPublishedManifestDataModel get() = dataModel
 
     // region Intent processing
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.viewModels
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
 import androidx.databinding.ViewDataBinding
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
 import java.util.Locale
@@ -69,7 +68,7 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
             .stateIn(lifecycleScope, SharingStarted.WhileSubscribed(), emptyList())
     }
     override val localesToDownload by lazy {
-        dataModel.locale.asFlow()
+        dataModel.locale
             .map { listOfNotNull(it) }
             .stateIn(lifecycleScope, SharingStarted.WhileSubscribed(), emptyList())
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.viewModels
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
 import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
 import java.util.Locale
@@ -25,8 +26,6 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
     private val requireTool: Boolean,
     private val supportedType: Manifest.Type?
 ) : BaseToolActivity<B>(contentLayoutId) {
-    override val activeManifestLiveData get() = dataModel.manifest
-
     override val viewModel: BaseSingleToolActivityDataModel by viewModels()
     protected open val dataModel get() = viewModel
 
@@ -75,7 +74,7 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
 
     override val activeDownloadProgressLiveData get() = dataModel.downloadProgress
     override val activeToolLoadingStateLiveData by lazy {
-        activeManifestLiveData.combineWith(dataModel.translation, isConnected) { m, t, isConnected ->
+        viewModel.manifest.asLiveData().combineWith(dataModel.translation, isConnected) { m, t, isConnected ->
             LoadingState.determineToolState(m, t, manifestType = supportedType, isConnected = isConnected)
         }.distinctUntilChanged()
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -64,7 +64,7 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
         }
 
     override val toolsToDownload by lazy {
-        dataModel.toolCode.asFlow()
+        dataModel.toolCode
             .map { listOfNotNull(it) }
             .stateIn(lifecycleScope, SharingStarted.WhileSubscribed(), emptyList())
     }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivity.kt
@@ -28,7 +28,8 @@ abstract class BaseSingleToolActivity<B : ViewDataBinding>(
 ) : BaseToolActivity<B>(contentLayoutId) {
     override val activeManifestLiveData get() = dataModel.manifest
 
-    protected open val dataModel: BaseSingleToolActivityDataModel by viewModels()
+    override val viewModel: BaseSingleToolActivityDataModel by viewModels()
+    protected open val dataModel get() = viewModel
 
     // region Intent processing
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.base.tool.activity
 
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Locale
 import javax.inject.Inject
@@ -16,7 +15,7 @@ open class BaseSingleToolActivityDataModel @Inject constructor(
     manifestManager: ManifestManager,
     downloadManager: GodToolsDownloadManager,
     translationsRepository: TranslationsRepository
-) : ViewModel() {
+) : BaseToolRendererViewModel() {
     val toolCode = MutableLiveData<String?>()
     val locale = MutableLiveData<Locale?>()
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -1,10 +1,9 @@
 package org.cru.godtools.base.tool.activity
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.asLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.Locale
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
 import org.ccci.gto.android.common.kotlin.coroutines.flow.combineTransformLatest
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -15,11 +14,9 @@ import org.keynote.godtools.android.db.repository.TranslationsRepository
 open class BaseSingleToolActivityDataModel @Inject constructor(
     manifestManager: ManifestManager,
     downloadManager: GodToolsDownloadManager,
-    translationsRepository: TranslationsRepository
-) : BaseToolRendererViewModel() {
-    val toolCode = MutableStateFlow<String?>(null)
-    val locale = MutableStateFlow<Locale?>(null)
-
+    translationsRepository: TranslationsRepository,
+    savedState: SavedStateHandle,
+) : BaseToolRendererViewModel(savedState) {
     val manifest = toolCode.combineTransformLatest(locale) { tool, locale ->
         when {
             tool == null || locale == null -> emit(null)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -1,11 +1,13 @@
 package org.cru.godtools.base.tool.activity
 
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Locale
 import javax.inject.Inject
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.switchCombineWith
 import org.cru.godtools.base.tool.service.ManifestManager
-import org.cru.godtools.base.tool.viewmodel.LatestPublishedManifestDataModel
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 
@@ -14,7 +16,17 @@ open class BaseSingleToolActivityDataModel @Inject constructor(
     manifestManager: ManifestManager,
     downloadManager: GodToolsDownloadManager,
     translationsRepository: TranslationsRepository
-) : LatestPublishedManifestDataModel(manifestManager) {
+) : ViewModel() {
+    val toolCode = MutableLiveData<String?>()
+    val locale = MutableLiveData<Locale?>()
+
+    val manifest = toolCode.switchCombineWith(locale) { code, locale ->
+        when {
+            code == null || locale == null -> emptyLiveData()
+            else -> manifestManager.getLatestPublishedManifestLiveData(code, locale)
+        }
+    }
+
     val translation = toolCode.switchCombineWith(locale) { code, locale ->
         when {
             code == null || locale == null -> emptyLiveData()

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -16,14 +16,7 @@ open class BaseSingleToolActivityDataModel @Inject constructor(
     downloadManager: GodToolsDownloadManager,
     translationsRepository: TranslationsRepository,
     savedState: SavedStateHandle,
-) : BaseToolRendererViewModel(savedState) {
-    val manifest = toolCode.combineTransformLatest(locale) { tool, locale ->
-        when {
-            tool == null || locale == null -> emit(null)
-            else -> emitAll(manifestManager.getLatestPublishedManifestFlow(tool, locale))
-        }
-    }.asLiveData()
-
+) : BaseToolRendererViewModel(manifestManager, savedState) {
     val translation = toolCode.combineTransformLatest(locale) { tool, locale ->
         when {
             tool == null || locale == null -> emit(null)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseSingleToolActivityDataModel.kt
@@ -8,15 +8,17 @@ import kotlinx.coroutines.flow.emitAll
 import org.ccci.gto.android.common.kotlin.coroutines.flow.combineTransformLatest
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.GodToolsDownloadManager
+import org.cru.godtools.user.activity.UserActivityManager
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 
 @HiltViewModel
 open class BaseSingleToolActivityDataModel @Inject constructor(
-    manifestManager: ManifestManager,
     downloadManager: GodToolsDownloadManager,
+    manifestManager: ManifestManager,
     translationsRepository: TranslationsRepository,
+    userActivityManager: UserActivityManager,
     savedState: SavedStateHandle,
-) : BaseToolRendererViewModel(manifestManager, savedState) {
+) : BaseToolRendererViewModel(manifestManager, userActivityManager, savedState) {
     val translation = toolCode.combineTransformLatest(locale) { tool, locale ->
         when {
             tool == null || locale == null -> emit(null)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -73,6 +73,8 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     @Named(IS_CONNECTED_LIVE_DATA)
     internal lateinit var isConnected: LiveData<Boolean>
 
+    protected abstract val viewModel: BaseToolRendererViewModel
+
     // region Lifecycle
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -13,6 +13,7 @@ import androidx.annotation.StringRes
 import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.map
@@ -94,7 +95,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
 
     @CallSuper
     override fun onBindingChanged() {
-        binding.setVariable(BR.manifest, activeManifestLiveData)
+        binding.setVariable(BR.manifest, viewModel.manifest.asLiveData())
         binding.setVariable(BR.loadingProgress, activeDownloadProgressLiveData)
         binding.setVariable(BR.loadingState, activeToolLoadingStateLiveData)
     }
@@ -140,7 +141,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     /**
      * @return The currently active manifest that is a valid supported type for this activity, otherwise return null.
      */
-    protected val activeManifest get() = activeManifestLiveData.value
+    protected val activeManifest get() = viewModel.manifest.value
 
     // region Status Bar / Toolbar logic
     override val toolbar get() = when (val it = binding) {
@@ -151,7 +152,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     private fun setupStatusBar() {
         window.apply {
             addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            activeManifestLiveData.observe(this@BaseToolActivity) {
+            viewModel.manifest.asLiveData().observe(this@BaseToolActivity) {
                 statusBarColor = it.navBarColor.toHslColor().darken(0.12f).toColorInt()
             }
         }
@@ -252,7 +253,6 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     }
 
     protected abstract val activeDownloadProgressLiveData: LiveData<DownloadProgress?>
-    protected abstract val activeManifestLiveData: LiveData<Manifest?>
     protected abstract val activeToolLoadingStateLiveData: LiveData<LoadingState>
     // endregion Tool state
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
@@ -1,5 +1,19 @@
 package org.cru.godtools.base.tool.activity
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import java.util.Locale
+import org.ccci.gto.android.common.androidx.lifecycle.getMutableStateFlow
+import org.cru.godtools.base.EXTRA_TOOL
 
-abstract class BaseToolRendererViewModel : ViewModel()
+open class BaseToolRendererViewModel(
+    savedState: SavedStateHandle,
+) : ViewModel() {
+    protected companion object {
+        internal const val STATE_ACTIVE_LOCALE = "activeLocale"
+    }
+
+    val toolCode = savedState.getMutableStateFlow<String?>(viewModelScope, EXTRA_TOOL, null)
+    val locale = savedState.getMutableStateFlow<Locale?>(viewModelScope, STATE_ACTIVE_LOCALE, null)
+}

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
@@ -4,16 +4,36 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import java.util.Locale
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.stateIn
 import org.ccci.gto.android.common.androidx.lifecycle.getMutableStateFlow
+import org.ccci.gto.android.common.kotlin.coroutines.flow.combineTransformLatest
 import org.cru.godtools.base.EXTRA_TOOL
+import org.cru.godtools.base.tool.service.ManifestManager
+import org.cru.godtools.shared.tool.parser.model.Manifest
 
 open class BaseToolRendererViewModel(
+    manifestManager: ManifestManager,
     savedState: SavedStateHandle,
 ) : ViewModel() {
     protected companion object {
         internal const val STATE_ACTIVE_LOCALE = "activeLocale"
     }
 
+    val supportedType = MutableStateFlow<Manifest.Type?>(null)
     val toolCode = savedState.getMutableStateFlow<String?>(viewModelScope, EXTRA_TOOL, null)
     val locale = savedState.getMutableStateFlow<Locale?>(viewModelScope, STATE_ACTIVE_LOCALE, null)
+
+    val manifest = toolCode
+        .combineTransformLatest(locale) { tool, locale ->
+            when {
+                tool == null || locale == null -> emit(null)
+                else -> emitAll(manifestManager.getLatestPublishedManifestFlow(tool, locale))
+            }
+        }
+        .combine(supportedType) { m, t -> m?.takeIf { t == null || it.type == t } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModel.kt
@@ -1,0 +1,5 @@
+package org.cru.godtools.base.tool.activity
+
+import androidx.lifecycle.ViewModel
+
+abstract class BaseToolRendererViewModel : ViewModel()

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -166,7 +166,6 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // endregion Tool sync
 
     // region Active Translation management
-    override val activeManifestLiveData get() = dataModel.activeManifest
     override val activeToolLoadingStateLiveData get() = dataModel.activeLoadingState
     // endregion Active Translation management
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -66,7 +66,8 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     // endregion Lifecycle
 
     // region Data Model
-    protected open val dataModel: MultiLanguageToolActivityDataModel by viewModels()
+    override val viewModel: MultiLanguageToolActivityDataModel by viewModels()
+    protected open val dataModel get() = viewModel
 
     private fun setupDataModel() {
         dataModel.supportedType.value = supportedType

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -23,7 +23,6 @@ import org.ccci.gto.android.common.androidx.lifecycle.and
 import org.ccci.gto.android.common.androidx.lifecycle.combine
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.emptyLiveData
-import org.ccci.gto.android.common.androidx.lifecycle.getMutableStateFlow
 import org.ccci.gto.android.common.androidx.lifecycle.livedata
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observe
@@ -59,8 +58,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     translationsRepository: TranslationsRepository,
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
     savedState: SavedStateHandle,
-) : BaseToolRendererViewModel() {
-    val toolCode = savedState.getMutableStateFlow<String?>(viewModelScope, EXTRA_TOOL, null)
+) : BaseToolRendererViewModel(savedState) {
     val primaryLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
     val parallelLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
 
@@ -133,7 +131,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     // endregion Loading State
 
     // region Active Tool
-    val activeLocale by savedState.livedata<Locale?>()
+    val activeLocale by savedState.livedata<Locale?>(STATE_ACTIVE_LOCALE)
 
     val activeLoadingState = distinctToolCode.switchCombineWith(activeLocale) { tool, l ->
         val manifest = manifestCache.get(tool, l)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -46,6 +46,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.TranslationKey
 import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.user.activity.UserActivityManager
 import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.TranslationsRepository
@@ -57,9 +58,10 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     downloadManager: GodToolsDownloadManager,
     manifestManager: ManifestManager,
     translationsRepository: TranslationsRepository,
+    userActivityManager: UserActivityManager,
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
     savedState: SavedStateHandle,
-) : BaseToolRendererViewModel(manifestManager, savedState) {
+) : BaseToolRendererViewModel(manifestManager, userActivityManager, savedState) {
     val primaryLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
     val parallelLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -5,7 +5,6 @@ import androidx.collection.LruCache
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import androidx.lifecycle.switchMap
@@ -60,7 +59,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     translationsRepository: TranslationsRepository,
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
     savedState: SavedStateHandle,
-) : ViewModel() {
+) : BaseToolRendererViewModel() {
     val toolCode = savedState.getMutableStateFlow<String?>(viewModelScope, EXTRA_TOOL, null)
     val primaryLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
     val parallelLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModelTest.kt
@@ -1,0 +1,74 @@
+package org.cru.godtools.base.tool.activity
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.cru.godtools.base.tool.service.ManifestManager
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BaseToolRendererViewModelTest {
+    private companion object {
+        private const val TOOL = "kgp"
+    }
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val manifestManager: ManifestManager = mockk {
+        every { getLatestPublishedManifestFlow(any(), any()) } returns flowOf(null)
+    }
+    private val testScope = TestScope()
+
+    private lateinit var viewModel: BaseToolRendererViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScope.testScheduler))
+
+        viewModel = BaseToolRendererViewModel(
+            manifestManager,
+            SavedStateHandle()
+        )
+    }
+
+    @After
+    fun cleanup() {
+        Dispatchers.resetMain()
+    }
+
+    // region Property: manifest
+    @Test
+    fun `Property manifest - Change Active Locale`() = testScope.runTest {
+        val frenchManifest = Manifest(type = Manifest.Type.TRACT)
+        every { manifestManager.getLatestPublishedManifestFlow(TOOL, Locale.ENGLISH) } returns flowOf(null)
+        every { manifestManager.getLatestPublishedManifestFlow(TOOL, Locale.FRENCH) } returns flowOf(frenchManifest)
+
+        viewModel.toolCode.value = TOOL
+        viewModel.locale.value = Locale.ENGLISH
+        viewModel.manifest.test {
+            assertNull(expectMostRecentItem())
+
+            viewModel.locale.value = Locale.FRENCH
+            assertSame(frenchManifest, awaitItem())
+        }
+    }
+    // endregion Property: manifest
+}

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/BaseToolRendererViewModelTest.kt
@@ -6,8 +6,16 @@ import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
 import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -16,12 +24,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.shared.tool.parser.model.Manifest
-import org.junit.After
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
-import org.junit.Before
 import org.junit.Rule
-import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BaseToolRendererViewModelTest {
@@ -39,7 +42,7 @@ class BaseToolRendererViewModelTest {
 
     private lateinit var viewModel: BaseToolRendererViewModel
 
-    @Before
+    @BeforeTest
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScope.testScheduler))
 
@@ -49,12 +52,55 @@ class BaseToolRendererViewModelTest {
         )
     }
 
-    @After
+    @AfterTest
     fun cleanup() {
         Dispatchers.resetMain()
     }
 
     // region Property: manifest
+    @Test
+    fun `Property manifest - supportedType constraint`() = testScope.runTest {
+        val manifestFlow = MutableStateFlow<Manifest?>(null)
+        every { manifestManager.getLatestPublishedManifestFlow(TOOL, Locale.ENGLISH) } returns manifestFlow
+
+        viewModel.manifest.test {
+            viewModel.supportedType.value = Manifest.Type.TRACT
+            viewModel.toolCode.value = TOOL
+            viewModel.locale.value = Locale.ENGLISH
+            manifestFlow.value = null
+            assertNull(expectMostRecentItem())
+
+            manifestFlow.value = Manifest(type = Manifest.Type.TRACT)
+            assertEquals(Manifest.Type.TRACT, assertNotNull(expectMostRecentItem()).type)
+
+            manifestFlow.value = Manifest(type = Manifest.Type.CYOA)
+            assertNull(expectMostRecentItem())
+
+            viewModel.supportedType.value = Manifest.Type.CYOA
+            assertEquals(Manifest.Type.CYOA, assertNotNull(expectMostRecentItem()).type)
+        }
+    }
+
+    @Test
+    fun `Property manifest - supportedType null`() = testScope.runTest {
+        val manifestFlow = MutableStateFlow<Manifest?>(null)
+        every { manifestManager.getLatestPublishedManifestFlow(TOOL, Locale.ENGLISH) } returns manifestFlow
+
+        viewModel.manifest.test {
+            viewModel.supportedType.value = null
+            viewModel.toolCode.value = TOOL
+            viewModel.locale.value = Locale.ENGLISH
+            manifestFlow.value = null
+            assertNull(expectMostRecentItem())
+
+            manifestFlow.value = Manifest(type = Manifest.Type.TRACT)
+            assertEquals(Manifest.Type.TRACT, assertNotNull(expectMostRecentItem()).type)
+
+            manifestFlow.value = Manifest(type = Manifest.Type.CYOA)
+            assertEquals(Manifest.Type.CYOA, assertNotNull(expectMostRecentItem()).type)
+        }
+    }
+
     @Test
     fun `Property manifest - Change Active Locale`() = testScope.runTest {
         val frenchManifest = Manifest(type = Manifest.Type.TRACT)

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -10,7 +10,6 @@ import io.mockk.excludeRecords
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
-import io.mockk.verifySequence
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -308,7 +307,6 @@ class MultiLanguageToolActivityDataModelTest {
     }
     // endregion Property: loadingState
 
-    // region Active Tool
     // region Property: activeLocale
     @Test
     fun `Property activeLocale - Initialize when locales initialized`() {
@@ -384,33 +382,6 @@ class MultiLanguageToolActivityDataModelTest {
         assertEquals(Locale.ENGLISH, dataModel2.activeLocale.value)
     }
     // endregion Property: activeLocale
-
-    // region Property: activeManifest
-    @Test
-    fun `Property activeManifest - Change Active Locale`() {
-        val frenchManifest = Manifest(type = Manifest.Type.TRACT)
-        val observer = mockk<Observer<Manifest?>>(relaxUnitFun = true)
-        everyGetManifest(TOOL, Locale.ENGLISH) returns emptyLiveData()
-        everyGetManifest(TOOL, Locale.FRENCH) returns MutableLiveData(frenchManifest)
-        dataModel.toolCode.value = TOOL
-        dataModel.supportedType.value = Manifest.Type.TRACT
-        dataModel.activeLocale.value = Locale.ENGLISH
-
-        dataModel.activeManifest.observeForever(observer)
-        verifySequence {
-            manifestManager.getLatestPublishedManifestLiveData(any(), Locale.ENGLISH)
-            observer.onChanged(null)
-        }
-        dataModel.activeLocale.value = Locale.FRENCH
-        verifySequence {
-            manifestManager.getLatestPublishedManifestLiveData(any(), Locale.ENGLISH)
-            observer.onChanged(null)
-            manifestManager.getLatestPublishedManifestLiveData(any(), Locale.FRENCH)
-            observer.onChanged(frenchManifest)
-        }
-    }
-    // endregion Property: activeManifest
-    // endregion Active Tool
 
     // region Property: visibleLocales
     @Test

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModelTest.kt
@@ -4,9 +4,11 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.mockk
+import io.mockk.verify
 import io.mockk.verifyAll
 import io.mockk.verifySequence
 import java.util.Locale
@@ -98,7 +100,7 @@ class MultiLanguageToolActivityDataModelTest {
         dataModel.primaryLocales.value = listOf(Locale.ENGLISH, Locale.FRENCH, Locale.CHINESE)
 
         dataModel.translations.observeForever(observer)
-        verifyAll {
+        verify {
             translationsRepository.getLatestTranslationLiveData(TOOL, Locale.ENGLISH, trackAccess = true)
             translationsRepository.getLatestTranslationLiveData(TOOL, Locale.FRENCH, trackAccess = true)
             translationsRepository.getLatestTranslationLiveData(TOOL, Locale.CHINESE, trackAccess = true)
@@ -116,6 +118,7 @@ class MultiLanguageToolActivityDataModelTest {
                 }
             )
         }
+        confirmVerified(observer)
     }
 
     @Test
@@ -142,10 +145,10 @@ class MultiLanguageToolActivityDataModelTest {
 
         dataModel.translations.observeForever(observer)
         french.value = Translation()
-        verifyAll {
+        verify {
             translationsRepository.getLatestTranslationLiveData(TOOL, Locale.ENGLISH, trackAccess = true)
             translationsRepository.getLatestTranslationLiveData(TOOL, Locale.FRENCH, trackAccess = true)
-            repeat(2) { observer.onChanged(any()) }
+            observer.onChanged(any())
         }
         assertThat(
             translations,

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -140,7 +140,7 @@ class CyoaActivity :
         val pageFragment = pageFragment
 
         val dismissCurrentPage = pageFragment?.page?.value?.dismissListeners?.contains(event.id) == true
-        val newPage = dataModel.activeManifest.value?.pages?.firstOrNull { it.listeners.contains(event.id) }
+        val newPage = dataModel.manifest.value?.pages?.firstOrNull { it.listeners.contains(event.id) }
 
         // trigger any page content listeners if we aren't dismissing the current page
         if (!dismissCurrentPage) pageFragment?.onContentEvent(event)

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaPageFragment.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
 import javax.inject.Inject
+import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.androidx.fragment.app.findListener
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
@@ -59,7 +61,7 @@ abstract class CyoaPageFragment<B : ViewDataBinding, C : BaseController<*>>(@Lay
     // region Page
     internal var pageId by arg<String>()
         private set
-    internal val page by lazy { dataModel.activeManifest.map { it?.findPage(pageId) } }
+    internal val page by lazy { dataModel.manifest.map { it?.findPage(pageId) }.asLiveData() }
 
     init {
         page?.let { pageId = page }

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
@@ -22,6 +22,7 @@ import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.sync.GodToolsSyncService
+import org.cru.godtools.user.activity.UserActivityManager
 import org.greenrobot.eventbus.EventBus
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.TranslationsRepository
@@ -47,6 +48,7 @@ class ExternalSingletonsModule {
     @get:Provides
     val downloadManager by lazy {
         mockk<GodToolsDownloadManager> {
+            every { getDownloadProgressFlow(any(), any()) } returns flowOf(null)
             every { getDownloadProgressLiveData(any(), any()) } answers { ImmutableLiveData(null) }
             every { downloadLatestPublishedTranslationAsync(any(), any()) } returns Job().apply { complete() }
         }
@@ -79,4 +81,6 @@ class ExternalSingletonsModule {
             every { getLatestTranslationLiveData(any(), any(), any(), any()) } answers { MutableLiveData(null) }
         }
     }
+    @get:Provides
+    val userActivityManager: UserActivityManager by lazy { mockk(relaxUnitFun = true) }
 }

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -8,7 +8,6 @@ import android.net.Uri
 import android.view.ViewGroup
 import androidx.activity.viewModels
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +18,7 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivityDataModel
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -68,7 +68,7 @@ class CyoaActivityTest {
     @Inject
     internal lateinit var manifestManager: ManifestManager
 
-    private val manifestEnglish = MutableLiveData<Manifest?>(null)
+    private val manifestEnglish = MutableStateFlow<Manifest?>(null)
 
     private val page1 = contentPage("page1")
     private val page2 = contentPage("page2")
@@ -84,7 +84,7 @@ class CyoaActivityTest {
     @Before
     fun setupMocks() {
         hiltRule.inject()
-        every { manifestManager.getLatestPublishedManifestLiveData(TOOL, Locale.ENGLISH) } returns manifestEnglish
+        every { manifestManager.getLatestPublishedManifestFlow(TOOL, Locale.ENGLISH) } returns manifestEnglish
     }
 
     private fun manifest(pages: List<Page> = emptyList()) = Manifest(

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -231,7 +231,7 @@ class LessonActivityDataModel @Inject constructor(
 ) : BaseSingleToolActivityDataModel(manifestManager, downloadManager, translationsRepository, savedState) {
     val visiblePages = SetLiveData<String>(synchronous = true)
 
-    val pages = manifest.combineWith(visiblePages) { manifest, visible ->
+    val pages = manifest.asLiveData().combineWith(visiblePages) { manifest, visible ->
         manifest?.pages.orEmpty().filterIsInstance<LessonPage>().filter { !it.isHidden || it.id in visible }
     }.distinctUntilChanged()
 

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -228,7 +228,7 @@ class LessonActivityDataModel @Inject constructor(
     settings: Settings,
     translationsRepository: TranslationsRepository,
     savedState: SavedStateHandle
-) : BaseSingleToolActivityDataModel(manifestManager, downloadManager, translationsRepository) {
+) : BaseSingleToolActivityDataModel(manifestManager, downloadManager, translationsRepository, savedState) {
     val visiblePages = SetLiveData<String>(synchronous = true)
 
     val pages = manifest.combineWith(visiblePages) { manifest, visible ->

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -50,7 +50,8 @@ class LessonActivity :
         supportedType = Manifest.Type.LESSON
     ),
     LessonPageAdapter.Callbacks {
-    override val dataModel: LessonActivityDataModel by viewModels()
+    override val viewModel: LessonActivityDataModel by viewModels()
+    override val dataModel get() = viewModel
     private val toolState: ToolStateHolder by viewModels()
 
     // region Lifecycle

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -45,6 +45,7 @@ import org.cru.godtools.tool.lesson.analytics.model.LessonPageAnalyticsScreenEve
 import org.cru.godtools.tool.lesson.databinding.LessonActivityBinding
 import org.cru.godtools.tool.lesson.ui.feedback.LessonFeedbackDialogFragment
 import org.cru.godtools.tool.lesson.util.isLessonDeepLink
+import org.cru.godtools.user.activity.UserActivityManager
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 
 @AndroidEntryPoint
@@ -223,12 +224,19 @@ class LessonActivity :
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
 class LessonActivityDataModel @Inject constructor(
-    manifestManager: ManifestManager,
     downloadManager: GodToolsDownloadManager,
+    manifestManager: ManifestManager,
     settings: Settings,
     translationsRepository: TranslationsRepository,
+    userActivityManager: UserActivityManager,
     savedState: SavedStateHandle
-) : BaseSingleToolActivityDataModel(manifestManager, downloadManager, translationsRepository, savedState) {
+) : BaseSingleToolActivityDataModel(
+    downloadManager,
+    manifestManager,
+    translationsRepository,
+    userActivityManager,
+    savedState
+) {
     val visiblePages = SetLiveData<String>(synchronous = true)
 
     val pages = manifest.asLiveData().combineWith(visiblePages) { manifest, visible ->

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.viewModels
 import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.map
 import com.google.android.instantapps.InstantApps
@@ -18,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
+import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.androidx.fragment.app.showAllowingStateLoss
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.notNull
@@ -317,7 +319,7 @@ class TractActivity :
     }
 
     override val shareLinkUriLiveData by lazy {
-        activeManifestLiveData.map { it?.buildShareLink()?.build()?.toString() }
+        viewModel.manifest.map { it?.buildShareLink()?.build()?.toString() }.asLiveData()
     }
     private fun Manifest.buildShareLink(page: Int = pager.currentItem): Uri.Builder? {
         val tool = code ?: return null

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/ui/settings/SettingsBottomSheetDialogFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,7 +40,7 @@ class SettingsBottomSheetDialogFragment :
     override fun onBindingCreated(binding: TractSettingsSheetBinding, savedInstanceState: Bundle?) {
         binding.callbacks = this
         binding.tool = activityDataModel.tool
-        binding.activeManifest = activityDataModel.activeManifest
+        binding.activeManifest = activityDataModel.manifest.asLiveData()
         binding.hasTips = activityDataModel.hasTips
         binding.showTips = activityDataModel.showTips
         binding.primaryLanguage = primaryLanguage


### PR DESCRIPTION
This PR extracts some common tool render view model business logic. It then ties into this business logic to record when a tool is actually used in a language with the user counters framework.