### PR TITLE
Revert "Update dependency androidx.compose.compiler:compiler to v1.4.0-alpha02"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanist = "0.28.0"
 android-gradle-plugin = "7.3.1"
 androidx-compose-ui = "1.3.2"
-androidx-compose-compiler = "1.4.0-alpha02"
+androidx-compose-compiler = "1.4.0-dev-k1.7.21-d324f46b7bd"
 androidx-core = "1.9.0"
 androidx-hilt = "1.0.0"
 androidx-lifecycle = "2.5.1"


### PR DESCRIPTION
This reverts commit f0259da224dba5187741c2a87c856fdaa5e9d4eb.

There is some incompatibility in the 1.4.0-alpha02 compiler, I think it was originally masked by the gradle build cache.