### PR TITLE
cleanup

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/GlobalActivityEntity.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/GlobalActivityEntity.kt
@@ -25,10 +25,10 @@ internal class GlobalActivityEntity(
     @PrimaryKey
     var id = ID
 
-    fun toModel() = GlobalActivityAnalytics().also {
-        it.users = users
-        it.countries = countries
-        it.launches = launches
-        it.gospelPresentations = gospelPresentations
-    }
+    fun toModel() = GlobalActivityAnalytics(
+        users = users,
+        countries = countries,
+        launches = launches,
+        gospelPresentations = gospelPresentations
+    )
 }

--- a/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/db/DownloadManagerRepository.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/db/DownloadManagerRepository.kt
@@ -7,14 +7,14 @@ import org.ccci.gto.android.common.db.Expression.Companion.bind
 import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.getAsFlow
 import org.cru.godtools.model.Translation
-import org.keynote.godtools.android.db.Contract
+import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
 
 private val QUERY_FAVORITE_TRANSLATIONS = Query.select<Translation>()
     .joins(TranslationTable.SQL_JOIN_TOOL)
     .where(
-        Contract.ToolTable.FIELD_ADDED.eq(true)
+        ToolTable.FIELD_ADDED.eq(true)
             .and(TranslationTable.SQL_WHERE_PUBLISHED)
             .and(TranslationTable.FIELD_DOWNLOADED.eq(false))
     )

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Base.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Base.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.model
 
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiId
-import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 
 abstract class Base {
     companion object {
@@ -15,12 +14,4 @@ abstract class Base {
         set(id) {
             _id = id
         }
-
-    @JsonApiIgnore
-    private var stashedId: Long? = null
-
-    fun stashId() {
-        stashedId = _id
-        _id = null
-    }
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/GlobalActivityAnalytics.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/GlobalActivityAnalytics.kt
@@ -11,13 +11,13 @@ private const val JSON_LAUNCHES = "launches"
 private const val JSON_GOSPEL_PRESENTATIONS = "gospel-presentations"
 
 @JsonApiType(JSON_API_TYPE_GLOBAL_ANALYTICS)
-class GlobalActivityAnalytics : Base() {
+data class GlobalActivityAnalytics(
     @JsonApiAttribute(JSON_USERS)
-    var users = 0
+    var users: Int = 0,
     @JsonApiAttribute(JSON_COUNTRIES)
-    var countries = 0
+    var countries: Int = 0,
     @JsonApiAttribute(JSON_LAUNCHES)
-    var launches = 0
+    var launches: Int = 0,
     @JsonApiAttribute(JSON_GOSPEL_PRESENTATIONS)
-    var gospelPresentations = 0
-}
+    var gospelPresentations: Int = 0,
+)

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
@@ -2,13 +2,10 @@ package org.cru.godtools.sync.task
 
 import android.database.sqlite.SQLiteDatabase
 import io.mockk.Called
-import io.mockk.every
-import io.mockk.excludeRecords
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
 import java.util.Locale
-import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.model.Language
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -27,16 +24,9 @@ class BaseDataSyncTasksTest {
 
     @Test
     fun `storeLanguage()`() {
-        // setup test
         val language = Language().apply {
             id = 1
             code = Locale("lt")
-        }
-        every { dao.refresh(any()) } returns null
-        every { dao.get(any<Query<Language>>()) } returns emptyList()
-        excludeRecords {
-            dao.refresh(any())
-            dao.get(any<Query<Language>>())
         }
 
         // run test


### PR DESCRIPTION
- remove some unnecessary mocking
- tweak imports
- remove unused stashId functionality
- GlobalActivityEntity doesn't need to extend the Base model
