### PR TITLE
GT-1878 Use shared analytics constants

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/activity/BasePlatformActivity.kt
@@ -35,19 +35,14 @@ import org.cru.godtools.R
 import org.cru.godtools.account.AccountType
 import org.cru.godtools.account.GodToolsAccountManager
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_CONTACT_US
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_COPYRIGHT
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_HELP
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_PRIVACY_POLICY
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_SHARE_GODTOOLS
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_SHARE_STORY
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_TERMS_OF_USE
 import org.cru.godtools.base.URI_SHARE_BASE
 import org.cru.godtools.base.ui.activity.BaseBindingActivity
 import org.cru.godtools.base.ui.util.openUrl
 import org.cru.godtools.base.util.deviceLocale
 import org.cru.godtools.databinding.ActivityGenericFragmentWithNavDrawerBinding
 import org.cru.godtools.fragment.BasePlatformFragment
+import org.cru.godtools.shared.analytics.AnalyticsActionNames
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.sync.GodToolsSyncService
 import org.cru.godtools.tutorial.PageSet
 import org.cru.godtools.tutorial.startTutorialActivity
@@ -143,7 +138,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             true
         }
         R.id.action_help -> {
-            eventBus.post(AnalyticsScreenEvent(SCREEN_HELP, deviceLocale))
+            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.PLATFORM_HELP, deviceLocale))
             openUrl(URI_HELP)
             true
         }
@@ -164,17 +159,17 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
             true
         }
         R.id.action_terms_of_use -> {
-            eventBus.post(AnalyticsScreenEvent(SCREEN_TERMS_OF_USE, deviceLocale))
+            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.PLATFORM_TERMS_OF_USE, deviceLocale))
             openUrl(URI_TERMS_OF_USE)
             true
         }
         R.id.action_privacy_policy -> {
-            eventBus.post(AnalyticsScreenEvent(SCREEN_PRIVACY_POLICY, deviceLocale))
+            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.PLATFORM_PRIVACY_POLICY, deviceLocale))
             openUrl(URI_PRIVACY)
             true
         }
         R.id.action_copyright -> {
-            eventBus.post(AnalyticsScreenEvent(SCREEN_COPYRIGHT, deviceLocale))
+            eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.PLATFORM_COPYRIGHT, deviceLocale))
             openUrl(URI_COPYRIGHT)
             true
         }
@@ -281,7 +276,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
     }
 
     private fun launchContactUs() {
-        eventBus.post(AnalyticsScreenEvent(SCREEN_CONTACT_US, deviceLocale))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsActionNames.PLATFORM_CONTACT_US, deviceLocale))
         try {
             startActivity(Intent(Intent.ACTION_SENDTO, MAILTO_SUPPORT))
         } catch (e: ActivityNotFoundException) {
@@ -290,7 +285,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
     }
 
     private fun launchShare() {
-        eventBus.post(AnalyticsScreenEvent(SCREEN_SHARE_GODTOOLS, settings.primaryLanguage))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsActionNames.PLATFORM_SHARE_GODTOOLS, settings.primaryLanguage))
         val shareLink = URI_SHARE_BASE.buildUpon()
             .appendPath(settings.primaryLanguage.toLanguageTag().lowercase(Locale.US))
             .appendPath("")
