### PR TITLE
GT-1864 Some cleanup and tests for ToolDetailsLanguages()

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -52,7 +52,6 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
-import java.text.Collator
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
 import org.ccci.gto.android.common.androidx.compose.material3.ClickableText
@@ -72,6 +71,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.getDescription
 import org.cru.godtools.model.getName
+import org.cru.godtools.model.getSortedDisplayNames
 import org.cru.godtools.ui.tooldetails.analytics.model.ToolDetailsScreenEvent
 import org.cru.godtools.ui.tools.DownloadProgressIndicator
 import org.cru.godtools.ui.tools.PreloadTool
@@ -340,12 +340,7 @@ internal fun ToolDetailsLanguages(viewModel: ToolViewModels.ToolViewModel, modif
     val context = LocalContext.current
     val locale = LocaleCompat.getDefault(LocaleCompat.Category.DISPLAY)
     val displayLanguages by remember(context, locale) {
-        derivedStateOf {
-            languages
-                .map { it.getDisplayName(context) }
-                .sortedWith(Collator.getInstance(locale).apply { strength = Collator.PRIMARY })
-                .joinToString(", ")
-        }
+        derivedStateOf { languages.getSortedDisplayNames(context, locale).joinToString(", ") }
     }
 
     Column(modifier = modifier.fillMaxWidth()) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -80,6 +80,9 @@ import org.cru.godtools.ui.tools.VariantToolCard
 
 private val TOOL_DETAILS_HORIZONTAL_MARGIN = 32.dp
 
+internal const val TEST_TAG_ACTION_TOOL_TRAINING = "action_tool_training"
+internal const val TEST_TAG_LANGUAGES_AVAILABLE = "languages_available"
+
 @Composable
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalPagerApi::class)
 fun ToolDetailsLayout(
@@ -245,7 +248,7 @@ internal fun ToolDetailsActions(
         Button(
             onClick = { onOpenToolTraining(tool, translation.value) },
             modifier = Modifier
-                .testTag("action_tool_training")
+                .testTag(TEST_TAG_ACTION_TOOL_TRAINING)
                 .fillMaxWidth()
         ) { Text(stringResource(R.string.action_tools_open_training)) }
     }
@@ -329,7 +332,8 @@ private fun ToolDetailsVariants(
 }
 
 @Composable
-private fun ToolDetailsLanguages(viewModel: ToolViewModels.ToolViewModel, modifier: Modifier = Modifier) {
+@VisibleForTesting
+internal fun ToolDetailsLanguages(viewModel: ToolViewModels.ToolViewModel, modifier: Modifier = Modifier) {
     val languages by viewModel.availableLanguages.collectAsState()
     if (languages.isEmpty()) return
 
@@ -353,7 +357,9 @@ private fun ToolDetailsLanguages(viewModel: ToolViewModels.ToolViewModel, modifi
         Text(
             displayLanguages,
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(top = 8.dp)
+            modifier = Modifier
+                .testTag(TEST_TAG_LANGUAGES_AVAILABLE)
+                .padding(top = 8.dp)
         )
     }
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
@@ -33,7 +33,7 @@ class Language : Base() {
 
     fun getDisplayName(context: Context?) = getDisplayName(context, null)
     fun getDisplayName(context: Context?, inLocale: Locale?) =
-        _code?.getDisplayName(context, name, inLocale).orEmpty()
+        _code?.getDisplayName(context, name, inLocale) ?: name ?: ""
 
     // XXX: output the language id and code for debugging purposes
     override fun toString() = "Language{id=$id, code=$_code}"

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
@@ -45,3 +45,6 @@ fun Collection<Language>.toDisplayNameSortedMap(context: Context?, displayLocale
 
 fun Collection<Language>.sortedByDisplayName(context: Context?, displayLocale: Locale? = null): List<Language> =
     toDisplayNameSortedMap(context, displayLocale).values.toList()
+
+fun Collection<Language>.getSortedDisplayNames(context: Context?, displayLocale: Locale? = null) =
+    toDisplayNameSortedMap(context, displayLocale).keys.toList()

--- a/library/model/src/test/kotlin/org/cru/godtools/model/LanguageTest.kt
+++ b/library/model/src/test/kotlin/org/cru/godtools/model/LanguageTest.kt
@@ -27,4 +27,16 @@ class LanguageTest {
     private fun parseJson(file: String) = this::class.java.getResourceAsStream(file)!!.reader()
         .use { jsonApiConverter.fromJson(it.readText(), Language::class.java).dataSingle!! }
     // endregion jsonapi parsing
+
+    // region getDisplayName()
+    @Test
+    fun `getDisplayName() - Missing Locale and Default Name`() {
+        assertEquals("", Language().getDisplayName(null))
+    }
+
+    @Test
+    fun `getDisplayName() - Missing Locale`() {
+        assertEquals("Default Name", Language().apply { name = "Default Name" }.getDisplayName(null))
+    }
+    // endregion getDisplayName()
 }


### PR DESCRIPTION
- make sure the display name defaults to the default name if no locale is present
- add a couple unit tests for ToolDetailsLanguages()
- utilize getSortedDisplayNames() for the ToolDetailsLanguages composable
