### PR TITLE
GT-1791 Fix syncing followups to the API

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/LanguagesRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/LanguagesRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.model.Language
 
 interface LanguagesRepository {
+    suspend fun findLanguage(locale: Locale): Language?
     fun getLanguageFlow(locale: Locale): Flow<Language?>
     suspend fun getLanguages(): List<Language>
     fun getLanguagesForLocalesFlow(locales: Collection<Locale>): Flow<Collection<Language>>

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/LanguagesDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/LanguagesDao.kt
@@ -17,6 +17,8 @@ internal interface LanguagesDao {
     fun insertOrReplaceLanguages(languages: Collection<LanguageEntity>)
 
     @Query("SELECT * FROM languages WHERE code = :locale")
+    suspend fun findLanguage(locale: Locale): LanguageEntity?
+    @Query("SELECT * FROM languages WHERE code = :locale")
     fun findLanguageFlow(locale: Locale): Flow<LanguageEntity?>
 
     @Query("SELECT * FROM languages")

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepository.kt
@@ -14,6 +14,7 @@ import org.cru.godtools.model.Language
 internal abstract class LanguagesRoomRepository(private val db: GodToolsRoomDatabase) : LanguagesRepository {
     val dao get() = db.languagesDao
 
+    override suspend fun findLanguage(locale: Locale) = dao.findLanguage(locale)?.toModel()
     override fun getLanguageFlow(locale: Locale) = dao.findLanguageFlow(locale).map { it?.toModel() }
     override suspend fun getLanguages() = dao.getLanguages().map { it.toModel() }
     override fun getLanguagesForLocalesFlow(locales: Collection<Locale>): Flow<Collection<Language>> =

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/LanguagesRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/LanguagesRepositoryIT.kt
@@ -32,6 +32,17 @@ abstract class LanguagesRepositoryIT {
     }
 
     @Test
+    fun `findLanguage()`() = testScope.runTest {
+        assertNull(repository.findLanguage(Locale.ENGLISH))
+
+        repository.storeLanguageFromSync(language1)
+        assertEquals(language1, repository.findLanguage(Locale.ENGLISH))
+
+        repository.removeLanguagesMissingFromSync(syncedLanguages = emptyList())
+        assertNull(repository.findLanguage(Locale.ENGLISH))
+    }
+
+    @Test
     fun `getLanguageFlow()`() = testScope.runTest {
         repository.getLanguageFlow(Locale.ENGLISH).test {
             assertNull(awaitItem())

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Followup.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Followup.kt
@@ -5,6 +5,7 @@ import java.util.Locale
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiType
+import org.jetbrains.annotations.VisibleForTesting
 
 private const val JSON_API_TYPE_FOLLOWUP = "follow_up"
 
@@ -28,8 +29,10 @@ class Followup(
     @JsonApiIgnore
     val createTime: Instant = Instant.now(),
 ) {
+    @VisibleForTesting
     @JsonApiAttribute(JSON_LANGUAGE)
-    private var languageId: Long? = null
+    var languageId: Long? = null
+        private set
 
     fun setLanguage(language: Language?) {
         languageId = language?.id

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -34,7 +34,9 @@ import org.cru.godtools.sync.work.scheduleSyncLanguagesWork
 import org.cru.godtools.sync.work.scheduleSyncToolSharesWork
 import org.cru.godtools.sync.work.scheduleSyncToolsWork
 import org.greenrobot.eventbus.EventBus
+import timber.log.Timber
 
+private const val TAG = "GodToolsSyncService"
 private const val SYNC_PARALLELISM = 8
 
 private const val EXTRA_SYNCTYPE = "org.cru.godtools.sync.GodToolsSyncService.EXTRA_SYNCTYPE"
@@ -96,6 +98,9 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
         try {
             with<T, Boolean> { block() }
         } catch (e: IOException) {
+            false
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Unhandled sync exception")
             false
         }
     }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/FollowupSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/FollowupSyncTasks.kt
@@ -7,16 +7,15 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.ccci.gto.android.common.db.find
 import org.cru.godtools.api.FollowupApi
 import org.cru.godtools.db.repository.FollowupsRepository
-import org.keynote.godtools.android.db.GodToolsDao
+import org.cru.godtools.db.repository.LanguagesRepository
 
 @Singleton
 internal class FollowupSyncTasks @Inject internal constructor(
-    private val dao: GodToolsDao,
     private val followupApi: FollowupApi,
     private val followupsRepository: FollowupsRepository,
+    private val languagesRepository: LanguagesRepository,
 ) : BaseSyncTasks() {
     private val followupsMutex = Mutex()
 
@@ -26,7 +25,7 @@ internal class FollowupSyncTasks @Inject internal constructor(
                 .map { followup ->
                     async {
                         try {
-                            followup.languageCode?.let { followup.setLanguage(dao.find(it)) }
+                            followup.setLanguage(languagesRepository.findLanguage(followup.languageCode))
                             followupApi.subscribe(followup).isSuccessful
                                 .also {
                                     if (it) {

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/work/SyncToolsWorker.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/work/SyncToolsWorker.kt
@@ -12,8 +12,10 @@ import org.cru.godtools.sync.task.ToolSyncTasks
 
 private const val WORK_NAME = "SyncTools"
 
+private val SYNC_TOOLS_WORK_REQUEST = SyncWorkRequestBuilder<SyncToolsWorker>().build()
+
 internal fun WorkManager.scheduleSyncToolsWork() =
-    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SyncWorkRequestBuilder<SyncToolsWorker>().build())
+    enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.KEEP, SYNC_TOOLS_WORK_REQUEST)
 
 @HiltWorker
 internal class SyncToolsWorker @AssistedInject constructor(

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
@@ -2,9 +2,13 @@ package org.cru.godtools.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
+import io.mockk.Called
 import io.mockk.coEvery
-import io.mockk.coVerify
+import io.mockk.coVerifyAll
+import io.mockk.every
+import io.mockk.excludeRecords
 import io.mockk.mockk
+import java.io.IOException
 import javax.inject.Provider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -12,8 +16,12 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.sync.task.BaseSyncTasks
 import org.cru.godtools.sync.task.ToolSyncTasks
+import org.cru.godtools.sync.work.scheduleSyncToolsWork
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import timber.log.Timber
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -23,15 +31,68 @@ class GodToolsSyncServiceTest {
     private val syncTasks = mapOf<Class<out BaseSyncTasks>, Provider<BaseSyncTasks>>(
         ToolSyncTasks::class.java to Provider { toolsSyncTasks }
     )
+    private val timber: Timber.Tree = mockk(relaxed = true)
     private val workManager: WorkManager = mockk()
     private val testScope = TestScope()
 
     private val syncService =
         GodToolsSyncService(mockk(relaxUnitFun = true), { workManager }, syncTasks, UnconfinedTestDispatcher())
 
+    @Before
+    fun setup() {
+        Timber.plant(timber)
+        excludeRecords { Timber.tag(any()) }
+    }
+
+    @After
+    fun cleanup() {
+        Timber.uproot(timber)
+    }
+
     @Test
-    fun testSyncTools() = testScope.runTest {
+    fun `syncTools()`() = testScope.runTest {
         syncService.syncTools(false)
-        coVerify { toolsSyncTasks.syncTools(any()) }
+        coVerifyAll {
+            toolsSyncTasks.syncTools(false)
+            workManager wasNot Called
+        }
+    }
+
+    @Test
+    fun `syncTools() - Failure`() = testScope.runTest {
+        coEvery { toolsSyncTasks.syncTools(any()) } returns false
+        every { workManager.scheduleSyncToolsWork() } returns mockk()
+
+        syncService.syncTools(false)
+        coVerifyAll {
+            toolsSyncTasks.syncTools(false)
+            workManager.scheduleSyncToolsWork()
+        }
+    }
+
+    @Test
+    fun `syncTools() - Failure - IOException`() = testScope.runTest {
+        coEvery { toolsSyncTasks.syncTools(any()) } throws IOException()
+        every { workManager.scheduleSyncToolsWork() } returns mockk()
+
+        syncService.syncTools(false)
+        coVerifyAll {
+            toolsSyncTasks.syncTools(false)
+            workManager.scheduleSyncToolsWork()
+        }
+    }
+
+    @Test
+    fun `syncTools() - Failure - Other Exception`() = testScope.runTest {
+        val e = Exception()
+        coEvery { toolsSyncTasks.syncTools(any()) } throws e
+        every { workManager.scheduleSyncToolsWork() } returns mockk()
+
+        syncService.syncTools(false)
+        coVerifyAll {
+            toolsSyncTasks.syncTools(false)
+            timber.e(e, any())
+            workManager.scheduleSyncToolsWork()
+        }
     }
 }

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/FollowupSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/FollowupSyncTasksTest.kt
@@ -1,0 +1,89 @@
+package org.cru.godtools.sync.task
+
+import io.mockk.Called
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerifyAll
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import java.util.Locale
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.cru.godtools.api.FollowupApi
+import org.cru.godtools.db.repository.FollowupsRepository
+import org.cru.godtools.db.repository.LanguagesRepository
+import org.cru.godtools.model.Followup
+import org.cru.godtools.model.Language
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FollowupSyncTasksTest {
+
+    private val api: FollowupApi = mockk()
+    private val followupsRepository: FollowupsRepository = mockk {
+        coEvery { getFollowups() } returns emptyList()
+        coEvery { deleteFollowup(any()) } just Runs
+    }
+    private val languagesRepository: LanguagesRepository = mockk {
+        coEvery { findLanguage(any()) } returns null
+    }
+
+    private val syncTasks = FollowupSyncTasks(api, followupsRepository, languagesRepository)
+
+    @Test
+    fun `syncFollowups() - No Followups to sync`() = runTest {
+        assertTrue(syncTasks.syncFollowups())
+        coVerifyAll {
+            followupsRepository.getFollowups()
+            api wasNot Called
+        }
+    }
+
+    @Test
+    fun `syncFollowups()`() = runTest {
+        val followups = listOf(Followup(email = "test@example.com", destination = 1, languageCode = Locale.ENGLISH))
+        coEvery { followupsRepository.getFollowups() } returns followups
+        coEvery { languagesRepository.findLanguage(Locale.ENGLISH) } returns Language().apply {
+            code = Locale.ENGLISH
+            id = 2
+        }
+        val followup = slot<Followup>()
+        coEvery { api.subscribe(capture(followup)) } returns Response.success(null)
+
+        assertTrue(syncTasks.syncFollowups())
+        coVerifyAll {
+            followupsRepository.getFollowups()
+            languagesRepository.findLanguage(Locale.ENGLISH)
+            api.subscribe(followup.captured)
+            followupsRepository.deleteFollowup(followup.captured)
+        }
+        assertEquals("Make sure the languageId is set on the followup", 2L, followup.captured.languageId)
+    }
+
+    @Test
+    fun `syncFollowups() - api failed`() = runTest {
+        val followup = Followup(email = "test@example.com", destination = 1, languageCode = Locale.ENGLISH)
+        coEvery { followupsRepository.getFollowups() } returns listOf(followup)
+        coEvery { languagesRepository.findLanguage(Locale.ENGLISH) } returns Language().apply {
+            code = Locale.ENGLISH
+            id = 2
+        }
+        val submittedFollowup = slot<Followup>()
+        coEvery { api.subscribe(capture(submittedFollowup)) } returns Response.error(400, "".toResponseBody())
+
+        assertFalse(syncTasks.syncFollowups())
+        coVerifyAll {
+            followupsRepository.getFollowups()
+            languagesRepository.findLanguage(Locale.ENGLISH)
+            api.subscribe(followup)
+            // We shouldn't delete the followup if the API didn't return success
+            // followupsRepository.deleteFollowup(any())
+        }
+    }
+}


### PR DESCRIPTION
In the various migrations from the legacy DAO to Room I missed updating the logic loading the language object from the database which is used to populate the Followup languageId. This issue would have triggered an exception, but I believe that exception was lost because it was running in a background coroutine.

After fixing the issue I added several tests for each part of the bug and fix implemented.