@@ -305,7 +300,7 @@ abstract class BasePlatformActivity<B : ViewBinding> protected constructor(@Layo
     }
 
     private fun launchShareStory() {
-        eventBus.post(AnalyticsScreenEvent(SCREEN_SHARE_STORY, deviceLocale))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsActionNames.PLATFORM_SHARE_STORY, deviceLocale))
         try {
             startActivity(
                 Intent(Intent.ACTION_SENDTO, MAILTO_SUPPORT)

--- a/app/src/main/kotlin/org/cru/godtools/ui/about/AboutActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/about/AboutActivity.kt
@@ -17,12 +17,12 @@ import dagger.hilt.android.AndroidEntryPoint
 import org.cru.godtools.R
 import org.cru.godtools.activity.BasePlatformActivity
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_ABOUT
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.base.ui.theme.GodToolsAppBarColors
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.base.util.deviceLocale
 import org.cru.godtools.databinding.ActivityGenericComposeWithNavDrawerBinding
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 
 fun Activity.startAboutActivity() {
     Intent(this, AboutActivity::class.java)
@@ -58,7 +58,7 @@ class AboutActivity : BasePlatformActivity<ActivityGenericComposeWithNavDrawerBi
 
     override fun onResume() {
         super.onResume()
-        eventBus.post(AnalyticsScreenEvent(SCREEN_ABOUT, deviceLocale))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.PLATFORM_ABOUT, deviceLocale))
     }
     // endregion Lifecycle
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -147,6 +147,7 @@ internal fun AccountLayout(onEvent: (AccountLayoutEvent) -> Unit = {}) {
 @Composable
 private fun RecordAccountPageAnalytics(page: AccountPage?) {
     val screen = when (page) {
+        AccountPage.ACTIVITY -> AnalyticsScreenEvent(AnalyticsScreenNames.ACCOUNT_ACTIVITY)
         AccountPage.GLOBAL_ACTIVITY -> AnalyticsScreenEvent(AnalyticsScreenNames.ACCOUNT_GLOBAL_ACTIVITY)
         else -> null
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -43,7 +43,7 @@ import org.ccci.gto.android.common.androidx.compose.ui.draw.invisibleIf
 import org.cru.godtools.R
 import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_GLOBAL_DASHBOARD
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.account.activity.AccountActivityLayout
 import org.cru.godtools.ui.account.globalactivity.AccountGlobalActivityLayout
 
@@ -147,7 +147,7 @@ internal fun AccountLayout(onEvent: (AccountLayoutEvent) -> Unit = {}) {
 @Composable
 private fun RecordAccountPageAnalytics(page: AccountPage?) {
     val screen = when (page) {
-        AccountPage.GLOBAL_ACTIVITY -> AnalyticsScreenEvent(SCREEN_GLOBAL_DASHBOARD)
+        AccountPage.GLOBAL_ACTIVITY -> AnalyticsScreenEvent(AnalyticsScreenNames.ACCOUNT_GLOBAL_ACTIVITY)
         else -> null
     }
     if (screen != null) RecordAnalyticsScreen(screen)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -33,6 +33,7 @@ import org.cru.godtools.base.ui.compose.LocalEventBus
 import org.cru.godtools.base.ui.dashboard.Page
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.dashboard.home.AllFavoritesList
 import org.cru.godtools.ui.dashboard.home.HomeContent
 import org.cru.godtools.ui.dashboard.lessons.LessonsLayout
@@ -94,15 +95,15 @@ private fun DashboardLayoutAnalytics(page: Page) {
     val eventBus = LocalEventBus.current
     when (page) {
         Page.LESSONS -> {
-            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_LESSONS))
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenNames.DASHBOARD_LESSONS))
             OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_LESSONS)) }
         }
         Page.HOME, Page.FAVORITE_TOOLS -> {
-            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_HOME))
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenNames.DASHBOARD_HOME))
             OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_HOME)) }
         }
         Page.ALL_TOOLS -> {
-            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenEvent.SCREEN_ALL_TOOLS))
+            RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenNames.DASHBOARD_ALL_TOOLS))
             OnResume { eventBus.post(FirebaseIamActionEvent(ACTION_IAM_ALL_TOOLS)) }
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSelectionActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSelectionActivity.kt
@@ -10,10 +10,10 @@ import javax.inject.Inject
 import org.cru.godtools.R
 import org.cru.godtools.activity.BasePlatformActivity
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_LANGUAGE_SELECTION
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.download.manager.GodToolsDownloadManager
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.databinding.ActivityGenericFragmentBinding
 
 private const val EXTRA_PRIMARY = "org.cru.godtools.ui.languages.LanguageSelectionActivity.PRIMARY"
@@ -45,7 +45,7 @@ class LanguageSelectionActivity : BasePlatformActivity<ActivityGenericFragmentBi
 
     override fun onResume() {
         super.onResume()
-        eventBus.post(AnalyticsScreenEvent(SCREEN_LANGUAGE_SELECTION))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.SETTINGS_LANGUAGE_SELECTION))
     }
 
     override fun onLocaleSelected(locale: Locale?) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsActivity.kt
