### PR TITLE
GT-1901 Upgrade to AGP 7.4.0-rc03

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ android {
     }
 
     buildTypes {
-        named("debug") {
+        debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
 
@@ -99,7 +99,7 @@ android {
             buildConfigField("String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.qa.okta\"")
             resValue("string", "app_name_debug", "GodTools (QA)")
         }
-        named("release") {
+        release {
             isMinifyEnabled = true
             signingConfigs.getByName("release")
                 .takeIf { it.storeFile?.exists() == true }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
     baseConfiguration(project)
     configureCompose(project)
     configureQaBuildType(project)
+    configureGodToolsCustomUri()
 
     defaultConfig {
         applicationId = "org.keynote.godtools.android"
@@ -75,12 +76,7 @@ android {
 
             isMinifyEnabled = false
 
-            manifestPlaceholders += mapOf(
-                "webAuthenticationRedirectScheme" to "org.cru.godtools.debug.okta",
-                "hostGodtoolsCustomUri" to "org.cru.godtools.debug"
-            )
-
-            buildConfigField("String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools.debug\"")
+            manifestPlaceholders += "webAuthenticationRedirectScheme" to "org.cru.godtools.debug.okta"
             buildConfigField("String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.debug.okta\"")
             resValue("string", "app_name_debug", "GodTools (Dev)")
         }
@@ -90,12 +86,7 @@ android {
 
             isMinifyEnabled = true
 
-            manifestPlaceholders += mapOf(
-                "webAuthenticationRedirectScheme" to "org.cru.godtools.qa.okta",
-                "hostGodtoolsCustomUri" to "org.cru.godtools.qa"
-            )
-
-            buildConfigField("String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools.qa\"")
+            manifestPlaceholders += "webAuthenticationRedirectScheme" to "org.cru.godtools.qa.okta"
             buildConfigField("String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.qa.okta\"")
             resValue("string", "app_name_debug", "GodTools (QA)")
         }
@@ -105,12 +96,7 @@ android {
                 .takeIf { it.storeFile?.exists() == true }
                 ?.let { signingConfig = it }
 
-            manifestPlaceholders += mapOf(
-                "webAuthenticationRedirectScheme" to "org.cru.godtools.okta",
-                "hostGodtoolsCustomUri" to "org.cru.godtools"
-            )
-
-            buildConfigField("String", "HOST_GODTOOLS_CUSTOM_URI", "\"org.cru.godtools\"")
+            manifestPlaceholders += "webAuthenticationRedirectScheme" to "org.cru.godtools.okta"
             buildConfigField("String", "OKTA_AUTH_SCHEME", "\"org.cru.godtools.okta\"")
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/dagger/ConfigModule.kt
+++ b/app/src/main/kotlin/org/cru/godtools/dagger/ConfigModule.kt
@@ -7,7 +7,6 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.api.ApiModule
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -15,8 +14,4 @@ object ConfigModule {
     @get:Provides
     @get:Named(ApiModule.MOBILE_CONTENT_API_URL)
     val mobileContentApiBaseUrl = BuildConfig.MOBILE_CONTENT_API
-
-    @get:Provides
-    @get:Named(DAGGER_HOST_CUSTOM_URI)
-    val godtoolsCustomUriHost = BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 }

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -14,8 +14,8 @@ import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
 internal const val BUILD_TYPE_QA = "qa"
-private const val FLAVOR_DIMENSION_ENV = "env"
-private const val FLAVOR_ENV_STAGE = "stage"
+const val FLAVOR_DIMENSION_ENV = "env"
+const val FLAVOR_ENV_STAGE = "stage"
 private const val FLAVOR_ENV_PRODUCTION = "production"
 
 // TODO: provide Project using the new multiple context receivers functionality.

--- a/buildSrc/src/main/kotlin/GodToolsCustomUriConfiguration.kt
+++ b/buildSrc/src/main/kotlin/GodToolsCustomUriConfiguration.kt
@@ -1,0 +1,24 @@
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.VariantDimension
+
+private const val BUILD_CONFIG_FIELD_HOST = "HOST_GODTOOLS_CUSTOM_URI"
+private const val PLACEHOLDER_HOST = "hostGodtoolsCustomUri"
+
+fun CommonExtension<*, *, *, *>.configureGodToolsCustomUri() {
+    buildTypes {
+        named("debug") {
+            setHost("org.cru.godtools.debug")
+        }
+        named(BUILD_TYPE_QA) {
+            setHost("org.cru.godtools.qa")
+        }
+        named("release") {
+            setHost("org.cru.godtools")
+        }
+    }
+}
+
+private fun VariantDimension.setHost(host: String) {
+    manifestPlaceholders += PLACEHOLDER_HOST to host
+    buildConfigField("String", BUILD_CONFIG_FIELD_HOST, "\"$host\"")
+}

--- a/buildSrc/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/DownloadApiResourcesTask.kt
+++ b/buildSrc/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/DownloadApiResourcesTask.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.gradle.bundledcontent
 
 import de.undercouch.gradle.tasks.download.DownloadAction
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -21,17 +22,20 @@ abstract class DownloadApiResourcesTask : DefaultTask() {
     lateinit var api: String
 
     @get:OutputDirectory
-    abstract val output: RegularFileProperty
+    abstract val output: DirectoryProperty
+    @get:Input
+    var outputSubDir: String? = null
 
     @TaskAction
     fun downloadApiResources() {
         val resourcesJson = resources.asFile.get().loadJson()
+        val downloadDir = output.dir(outputSubDir ?: ".").get().asFile
 
         resourcesJson.keySet().map { resource ->
             val fileName = resourcesJson.getString(resource)
             DownloadAction(project).apply {
                 src("$api$resource")
-                dest(output.asFile.get().resolve(fileName))
+                dest(downloadDir.resolve(fileName))
                 overwrite(false)
                 retries(2)
                 tempAndMove(true)

--- a/buildSrc/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/PruneJsonApiResponseTask.kt
+++ b/buildSrc/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/PruneJsonApiResponseTask.kt
@@ -1,11 +1,12 @@
 package org.cru.godtools.gradle.bundledcontent
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -28,8 +29,10 @@ abstract class PruneJsonApiResponseTask : DefaultTask() {
     @get:Input
     var sortRelationships = true
 
-    @get:OutputFile
-    abstract val output: RegularFileProperty
+    @get:OutputDirectory
+    abstract val output: DirectoryProperty
+    @get:Input
+    lateinit var outputFilename: String
 
     @TaskAction
     fun pruneJsonApi() {
@@ -45,7 +48,7 @@ abstract class PruneJsonApiResponseTask : DefaultTask() {
         if (sortData) json.optJSONArray("data")?.sortJsonApiObjects()
         json.optJSONArray("included")?.sortJsonApiObjects()
 
-        json.writeJson(output.asFile.get())
+        json.writeJson(output.file(outputFilename).get().asFile)
     }
 
     private fun JSONObject.removeJsonApiAttributes() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = "0.28.0"
-android-gradle-plugin = "7.3.1"
+android-gradle-plugin = "7.4.0-rc03"
 androidx-compose-ui = "1.3.2"
 androidx-compose-compiler = "1.4.0-dev-k1.7.21-d324f46b7bd"
 androidx-core = "1.9.0"

--- a/library/base/src/main/kotlin/org/cru/godtools/base/Constants.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/Constants.kt
@@ -14,6 +14,3 @@ const val HOST_GET_GODTOOLSAPP_COM = "get.godtoolsapp.com"
 const val HOST_KNOWGOD_COM = "knowgod.com"
 
 val URI_SHARE_BASE: Uri = Uri.parse("https://$HOST_KNOWGOD_COM/")
-
-// Dagger Qualifiers
-const val DAGGER_HOST_CUSTOM_URI = "godtoolsCustomUriHost"

--- a/library/initial-content/build.gradle.kts
+++ b/library/initial-content/build.gradle.kts
@@ -11,18 +11,20 @@ android {
 
     baseConfiguration(project)
     configureFlavorDimensions(project)
+}
 
-    libraryVariants.configureEach {
-        val mobileContentApi =
-            if (flavorName.contains("stage")) URI_MOBILE_CONTENT_API_STAGE else URI_MOBILE_CONTENT_API_PRODUCTION
-
-        configureBundledContent(
+androidComponents {
+    onVariants {
+        it.configureBundledContent(
             project,
-            apiUrl = mobileContentApi,
+            apiUrl = when (it.productFlavors.toMap()[FLAVOR_DIMENSION_ENV]) {
+                FLAVOR_ENV_STAGE -> URI_MOBILE_CONTENT_API_STAGE
+                else -> URI_MOBILE_CONTENT_API_PRODUCTION
+            },
             bundledTools = listOf("kgp", "fourlaws", "satisfied", "teachmetoshare"),
             bundledAttachments = listOf("attr-banner", "attr-banner-about", "attr-about-banner-animation"),
             bundledLanguages = listOf("en"),
-            downloadTranslations = false
+            downloadTranslations = false,
         )
     }
 }

--- a/ui/article-renderer/build.gradle.kts
+++ b/ui/article-renderer/build.gradle.kts
@@ -7,8 +7,10 @@ plugins {
 
 android {
     namespace = "org.cru.godtools.tool.article"
-
     baseConfiguration(project)
+
+    configureQaBuildType(project)
+    configureGodToolsCustomUri()
 
     buildFeatures {
         dataBinding = true

--- a/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
+++ b/ui/article-renderer/src/main/kotlin/org/cru/godtools/article/ui/ArticlesActivity.kt
@@ -10,8 +10,6 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.asLiveData
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Named
 import kotlinx.coroutines.flow.filterNotNull
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.cru.godtools.article.aem.model.Article
@@ -19,12 +17,12 @@ import org.cru.godtools.article.aem.ui.startAemArticleActivity
 import org.cru.godtools.article.ui.articles.ArticlesFragment
 import org.cru.godtools.article.ui.categories.CategoriesFragment
 import org.cru.godtools.article.ui.categories.CategorySelectedListener
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.tool.activity.BaseArticleActivity
 import org.cru.godtools.shared.tool.parser.model.Category
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.tool.R
+import org.cru.godtools.tool.article.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.databinding.ToolGenericFragmentActivityBinding
 
 @AndroidEntryPoint
@@ -56,10 +54,6 @@ class ArticlesActivity :
     // endregion Lifecycle
 
     // region Intent Processing
-    @Inject
-    @Named(DAGGER_HOST_CUSTOM_URI)
-    internal lateinit var hostCustomUriScheme: String
-
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         val data = intent.data?.normalizeScheme() ?: return
@@ -77,7 +71,7 @@ class ArticlesActivity :
     }
 
     private fun Uri.isCustomUriDeepLink() = scheme == SCHEME_GODTOOLS &&
-        hostCustomUriScheme.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
+        HOST_GODTOOLS_CUSTOM_URI.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
         pathSegments?.getOrNull(0) == "tool" && pathSegments?.getOrNull(1) == "article"
     // endregion Intent Processing
 

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
@@ -9,9 +9,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import javax.inject.Named
 import kotlinx.coroutines.Job
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.DownloadManagerModule
@@ -29,10 +27,6 @@ import org.keynote.godtools.android.db.repository.TranslationsRepository
     ]
 )
 class ExternalSingletonsModule {
-    @get:Provides
-    @get:Named(DAGGER_HOST_CUSTOM_URI)
-    val hostCustomUri = "org.cru.godtools.test"
-
     @get:Provides
     val dao by lazy {
         mockk<GodToolsDao> {

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ui/ArticlesActivityTest.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ui/ArticlesActivityTest.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import java.util.Locale
 import org.cru.godtools.base.ui.createArticlesIntent
+import org.cru.godtools.tool.article.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Rule
@@ -53,7 +54,7 @@ class ArticlesActivityTest {
 
     @Test
     fun `processIntent() - Custom URI Deep Link`() {
-        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/article/$TOOL/en")) {
+        deepLinkScenario(Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/article/$TOOL/en")) {
             it.onActivity {
                 assertEquals(TOOL, it.tool)
                 assertEquals(Locale.ENGLISH, it.locale)

--- a/ui/cyoa-renderer/build.gradle.kts
+++ b/ui/cyoa-renderer/build.gradle.kts
@@ -7,8 +7,10 @@ plugins {
 
 android {
     namespace = "org.cru.godtools.tool.cyoa"
-
     baseConfiguration(project)
+
+    configureQaBuildType(project)
+    configureGodToolsCustomUri()
 
     buildFeatures.dataBinding = true
 }

--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -10,11 +10,8 @@ import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
-import javax.inject.Inject
-import javax.inject.Named
 import org.ccci.gto.android.common.androidx.fragment.app.backStackEntries
 import org.ccci.gto.android.common.androidx.fragment.app.hasPendingActions
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivity
 import org.cru.godtools.base.tool.model.Event
@@ -23,6 +20,7 @@ import org.cru.godtools.shared.tool.parser.model.page.CardCollectionPage
 import org.cru.godtools.shared.tool.parser.model.page.ContentPage
 import org.cru.godtools.shared.tool.parser.model.page.Page
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.tool.cyoa.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.cyoa.R
 import org.cru.godtools.tool.cyoa.databinding.CyoaActivityBinding
 import org.cru.godtools.tool.tips.ShowTipCallback
@@ -71,10 +69,6 @@ class CyoaActivity :
     // endregion Lifecycle
 
     // region Intent Processing
-    @Inject
-    @Named(DAGGER_HOST_CUSTOM_URI)
-    internal lateinit var hostCustomUri: String
-
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         if (savedInstanceState == null || !isValidStartState) {
@@ -91,7 +85,7 @@ class CyoaActivity :
 
     private inline val Uri.isCustomUriSchemeDeepLink
         get() = SCHEME_GODTOOLS.equals(scheme, true) &&
-            hostCustomUri.equals(host, true) &&
+            HOST_GODTOOLS_CUSTOM_URI.equals(host, true) &&
             pathSegments.size >= 4 && path?.startsWith("/tool/cyoa/") == true
     // endregion Intent Processing
 

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
@@ -9,13 +9,11 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import javax.inject.Named
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.analytics.AnalyticsModule
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.GodToolsDownloadManager
@@ -33,10 +31,6 @@ import org.keynote.godtools.android.db.repository.TranslationsRepository
     replaces = [AnalyticsModule::class]
 )
 class ExternalSingletonsModule {
-    @get:Provides
-    @get:Named(DAGGER_HOST_CUSTOM_URI)
-    val hostCustomUri = "org.cru.godtools.test"
-
     @get:Provides
     val dao by lazy {
         mockk<GodToolsDao> {

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -34,6 +34,7 @@ import org.cru.godtools.shared.tool.parser.model.page.backgroundColor
 import org.cru.godtools.shared.tool.parser.model.page.backgroundImageGravity
 import org.cru.godtools.shared.tool.parser.model.page.backgroundImageScaleType
 import org.cru.godtools.shared.tool.parser.model.page.controlColor
+import org.cru.godtools.tool.cyoa.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.cyoa.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -198,7 +199,7 @@ class CyoaActivityTest {
     fun `Intent Processing - Uri Scheme Deep Link`() {
         manifestEnglish.value = manifest(listOf(page1, page2))
 
-        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/cyoa/test/en"))) {
+        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/cyoa/test/en"))) {
             it.onActivity {
                 assertEquals("test", it.dataModel.toolCode.value)
                 assertEquals(listOf(Locale("en")), it.dataModel.primaryLocales.value)
@@ -211,7 +212,7 @@ class CyoaActivityTest {
     fun `Intent Processing - Uri Scheme Deep Link - Specific Page`() {
         manifestEnglish.value = manifest(listOf(page1, page2))
 
-        scenario(intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/cyoa/test/en/page2"))) {
+        scenario(Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/cyoa/test/en/page2"))) {
             it.onActivity {
                 assertEquals("test", it.dataModel.toolCode.value)
                 assertEquals(listOf(Locale("en")), it.dataModel.primaryLocales.value)

--- a/ui/lesson-renderer/build.gradle.kts
+++ b/ui/lesson-renderer/build.gradle.kts
@@ -7,8 +7,10 @@ plugins {
 
 android {
     namespace = "org.cru.godtools.tool.lesson"
-
     baseConfiguration(project)
+
+    configureQaBuildType(project)
+    configureGodToolsCustomUri()
 
     buildFeatures.dataBinding = true
 }

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -18,7 +18,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.combine
@@ -28,7 +27,6 @@ import org.ccci.gto.android.common.androidx.lifecycle.SetLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.getMutableStateFlow
 import org.ccci.gto.android.common.androidx.viewpager2.widget.whileMaintainingVisibleCurrentItem
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.Settings.Companion.FEATURE_LESSON_FEEDBACK
@@ -40,6 +38,7 @@ import org.cru.godtools.base.tool.viewmodel.ToolStateHolder
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.lesson.LessonPage
+import org.cru.godtools.tool.lesson.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.lesson.R
 import org.cru.godtools.tool.lesson.analytics.model.LessonPageAnalyticsScreenEvent
 import org.cru.godtools.tool.lesson.databinding.LessonActivityBinding
@@ -90,10 +89,6 @@ class LessonActivity :
     // endregion Lifecycle
 
     // region Intent Processing
-    @Inject
-    @Named(DAGGER_HOST_CUSTOM_URI)
-    internal lateinit var hostCustomUriScheme: String
-
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         val data = intent.data?.normalizeScheme() ?: return
@@ -116,7 +111,7 @@ class LessonActivity :
     }
 
     private fun Uri.isCustomUriDeepLink() = scheme == SCHEME_GODTOOLS &&
-        hostCustomUriScheme.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
+        HOST_GODTOOLS_CUSTOM_URI.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
         pathSegments?.getOrNull(0) == "tool" && pathSegments?.getOrNull(1) == "lesson"
     // endregion Intent Processing
 

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
@@ -10,9 +10,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import javax.inject.Named
 import kotlinx.coroutines.Job
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.DownloadManagerModule
@@ -28,10 +26,6 @@ import org.keynote.godtools.android.db.repository.TranslationsRepository
     replaces = [DownloadManagerModule::class]
 )
 class ExternalSingletonsModule {
-    @get:Provides
-    @get:Named(DAGGER_HOST_CUSTOM_URI)
-    val hostCustomUri = "org.cru.godtools.test"
-
     @get:Provides
     val dao by lazy {
         mockk<GodToolsDao> {

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivityTest.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivityTest.kt
@@ -15,6 +15,7 @@ import java.util.Locale
 import org.cru.godtools.base.EXTRA_LANGUAGE
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.tool.createLessonActivityIntent
+import org.cru.godtools.tool.lesson.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
@@ -78,7 +79,7 @@ class LessonActivityTest {
 
     @Test
     fun `processIntent() - Custom URI Deep Link`() {
-        val intent = Intent(ACTION_VIEW, Uri.parse("godtools://org.cru.godtools.test/tool/lesson/$TOOL/en"))
+        val intent = Intent(ACTION_VIEW, Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/lesson/$TOOL/en"))
         ActivityScenario.launch<LessonActivity>(intent).use {
             it.onActivity {
                 assertEquals(TOOL, it.tool)

--- a/ui/tract-renderer/build.gradle.kts
+++ b/ui/tract-renderer/build.gradle.kts
@@ -8,8 +8,10 @@ plugins {
 
 android {
     namespace = "org.cru.godtools.tool.tract"
-
     baseConfiguration(project)
+
+    configureQaBuildType(project)
+    configureGodToolsCustomUri()
     createEventBusIndex("org.cru.godtools.tract.TractEventBusIndex")
 
     defaultConfig.vectorDrawables.useSupportLibrary = true

--- a/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
+++ b/ui/tract-renderer/src/main/kotlin/org/cru/godtools/tract/activity/TractActivity.kt
@@ -18,7 +18,6 @@ import com.google.android.instantapps.InstantApps
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
 import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.androidx.fragment.app.showAllowingStateLoss
 import org.ccci.gto.android.common.androidx.lifecycle.combineWith
@@ -27,7 +26,6 @@ import org.ccci.gto.android.common.androidx.lifecycle.observe
 import org.ccci.gto.android.common.androidx.lifecycle.observeOnce
 import org.ccci.gto.android.common.util.includeFallbacks
 import org.cru.godtools.api.model.NavigationEvent
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.EXTRA_PAGE
 import org.cru.godtools.base.SCHEME_GODTOOLS
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_LIVE_SHARE
@@ -42,6 +40,7 @@ import org.cru.godtools.shared.tool.parser.model.tract.Modal
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage
 import org.cru.godtools.shared.tool.parser.model.tract.TractPage.Card
 import org.cru.godtools.tool.tips.ui.TipBottomSheetDialogFragment
+import org.cru.godtools.tool.tract.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.tract.R
 import org.cru.godtools.tool.tract.databinding.TractActivityBinding
 import org.cru.godtools.tract.PARAM_LIVE_SHARE_STREAM
@@ -153,10 +152,6 @@ class TractActivity :
     // endregion Lifecycle
 
     // region Intent Processing
-    @Inject
-    @Named(DAGGER_HOST_CUSTOM_URI)
-    internal lateinit var hostCustomUriScheme: String
-
     override fun processIntent(intent: Intent, savedInstanceState: Bundle?) {
         super.processIntent(intent, savedInstanceState)
         if (savedInstanceState == null) initialPage = intent.getIntExtra(EXTRA_PAGE, initialPage)
@@ -192,7 +187,7 @@ class TractActivity :
     }
 
     private fun Uri.isCustomUriDeepLink() = scheme == SCHEME_GODTOOLS &&
-        hostCustomUriScheme.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
+        HOST_GODTOOLS_CUSTOM_URI.equals(host, true) && pathSegments.orEmpty().size >= 4 &&
         pathSegments?.getOrNull(0) == "tool" && pathSegments?.getOrNull(1) == "tract"
 
     @VisibleForTesting

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/ExternalSingletonsModule.kt
@@ -10,7 +10,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import javax.inject.Named
 import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.db.findAsFlow
@@ -18,7 +17,6 @@ import org.ccci.gto.android.common.scarlet.ReferenceLifecycle
 import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.api.ApiModule
 import org.cru.godtools.api.TractShareService
-import org.cru.godtools.base.DAGGER_HOST_CUSTOM_URI
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.download.manager.DownloadManagerModule
@@ -41,10 +39,6 @@ import org.keynote.godtools.android.db.repository.TranslationsRepository
     ]
 )
 class ExternalSingletonsModule {
-    @get:Provides
-    @get:Named(DAGGER_HOST_CUSTOM_URI)
-    val hostCustomUri = "org.cru.godtools.test"
-
     @get:Provides
     val dao by lazy {
         mockk<GodToolsDao> {

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -28,6 +28,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.model.Translation
 import org.cru.godtools.shared.tool.parser.model.Manifest
 import org.cru.godtools.shared.tool.parser.model.tips.Tip
+import org.cru.godtools.tool.tract.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
 import org.cru.godtools.tool.tract.R
 import org.cru.godtools.tract.PARAM_LIVE_SHARE_STREAM
 import org.junit.Assert.assertEquals
@@ -143,7 +144,7 @@ class TractActivityTest {
 
     @Test
     fun `processIntent() - Deep Link - Custom Uri Scheme`() {
-        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/fr")) {
+        deepLinkScenario(Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/tract/$TOOL/fr")) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.FRENCH, it.dataModel.primaryLocales.value!!.single())
@@ -154,14 +155,14 @@ class TractActivityTest {
 
     @Test
     fun `processIntent() - Deep Link - Custom Uri Scheme - Missing Language`() {
-        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/")) {
+        deepLinkScenario(Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/tract/$TOOL/")) {
             assertEquals(Lifecycle.State.DESTROYED, it.state)
         }
     }
 
     @Test
     fun `processIntent() - Deep Link - Custom Uri Scheme - With Page Num`() {
-        deepLinkScenario(Uri.parse("godtools://org.cru.godtools.test/tool/tract/$TOOL/fr/3")) {
+        deepLinkScenario(Uri.parse("godtools://$HOST_GODTOOLS_CUSTOM_URI/tool/tract/$TOOL/fr/3")) {
             it.onActivity {
                 assertEquals(TOOL, it.dataModel.toolCode.value)
                 assertEquals(Locale.FRENCH, it.dataModel.primaryLocales.value!!.single())


### PR DESCRIPTION
AGP (Android Gradle Plugin) 7.4.0 breaks the following deprecated features:
- test `manifestPlaceholders`
- using `libraryVariants` to dynamically attach downloaded assets

We address these issues by:
- configuring our debug/qa/release `manifestPlaceholders` in each library that uses them
   - I was unable to find any other path to defining `manifestPlaceholders` for test variants. I think this is just a gap in coverage in the AGP as they are migrating to new APIs that interact with the gradle APIs in a cleaner manner. This will probably be addressed with time, but we needed a more immediate solution because this is blocking Kotlin 1.8, which is blocking some new features for Kotlin Multiplatform
- Updating the download initial content script to utilize the "new" `androidComponents.onVariants {}` API
   - This is the new API meant to replace `libraryVariants`, it's been available since AGP 4.0, but is not really documented anywhere that I could find. So it was mostly digging through classes to find what I needed.