### PR TITLE
Disable redundant Unit Tests

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -14,6 +14,7 @@ import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
+private const val BUILD_TYPE_DEBUG = "debug"
 internal const val BUILD_TYPE_QA = "qa"
 const val FLAVOR_DIMENSION_ENV = "env"
 const val FLAVOR_ENV_STAGE = "stage"
@@ -125,8 +126,8 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
 fun CommonExtension<*, *, *, *>.configureQaBuildType(project: Project) {
     buildTypes {
         register(BUILD_TYPE_QA) {
-            initWith(getByName("debug"))
-            matchingFallbacks += listOf("debug")
+            initWith(getByName(BUILD_TYPE_DEBUG))
+            matchingFallbacks += listOf(BUILD_TYPE_DEBUG)
         }
     }
 
@@ -139,7 +140,8 @@ fun CommonExtension<*, *, *, *>.configureQaBuildType(project: Project) {
     }
 
     project.configurations {
-        named("${BUILD_TYPE_QA}Implementation") { extendsFrom(getByName("debugImplementation")) }
+        named("${BUILD_TYPE_QA}Api") { extendsFrom(getByName("${BUILD_TYPE_DEBUG}Api")) }
+        named("${BUILD_TYPE_QA}Implementation") { extendsFrom(getByName("${BUILD_TYPE_DEBUG}Implementation")) }
     }
 }
 

--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -183,4 +183,12 @@ private fun TestedExtension.configureTestOptions(project: Project) {
             force(espressoCore)
         }
     }
+
+    // only enable unit tests for debug builds targeting production
+    project.androidComponents {
+        beforeVariants { builder ->
+            val env = builder.productFlavors.toMap()[FLAVOR_DIMENSION_ENV] ?: FLAVOR_ENV_PRODUCTION
+            builder.enableUnitTest = builder.buildType == BUILD_TYPE_DEBUG && env == FLAVOR_ENV_PRODUCTION
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -1,5 +1,10 @@
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.getByType
+
+internal fun Project.androidComponents(configure: Action<AndroidComponentsExtension<*, *, *>>): Unit =
+    extensions.configure("androidComponents", configure)
 
 internal val Project.libs get() = project.extensions.getByType<VersionCatalogsExtension>().named("libs")


### PR DESCRIPTION
Instead of running the same unit tests on every build variant, we only run them on production debug variants.