@@ -7,10 +7,10 @@ import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
 import org.cru.godtools.activity.BasePlatformActivity
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent.Companion.SCREEN_LANGUAGE_SETTINGS
 import org.cru.godtools.base.Settings.Companion.FEATURE_LANGUAGE_SETTINGS
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.databinding.ActivityGenericFragmentWithNavDrawerBinding
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.R
 
 fun Activity.startLanguageSettingsActivity() {
@@ -31,7 +31,7 @@ class LanguageSettingsActivity : BasePlatformActivity<ActivityGenericFragmentWit
     override fun onResume() {
         super.onResume()
         settings.setFeatureDiscovered(FEATURE_LANGUAGE_SETTINGS)
-        eventBus.post(AnalyticsScreenEvent(SCREEN_LANGUAGE_SETTINGS))
+        eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.SETTINGS_LANGUAGES))
     }
     // endregion Lifecycle
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/analytics/model/ToolDetailsScreenEvent.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/analytics/model/ToolDetailsScreenEvent.kt
@@ -1,7 +1,8 @@
 package org.cru.godtools.ui.tooldetails.analytics.model
 
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
+import org.cru.godtools.shared.analytics.AnalyticsAppSectionNames
 
 class ToolDetailsScreenEvent(tool: String) : AnalyticsScreenEvent("$tool-tool-info") {
-    override val appSection get() = APP_SECTION_TOOLS
+    override val appSection get() = AnalyticsAppSectionNames.TOOLS
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ firebase-messaging = "com.google.firebase:firebase-messaging:23.1.0"
 firebase-perf = { module = "com.google.firebase:firebase-perf", version.ref = "firebase-perf" }
 firebase-perf-gradlePlugin = "com.google.firebase:perf-plugin:1.4.2"
 firebase-perf-ktx = { module = "com.google.firebase:firebase-perf-ktx", version.ref = "firebase-perf" }
+godtoolsShared-analytics = { module = "org.cru.godtools.kotlin:analytics", version.ref = "godtoolsShared" }
 godtoolsShared-parser = { module = "org.cru.godtools.kotlin:parser", version.ref = "godtoolsShared" }
 godtoolsShared-user-activity = { module = "org.cru.godtools.kotlin:user-activity", version.ref = "godtoolsShared" }
 google-auto-value = { module = "com.google.auto.value:auto-value", version.ref = "google-auto-value" }

--- a/library/analytics/build.gradle.kts
+++ b/library/analytics/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation(project(":library:user-data"))
     implementation(project(":ui:base"))
 
+    api(libs.godtoolsShared.analytics)
+
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.perf)
 

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
@@ -2,58 +2,18 @@ package org.cru.godtools.analytics.model
 
 import java.util.Locale
 import javax.annotation.concurrent.Immutable
