### PR TITLE
cleanup

### DIFF
--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/AnalyticsModule.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/AnalyticsModule.kt
@@ -25,13 +25,13 @@ object AnalyticsModule {
     @Provides
     @ElementsIntoSet
     @EagerSingleton(threadMode = ThreadMode.MAIN)
-    internal fun mainEagerSingletons(firebase: FirebaseAnalyticsService) = setOf<Any>(firebase)
+    internal fun mainEagerSingletons(
+        firebase: FirebaseAnalyticsService,
+        user: UserAnalyticsService,
+    ) = setOf(firebase, user)
 
     @Provides
     @ElementsIntoSet
     @EagerSingleton(threadMode = ThreadMode.ASYNC)
-    internal fun backgroundEagerSingletons(
-        facebook: FacebookAnalyticsService,
-        user: UserAnalyticsService,
-    ) = setOf(facebook, user)
+    internal fun backgroundEagerSingletons(facebook: FacebookAnalyticsService) = setOf<Any>(facebook)
 }

--- a/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
+++ b/library/user-data/src/main/kotlin/org/cru/godtools/user/activity/UserActivityManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import org.ccci.gto.android.common.dagger.getValue
 import org.cru.godtools.db.repository.TrainingTipsRepository
 import org.cru.godtools.db.repository.UserCountersRepository
 import org.cru.godtools.model.UserCounter
@@ -21,7 +22,7 @@ import org.jetbrains.annotations.VisibleForTesting
 
 @Singleton
 class UserActivityManager @VisibleForTesting internal constructor(
-    private val syncService: Lazy<GodToolsSyncService>,
+    syncService: Lazy<GodToolsSyncService>,
     tipsRepository: TrainingTipsRepository,
     private val userCountersRepository: UserCountersRepository,
     private val coroutineScope: CoroutineScope,
@@ -32,6 +33,8 @@ class UserActivityManager @VisibleForTesting internal constructor(
         tipsRepository: TrainingTipsRepository,
         userCountersRepository: UserCountersRepository,
     ) : this(syncService, tipsRepository, userCountersRepository, CoroutineScope(SupervisorJob()))
+
+    private val syncService by syncService
 
     // region Counters
     fun isValidCounterName(name: String) = UserCounter.VALID_NAME.matches(name)
@@ -44,7 +47,7 @@ class UserActivityManager @VisibleForTesting internal constructor(
     suspend fun updateCounter(name: String, change: Int = 1) {
         require(isValidCounterName(name)) { "Invalid counter name: $name" }
         userCountersRepository.updateCounter(name, change)
-        coroutineScope.launch { syncService.get().syncDirtyUserCounters() }
+        coroutineScope.launch { syncService.syncDirtyUserCounters() }
     }
     // endregion Counters
 

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/BaseToolActivity.kt
@@ -12,7 +12,6 @@ import androidx.annotation.MainThread
 import androidx.annotation.StringRes
 import androidx.databinding.ViewDataBinding
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -24,6 +23,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -259,7 +259,7 @@ abstract class BaseToolActivity<B : ViewDataBinding>(@LayoutRes contentLayoutId:
     // region Tool sync/download logic
     @Inject
     internal lateinit var syncService: GodToolsSyncService
-    protected open val isInitialSyncFinished = MutableLiveData<Boolean>()
+    protected open val isInitialSyncFinished = MutableStateFlow(false)
 
     protected abstract val toolsToDownload: StateFlow<List<String>>
     protected abstract val localesToDownload: StateFlow<List<Locale>>

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -15,6 +15,7 @@ import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -112,14 +113,14 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     // endregion Resolved Data
 
     // region Loading State
-    val isInitialSyncFinished = MutableLiveData(false)
+    val isInitialSyncFinished = MutableStateFlow(false)
 
     val loadingState = locales.combineWith(
         manifests,
         translations,
         supportedType.asLiveData(),
         isConnected,
-        isInitialSyncFinished
+        isInitialSyncFinished.asLiveData()
     ) { l, m, t, type, connected, syncFinished ->
         l.associateWith {
             LoadingState.determineToolState(
@@ -143,7 +144,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
             translation,
             supportedType.asLiveData(),
             isConnected,
-            isInitialSyncFinished
+            isInitialSyncFinished.asLiveData()
         ) { m, t, type, c, s ->
             LoadingState.determineToolState(m, t, type, isConnected = c, isSyncFinished = s)
         }


### PR DESCRIPTION
- eagerly load the UserAnalyticsService to ensure we correctly count the launch event
- use a dagger delegate to simplify accessing an inject Lazy object
- use a MutableStateFlow for tracking if the initial sync finished
