### PR TITLE
GT-1879 make MultiLanguageToolActivityDataModel.locales a StateFlow

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivity.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.annotation.LayoutRes
 import androidx.databinding.ViewDataBinding
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.tabs.TabLayout
@@ -76,7 +75,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
 
     // region Intent Processing
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
-        if (dataModel.locales.value.isNullOrEmpty()) {
+        if (dataModel.primaryLocales.value.isNullOrEmpty() && dataModel.parallelLocales.value.isNullOrEmpty()) {
             val extras = intent.extras ?: return
             val locales = extras.getLocaleArray(EXTRA_LANGUAGES)?.filterNotNull().orEmpty()
             dataModel.primaryLocales.value = locales.take(1)
@@ -85,7 +84,8 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
     }
 
     override val isValidStartState
-        get() = !dataModel.toolCode.value.isNullOrEmpty() && !dataModel.locales.value.isNullOrEmpty()
+        get() = !dataModel.toolCode.value.isNullOrEmpty() &&
+            (!dataModel.primaryLocales.value.isNullOrEmpty() || !dataModel.parallelLocales.value.isNullOrEmpty())
     // endregion Intent Processing
 
     // region UI
@@ -157,10 +157,7 @@ abstract class MultiLanguageToolActivity<B : ViewDataBinding>(
         dataModel.toolCode.map { listOfNotNull(it) }
             .stateIn(lifecycleScope, SharingStarted.WhileSubscribed(), emptyList())
     }
-    override val localesToDownload by lazy {
-        dataModel.locales.asFlow()
-            .stateIn(lifecycleScope, SharingStarted.WhileSubscribed(), emptyList())
-    }
+    override val localesToDownload by lazy { dataModel.locales }
     // endregion Tool sync
 
     // region Active Translation management

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -52,6 +52,9 @@ import org.keynote.godtools.android.db.Contract.LanguageTable
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 
+private const val STATE_PRIMARY_LOCALES = "primaryLocales"
+private const val STATE_PARALLEL_LOCALES = "parallelLocales"
+
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
 class MultiLanguageToolActivityDataModel @Inject constructor(
@@ -63,8 +66,8 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     @Named(IS_CONNECTED_LIVE_DATA) isConnected: LiveData<Boolean>,
     savedState: SavedStateHandle,
 ) : BaseToolRendererViewModel(downloadManager, manifestManager, userActivityManager, savedState) {
-    val primaryLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
-    val parallelLocales by savedState.livedata<List<Locale>>(initialValue = emptyList())
+    val primaryLocales = savedState.getLiveData<List<Locale>>(STATE_PRIMARY_LOCALES, emptyList())
+    val parallelLocales = savedState.getLiveData<List<Locale>>(STATE_PARALLEL_LOCALES, emptyList())
 
     // region LiveData Caches
     private val manifestCache = object : LruCache<TranslationKey, LiveData<Manifest?>>(10) {

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -17,6 +17,7 @@ import javax.inject.Named
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
@@ -87,12 +88,16 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
 
     // region Resolved Data
     private val distinctToolCode = savedState.getLiveData<String?>(EXTRA_TOOL).distinctUntilChanged()
-    val locales = combine(primaryLocales, parallelLocales) { prim, para -> prim + para }.distinctUntilChanged()
+    val locales = combine(
+        savedState.getStateFlow<List<Locale>>(STATE_PRIMARY_LOCALES, emptyList()),
+        savedState.getStateFlow<List<Locale>>(STATE_PARALLEL_LOCALES, emptyList())
+    ) { prim, para -> (prim + para).distinct() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val tool = toolCode.flatMapLatest { it?.let { dao.findAsFlow<Tool>(it) } ?: flowOf(null) }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    val languages = locales.switchMap {
+    val languages = locales.asLiveData().switchMap {
         Query.select<Language>()
             .where(LanguageTable.FIELD_CODE.`in`(*Expression.constants(*it.toTypedArray())))
             .getAsLiveData(dao)
@@ -100,7 +105,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
 
     @VisibleForTesting
     internal val translations =
-        locales.switchFold(ImmutableLiveData(emptyList<Pair<Locale, Translation?>>())) { acc, locale ->
+        locales.asLiveData().switchFold(ImmutableLiveData(emptyList<Pair<Locale, Translation?>>())) { acc, locale ->
             distinctToolCode.switchMap { translationCache.get(it, locale).withInitialValue(null) }
                 .distinctUntilChanged()
                 .combineWith(acc.distinctUntilChanged()) { it, translations -> translations + Pair(locale, it) }
@@ -108,7 +113,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
 
     @VisibleForTesting
     internal val manifests =
-        locales.switchFold(ImmutableLiveData(emptyList<Pair<Locale, Manifest?>>())) { acc, locale ->
+        locales.asLiveData().switchFold(ImmutableLiveData(emptyList<Pair<Locale, Manifest?>>())) { acc, locale ->
             distinctToolCode.switchMap { manifestCache.get(it, locale).withInitialValue(null) }
                 .distinctUntilChanged()
                 .combineWith(acc.distinctUntilChanged()) { it, manifests -> manifests + Pair(locale, it) }
@@ -118,7 +123,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
     // region Loading State
     val isInitialSyncFinished = MutableStateFlow(false)
 
-    val loadingState = locales.combineWith(
+    val loadingState = locales.asLiveData().combineWith(
         manifests,
         translations,
         supportedType.asLiveData(),
@@ -196,7 +201,7 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
 
     init {
         // initialize the activeLocale if it hasn't been initialized yet
-        locales.map { it.firstOrNull() }.notNull().observeOnce(this) {
+        locales.asLiveData().map { it.firstOrNull() }.notNull().observeOnce(this) {
             if (activeLocale.value == null) activeLocale.value = it
         }
 

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -162,7 +162,10 @@ class TractActivity :
         if (savedInstanceState == null) initialPage = intent.getIntExtra(EXTRA_PAGE, initialPage)
 
         // deep link parsing
-        if (savedInstanceState == null || dataModel.locales.value.isNullOrEmpty()) {
+        if (
+            savedInstanceState == null ||
+            (dataModel.primaryLocales.value.isNullOrEmpty() && dataModel.parallelLocales.value.isNullOrEmpty())
+        ) {
             if (intent.action != Intent.ACTION_VIEW) return
             val data = intent.data?.normalizeScheme() ?: return
             val path = data.pathSegments ?: return
@@ -403,7 +406,7 @@ class TractActivity :
         event.locale?.takeUnless { it == dataModel.activeLocale.value }?.let {
             dataModel.toolCode.value?.let { tool -> downloadManager.downloadLatestPublishedTranslationAsync(tool, it) }
             // The requested locale is not an available locale, so add it as a parallelLocale
-            if (it !in dataModel.locales.value.orEmpty()) {
+            if (it !in dataModel.locales.value) {
                 dataModel.parallelLocales.value = dataModel.parallelLocales.value.orEmpty() + it
             }
             dataModel.activeLocale.value = it


### PR DESCRIPTION
- don't use the pointless livedata delegate for the primary and parallel locales
- update MultiLanguageToolActivityDataModel.locales to be a StateFlow