-
-/* App Sections */
-private const val APP_SECTION_MENU = "menu"
-private const val APP_SUB_SECTION_LANGUAGE_SETTINGS = "language settings"
+import org.cru.godtools.shared.analytics.AnalyticsAppSectionNames
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 
 @Immutable
 open class AnalyticsScreenEvent(val screen: String, locale: Locale? = null) : AnalyticsBaseEvent(locale) {
-    companion object {
-        /* Screen event names */
-        const val SCREEN_HOME = "Favorites"
-        const val SCREEN_ALL_TOOLS = "All Tools"
-        const val SCREEN_LESSONS = "Lessons"
-        const val SCREEN_LANGUAGE_SETTINGS = "Language Settings"
-        const val SCREEN_LANGUAGE_SELECTION = "Select Language"
-        const val SCREEN_ABOUT = "About"
-        const val SCREEN_HELP = "Help"
-        const val SCREEN_CONTACT_US = "Contact Us"
-        const val SCREEN_SHARE_GODTOOLS = "Share App"
-        const val SCREEN_SHARE_STORY = "Share Story"
-        const val SCREEN_TERMS_OF_USE = "Terms of Use"
-        const val SCREEN_PRIVACY_POLICY = "Privacy Policy"
-        const val SCREEN_COPYRIGHT = "Copyright Info"
-        const val SCREEN_GLOBAL_DASHBOARD = "Global Dashboard"
-
-        /* App Sections */
-        const val APP_SECTION_TOOLS = "tools"
-    }
-
     override fun isForSystem(system: AnalyticsSystem) = when (screen) {
-        SCREEN_LESSONS -> system == AnalyticsSystem.APPSFLYER || super.isForSystem(system)
+        AnalyticsScreenNames.DASHBOARD_LESSONS -> system == AnalyticsSystem.APPSFLYER || super.isForSystem(system)
         else -> super.isForSystem(system)
     }
 
-    override val appSection
-        get() = when (screen) {
-            SCREEN_ALL_TOOLS -> APP_SECTION_TOOLS
-            SCREEN_LANGUAGE_SETTINGS,
-            SCREEN_LANGUAGE_SELECTION,
-            SCREEN_ABOUT, SCREEN_HELP,
-            SCREEN_CONTACT_US,
-            SCREEN_SHARE_GODTOOLS,
-            SCREEN_SHARE_STORY,
-            SCREEN_TERMS_OF_USE,
-            SCREEN_PRIVACY_POLICY,
-            SCREEN_COPYRIGHT -> APP_SECTION_MENU
-            else -> super.appSection
-        }
-    override val appSubSection
-        get() = when (screen) {
-            SCREEN_LANGUAGE_SELECTION -> APP_SUB_SECTION_LANGUAGE_SETTINGS
-            else -> super.appSubSection
-        }
+    override val appSection get() = AnalyticsAppSectionNames.forScreen(screen) ?: super.appSection
+    override val appSubSection get() = AnalyticsAppSectionNames.subSectionForScreen(screen) ?: super.appSubSection
 
     override fun equals(other: Any?) = when {
         this === other -> true

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEvent.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEvent.kt
@@ -1,5 +1,7 @@
 package org.cru.godtools.tool.cyoa.analytics.model
 
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.page.CardCollectionPage.Card
 
-class CyoaCardCollectionPageAnalyticsScreenEvent(card: Card) : CyoaPageAnalyticsScreenEvent(card.page, suffix = card.id)
+class CyoaCardCollectionPageAnalyticsScreenEvent(card: Card) :
+    CyoaPageAnalyticsScreenEvent(card.page, ToolAnalyticsScreenNames.forCyoaCardCollectionCard(card))

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEvent.kt
@@ -1,15 +1,14 @@
 package org.cru.godtools.tool.cyoa.analytics.model
 
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.page.Page
 
-private const val SEPARATOR = ":"
-
-open class CyoaPageAnalyticsScreenEvent(page: Page, suffix: String? = null) : ToolAnalyticsScreenEvent(
-    screen = page.toAnalyticsScreenName(suffix),
+open class CyoaPageAnalyticsScreenEvent(
+    page: Page,
+    screen: String = ToolAnalyticsScreenNames.forCyoaPage(page)
+) : ToolAnalyticsScreenEvent(
+    screen = screen,
     tool = page.manifest.code,
     locale = page.manifest.locale
 )
-
-private fun Page.toAnalyticsScreenName(suffix: String?) =
-    listOfNotNull(manifest.code.orEmpty(), id, suffix).joinToString(SEPARATOR)

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEventTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaCardCollectionPageAnalyticsScreenEventTest.kt
@@ -1,0 +1,30 @@
+package org.cru.godtools.tool.cyoa.analytics.model
+
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Locale
+import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.shared.tool.parser.model.page.CardCollectionPage
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CyoaCardCollectionPageAnalyticsScreenEventTest {
+    private companion object {
+        private const val TOOL = "tool"
+        private const val PAGE = "page"
+        private const val CARD = "card"
+    }
+
+    private val card: CardCollectionPage.Card = mockk {
+        every { id } returns CARD
+        every { page } returns mockk {
+            every { manifest } returns Manifest(code = TOOL, locale = Locale.ENGLISH)
+            every { id } returns PAGE
+        }
+    }
+
+    @Test
+    fun `Property - screen`() {
+        assertEquals("tool:page:card", CyoaCardCollectionPageAnalyticsScreenEvent(card).screen)
+    }
+}

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonPageAnalyticsScreenEvent.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonPageAnalyticsScreenEvent.kt
@@ -1,9 +1,8 @@
 package org.cru.godtools.tool.lesson.analytics.model
 
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
 
 class LessonPageAnalyticsScreenEvent(page: LessonPage) :
-    ToolAnalyticsScreenEvent(page.toAnalyticsScreenName(), page.manifest)
-
-private fun LessonPage.toAnalyticsScreenName() = "${manifest.code}-$position"
+    ToolAnalyticsScreenEvent(ToolAnalyticsScreenNames.forLessonPage(page), page.manifest)

--- a/ui/tips-renderer/src/main/kotlin/org/cru/godtools/tool/tips/analytics/model/TipAnalyticsScreenEvent.kt
+++ b/ui/tips-renderer/src/main/kotlin/org/cru/godtools/tool/tips/analytics/model/TipAnalyticsScreenEvent.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.tool.tips.analytics.model
 
 import java.util.Locale
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 
 class TipAnalyticsScreenEvent(tool: String, locale: Locale, tipId: String, page: Int) :
-    ToolAnalyticsScreenEvent("$tool-tip-$tipId-$page", tool, locale)
+    ToolAnalyticsScreenEvent(ToolAnalyticsScreenNames.forTipPage(tool, tipId, page), tool, locale)

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEvent.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEvent.kt
@@ -1,18 +1,9 @@
 package org.cru.godtools.tract.analytics.model
 
 import org.cru.godtools.base.tool.analytics.model.ToolAnalyticsScreenEvent
+import org.cru.godtools.shared.tool.analytics.ToolAnalyticsScreenNames
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage.Card
 
 class TractPageAnalyticsScreenEvent(page: TractPage, card: Card? = null) :
-    ToolAnalyticsScreenEvent(page.toAnalyticsScreenName(card), page.manifest)
-
-private fun TractPage.toAnalyticsScreenName(card: Card?) = buildString {
-    append(manifest.code).append('-').append(position)
-    when (val pos = card?.position) {
-        null -> Unit
-        // convert card index to letter 'a'-'z'
-        in 0..25 -> append((97 + pos).toChar())
-        else -> append('-').append(pos)
-    }
-}
+    ToolAnalyticsScreenEvent(ToolAnalyticsScreenNames.forTractPage(page, card), page.manifest)


### PR DESCRIPTION
- utilize analytics constant names from godtools shared
- add a unit test for the analytics screen name of a card collection page card
- update several tool analytics events to utilize the shared tool analytics screen names
- add analytics event for the account activity page
