### PR TITLE
GT-1850 Include the number of completed tips when generating activity

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/TrainingTipsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/TrainingTipsRepository.kt
@@ -2,8 +2,11 @@ package org.cru.godtools.db.repository
 
 import java.util.Locale
 import kotlinx.coroutines.flow.Flow
+import org.cru.godtools.model.TrainingTip
 
 interface TrainingTipsRepository {
+    fun getCompletedTipsFlow(): Flow<Set<TrainingTip>>
+
     suspend fun markTipComplete(tool: String, locale: Locale, tipId: String)
     fun isTipCompleteFlow(tool: String, locale: Locale, tipId: String): Flow<Boolean>
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/TrainingTipDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/TrainingTipDao.kt
@@ -18,4 +18,7 @@ internal interface TrainingTipDao {
 
     @Query("SELECT * FROM training_tips WHERE tool = :tool AND locale = :locale AND tipId = :tipId")
     fun findTrainingTipFlow(tool: String, locale: Locale, tipId: String): Flow<TrainingTipEntity?>
+
+    @Query("SELECT * FROM training_tips WHERE isCompleted")
+    fun getCompletedTrainingTipsFlow(): Flow<List<TrainingTipEntity>>
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/TrainingTipEntity.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/TrainingTipEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.util.Locale
+import org.cru.godtools.model.TrainingTip
 
 @Entity(tableName = "training_tips")
 internal class TrainingTipEntity(@PrimaryKey @Embedded val key: Key) {
@@ -11,4 +12,11 @@ internal class TrainingTipEntity(@PrimaryKey @Embedded val key: Key) {
 
     var isCompleted = false
     var isNew = true
+
+    fun toModel() = TrainingTip(
+        tool = key.tool,
+        locale = key.locale,
+        tipId = key.tipId,
+        isCompleted = isCompleted
+    )
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepository.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.db.room.repository
 import androidx.room.Dao
 import java.util.Locale
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toSet
 import org.cru.godtools.db.repository.TrainingTipsRepository
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.cru.godtools.db.room.entity.TrainingTipEntity
@@ -10,6 +11,8 @@ import org.cru.godtools.db.room.entity.TrainingTipEntity
 @Dao
 internal abstract class TrainingTipsRoomRepository(private val db: GodToolsRoomDatabase) : TrainingTipsRepository {
     private inline val dao get() = db.trainingTipDao
+
+    override fun getCompletedTipsFlow() = dao.getCompletedTrainingTipsFlow().map { it.map { it.toModel() }.toSet() }
 
     override suspend fun markTipComplete(tool: String, locale: Locale, tipId: String) {
         val tip = TrainingTipEntity(TrainingTipEntity.Key(tool, locale, tipId))

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseRule.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseRule.kt
@@ -2,15 +2,18 @@ package org.cru.godtools.db.room
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asExecutor
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
-internal class GodToolsRoomDatabaseRule : TestWatcher() {
+internal class GodToolsRoomDatabaseRule(private val dispatcher: CoroutineDispatcher? = null) : TestWatcher() {
     lateinit var db: GodToolsRoomDatabase
 
     override fun starting(description: Description?) {
         db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), GodToolsRoomDatabase::class.java)
             .allowMainThreadQueries()
+            .apply { if (dispatcher != null) setQueryExecutor(dispatcher.asExecutor()) }
             .build()
     }
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
@@ -1,14 +1,17 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.cru.godtools.db.repository.TrainingTipsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabaseRule
 import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class TrainingTipsRoomRepositoryIT : TrainingTipsRepositoryIT() {
     @get:Rule
-    internal val dbRule = GodToolsRoomDatabaseRule()
+    internal val dbRule = GodToolsRoomDatabaseRule(StandardTestDispatcher(testScope.testScheduler))
     override val repository get() = dbRule.db.trainingTipsRepository
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/TrainingTip.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/TrainingTip.kt
@@ -1,0 +1,10 @@
+package org.cru.godtools.model
+
+import java.util.Locale
+
+data class TrainingTip(
+    val tool: String,
+    val locale: Locale,
+    val tipId: String,
+    val isCompleted: Boolean
+)

--- a/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
+++ b/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
@@ -6,26 +6,31 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import org.cru.godtools.db.repository.TrainingTipsRepository
 import org.cru.godtools.db.repository.UserCountersRepository
 import org.cru.godtools.model.UserCounter
+import org.cru.godtools.shared.user.activity.UserCounterNames
 import org.cru.godtools.shared.user.activity.model.UserActivity
 import org.cru.godtools.sync.GodToolsSyncService
 
 @Singleton
 class UserActivityManager internal constructor(
     private val syncService: Lazy<GodToolsSyncService>,
+    tipsRepository: TrainingTipsRepository,
     private val userCountersRepository: UserCountersRepository,
     private val coroutineScope: CoroutineScope,
 ) {
     @Inject
     internal constructor(
         syncService: Lazy<GodToolsSyncService>,
+        tipsRepository: TrainingTipsRepository,
         userCountersRepository: UserCountersRepository,
-    ) : this(syncService, userCountersRepository, CoroutineScope(SupervisorJob()))
+    ) : this(syncService, tipsRepository, userCountersRepository, CoroutineScope(SupervisorJob()))
 
     // region Counters
     fun isValidCounterName(name: String) = UserCounter.VALID_NAME.matches(name)
@@ -43,6 +48,9 @@ class UserActivityManager internal constructor(
     // endregion Counters
 
     val userActivityFlow = countersFlow
+        .combine(
+            tipsRepository.getCompletedTipsFlow().map { it.size }.distinctUntilChanged()
+        ) { counters, tips -> counters + (UserCounterNames.TIPS_COMPLETED to tips) }
         .map { UserActivity(it) }
         .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
         .distinctUntilChanged()

--- a/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
+++ b/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
@@ -17,9 +17,10 @@ import org.cru.godtools.model.UserCounter
 import org.cru.godtools.shared.user.activity.UserCounterNames
 import org.cru.godtools.shared.user.activity.model.UserActivity
 import org.cru.godtools.sync.GodToolsSyncService
+import org.jetbrains.annotations.VisibleForTesting
 
 @Singleton
-class UserActivityManager internal constructor(
+class UserActivityManager @VisibleForTesting internal constructor(
     private val syncService: Lazy<GodToolsSyncService>,
     tipsRepository: TrainingTipsRepository,
     private val userCountersRepository: UserCountersRepository,

--- a/library/user-data/src/test/kotlin/org/cru/godtools/user/activity/UserActivityManagerTest.kt
+++ b/library/user-data/src/test/kotlin/org/cru/godtools/user/activity/UserActivityManagerTest.kt
@@ -1,0 +1,74 @@
+package org.cru.godtools.user.activity
+
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.mockk
+import io.mockk.verifyAll
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.cru.godtools.db.repository.TrainingTipsRepository
+import org.cru.godtools.db.repository.UserCountersRepository
+import org.cru.godtools.model.TrainingTip
+import org.cru.godtools.model.UserCounter
+import org.cru.godtools.sync.GodToolsSyncService
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UserActivityManagerTest {
+    private companion object {
+        private const val COUNTER = "counter"
+    }
+
+    private val countersFlow = MutableStateFlow(emptyList<UserCounter>())
+    private val completedTipsFlow = MutableStateFlow(emptySet<TrainingTip>())
+
+    private val syncService: GodToolsSyncService = mockk {
+        coEvery { syncDirtyUserCounters() } returns true
+    }
+    private val tipsRepository: TrainingTipsRepository = mockk {
+        every { getCompletedTipsFlow() } returns completedTipsFlow
+    }
+    private val userCountersRepository: UserCountersRepository = mockk(relaxUnitFun = true) {
+        every { getCountersFlow() } returns countersFlow
+        excludeRecords { getCountersFlow() }
+    }
+    private val testScope = TestScope()
+
+    private val manager = UserActivityManager(
+        { syncService },
+        tipsRepository,
+        userCountersRepository,
+        testScope.backgroundScope
+    )
+
+    // region updateCounter()
+    @Test
+    fun `updateCounter()`() = testScope.runTest {
+        manager.updateCounter(COUNTER, 3)
+        runCurrent()
+        coVerifySequence {
+            userCountersRepository.updateCounter(COUNTER, 3)
+            syncService.syncDirtyUserCounters()
+        }
+    }
+
+    @Test
+    fun `updateCounter() - Invalid Name`() = testScope.runTest {
+        assertFailsWith<IllegalArgumentException> {
+            manager.updateCounter("Invalid Name", 3)
+        }
+        runCurrent()
+        verifyAll {
+            userCountersRepository wasNot Called
+            syncService wasNot Called
+        }
+    }
+    // endregion updateCounter()
+}

--- a/library/user-data/src/test/kotlin/org/cru/godtools/user/activity/UserActivityManagerTest.kt
+++ b/library/user-data/src/test/kotlin/org/cru/godtools/user/activity/UserActivityManagerTest.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.user.activity
 
+import app.cash.turbine.test
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerifySequence
@@ -7,8 +8,12 @@ import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.mockk
 import io.mockk.verifyAll
+import java.util.Locale
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -18,6 +23,8 @@ import org.cru.godtools.db.repository.TrainingTipsRepository
 import org.cru.godtools.db.repository.UserCountersRepository
 import org.cru.godtools.model.TrainingTip
 import org.cru.godtools.model.UserCounter
+import org.cru.godtools.shared.user.activity.UserCounterNames
+import org.cru.godtools.shared.user.activity.model.Badge.BadgeType
 import org.cru.godtools.sync.GodToolsSyncService
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -71,4 +78,29 @@ class UserActivityManagerTest {
         }
     }
     // endregion updateCounter()
+
+    // region userActivityFlow
+    @Test
+    fun `Property userActivityFlow`() = testScope.runTest {
+        manager.userActivityFlow.test {
+            assertNotNull(awaitItem()) {
+                assertEquals(0, it.sessions)
+                assertTrue(it.badges.none { it.isEarned })
+            }
+
+            countersFlow.value = listOf(UserCounter(UserCounterNames.SESSION).apply { apiCount = 5 })
+            assertNotNull(awaitItem()) {
+                assertEquals(5, it.sessions)
+                assertTrue(it.badges.none { it.isEarned })
+            }
+
+            completedTipsFlow.value = List(30) { TrainingTip("tool", Locale.ENGLISH, "tipId$it", true) }.toSet()
+            assertNotNull(awaitItem()) {
+                assertEquals(5, it.sessions)
+                assertTrue(it.badges.filter { it.type == BadgeType.TIPS_COMPLETED }.all { it.isEarned })
+                assertTrue(it.badges.filterNot { it.type == BadgeType.TIPS_COMPLETED }.none { it.isEarned })
+            }
+        }
+    }
+    // endregion userActivityFlow
 }


### PR DESCRIPTION
- expose a completed tip flow from the TrainingTipsRepository
- include the number of completed tips in the counters sent to generate UserActivity
