### PR TITLE
cleanup

### DIFF
--- a/app/src/debug/kotlin/org/cru/godtools/DebugGodToolsApplication.kt
+++ b/app/src/debug/kotlin/org/cru/godtools/DebugGodToolsApplication.kt
@@ -1,6 +1,6 @@
 package org.cru.godtools
 
-import com.facebook.flipper.plugins.leakcanary2.FlipperLeakListener
+import com.facebook.flipper.plugins.leakcanary2.FlipperLeakEventListener
 import leakcanary.LeakCanary
 import org.ccci.gto.android.common.leakcanary.crashlytics.CrashlyticsEventListener
 import org.ccci.gto.android.common.leakcanary.timber.TimberSharkLog
@@ -17,10 +17,7 @@ class DebugGodToolsApplication : GodToolsApplication() {
     private fun configLeakCanary() {
         SharkLog.logger = TimberSharkLog
         LeakCanary.config = LeakCanary.config.run {
-            copy(
-                eventListeners = eventListeners + CrashlyticsEventListener,
-                onHeapAnalyzedListener = FlipperLeakListener()
-            )
+            copy(eventListeners = eventListeners + CrashlyticsEventListener + FlipperLeakEventListener())
         }
     }
 

--- a/library/sync/src/main/AndroidManifest.xml
+++ b/library/sync/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.cru.godtools.sync">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- WorkManager permissions -->
     <!-- XXX: we only target newer versions of Android for this permission to provide seamless upgrades for old devices -->

--- a/ui/base-tool/build.gradle.kts
+++ b/ui/base-tool/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     kapt(libs.google.auto.value)
     kapt(libs.hilt.compiler)
 
+    testImplementation(kotlin("reflect"))
     testImplementation(kotlin("test"))
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.lifecycle.runtime.testing)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/shareable/ShareableImageBottomSheetDialogFragmentDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/shareable/ShareableImageBottomSheetDialogFragmentDataModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -15,6 +16,7 @@ import org.cru.godtools.base.tool.service.ManifestManager
 import org.cru.godtools.shared.tool.parser.model.shareable.ShareableImage
 
 @HiltViewModel
+@OptIn(ExperimentalCoroutinesApi::class)
 class ShareableImageBottomSheetDialogFragmentDataModel @Inject constructor(manifestManager: ManifestManager) :
     ViewModel() {
     val tool = MutableStateFlow<String?>(null)


### PR DESCRIPTION
- switch to FlipperLeakEventListener
- switch to jvmToolchain for configuring the target jvm version
- add kotlin-reflect to the test classpath to avoid a reflection warning
- its no longer necessary to specify the package in the AndroidManifest.xml file
