### PR TITLE
Stabilize AccountManager tests

### DIFF
--- a/library/account/src/main/kotlin/org/cru/godtools/account/GodToolsAccountManager.kt
+++ b/library/account/src/main/kotlin/org/cru/godtools/account/GodToolsAccountManager.kt
@@ -23,7 +23,8 @@ import org.cru.godtools.account.provider.AccountProvider
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsAccountManager @VisibleForTesting internal constructor(
-    private val providers: List<AccountProvider>,
+    @get:VisibleForTesting
+    internal val providers: List<AccountProvider>,
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob()),
 ) {
     @Inject

--- a/library/account/src/main/kotlin/org/cru/godtools/account/GodToolsAccountManager.kt
+++ b/library/account/src/main/kotlin/org/cru/godtools/account/GodToolsAccountManager.kt
@@ -22,11 +22,13 @@ import org.cru.godtools.account.provider.AccountProvider
 
 @Singleton
 @OptIn(ExperimentalCoroutinesApi::class)
-class GodToolsAccountManager @Inject internal constructor(
-    rawProviders: Set<@JvmSuppressWildcards AccountProvider>
+class GodToolsAccountManager @VisibleForTesting internal constructor(
+    private val providers: List<AccountProvider>,
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob()),
 ) {
-    private val coroutineScope = CoroutineScope(SupervisorJob())
-    private val providers = rawProviders.sortedWith(Ordered.COMPARATOR)
+    @Inject
+    internal constructor(providers: Set<@JvmSuppressWildcards AccountProvider>) :
+        this(providers.sortedWith(Ordered.COMPARATOR))
 
     @VisibleForTesting
     internal suspend fun activeProvider() = providers.firstOrNull { it.isAuthenticated() }

--- a/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
+++ b/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -38,6 +39,12 @@ class GodToolsAccountManagerTest {
         providers = listOf(provider1, provider2),
         coroutineScope = testScope.backgroundScope
     )
+
+    @Test
+    fun verifyInjectedProvidersSorted() {
+        val manager = GodToolsAccountManager(setOf(provider2, provider1))
+        assertEquals(listOf(provider1, provider2), manager.providers)
+    }
 
     @Test
     fun verifyActiveProvider() = testScope.runTest {

--- a/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
+++ b/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
@@ -7,6 +7,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.account.provider.AccountProvider
 import org.junit.Assert.assertFalse
@@ -18,21 +20,27 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsAccountManagerTest {
     private val provider1Authenticated = MutableStateFlow(false)
+    private val provider2Authenticated = MutableStateFlow(false)
+
     private val provider1 = mockk<AccountProvider>(relaxed = true) {
         every { order } returns 1
         coEvery { isAuthenticated() } answers { provider1Authenticated.value }
         every { isAuthenticatedFlow() } returns provider1Authenticated
     }
-    private val provider2Authenticated = MutableStateFlow(false)
     private val provider2 = mockk<AccountProvider>(relaxed = true) {
         every { order } returns 2
         coEvery { isAuthenticated() } answers { provider2Authenticated.value }
         every { isAuthenticatedFlow() } returns provider2Authenticated
     }
-    private val manager = GodToolsAccountManager(rawProviders = setOf(provider2, provider1))
+    private val testScope = TestScope()
+
+    private val manager = GodToolsAccountManager(
+        providers = listOf(provider1, provider2),
+        coroutineScope = testScope.backgroundScope
+    )
 
     @Test
-    fun verifyActiveProvider() = runTest {
+    fun verifyActiveProvider() = testScope.runTest {
         provider1Authenticated.value = true
         assertSame(provider1, manager.activeProvider())
         provider2Authenticated.value = true
@@ -44,28 +52,34 @@ class GodToolsAccountManagerTest {
     }
 
     @Test
-    fun verifyActiveProviderFlow() = runTest {
-        provider1Authenticated.value = true
+    fun verifyActiveProviderFlow() = testScope.runTest {
         manager.activeProviderFlow.test {
+            assertNull(awaitItem())
+
+            provider1Authenticated.value = true
+            runCurrent()
             assertSame(provider1, awaitItem())
             assertSame(provider1, manager.activeProviderFlow.value)
 
             provider2Authenticated.value = true
+            runCurrent()
             expectNoEvents()
             assertSame(provider1, manager.activeProviderFlow.value)
 
             provider1Authenticated.value = false
+            runCurrent()
             assertSame(provider2, awaitItem())
             assertSame(provider2, manager.activeProviderFlow.value)
 
             provider2Authenticated.value = false
+            runCurrent()
             assertNull(awaitItem())
             assertNull(manager.activeProviderFlow.value)
         }
     }
 
     @Test
-    fun verifyIsAuthenticated() = runTest {
+    fun verifyIsAuthenticated() = testScope.runTest {
         provider1Authenticated.value = false
         assertFalse(manager.isAuthenticated())
         provider1Authenticated.value = true
@@ -73,7 +87,7 @@ class GodToolsAccountManagerTest {
     }
 
     @Test
-    fun verifyIsAuthenticatedFlow() = runTest {
+    fun verifyIsAuthenticatedFlow() = testScope.runTest {
         provider1Authenticated.value = false
         manager.isAuthenticatedFlow().test {
             assertFalse(awaitItem())
@@ -87,7 +101,7 @@ class GodToolsAccountManagerTest {
     }
 
     @Test
-    fun verifyLogoutTriggersAllProviders() = runTest {
+    fun verifyLogoutTriggersAllProviders() = testScope.runTest {
         manager.logout()
         coVerify {
             provider1.logout()

--- a/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
+++ b/library/account/src/test/kotlin/org/cru/godtools/account/GodToolsAccountManagerTest.kt
@@ -5,18 +5,18 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.account.provider.AccountProvider
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
-import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsAccountManagerTest {


### PR DESCRIPTION
The AccountManager tests were dependent on a task executing in a background thread. This meant that there was a race condition within the test that could lead to occasional failures of the test.

This PR utilizes the coroutines test scope for those background tasks so we can manually control execution of them.