### PR TITLE
GT-1900 Abstract all Attachments db logic to an AttachmentsRepository

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/dagger/features/BundledContentFeatureDependencies.kt
+++ b/app/src/main/kotlin/org/cru/godtools/dagger/features/BundledContentFeatureDependencies.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.ccci.gto.android.common.jsonapi.JsonApiConverter
 import org.cru.godtools.base.Settings
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.greenrobot.eventbus.EventBus
@@ -19,6 +20,7 @@ interface BundledContentFeatureDependencies {
     fun application(): Application
     @ApplicationContext
     fun appContext(): Context
+    fun attachmentsRepository(): AttachmentsRepository
     fun dao(): GodToolsDao
     fun downloadManager(): GodToolsDownloadManager
     fun eventBus(): EventBus

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
@@ -43,7 +43,7 @@ class ToolDetailsFragmentDataModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
     val banner = tool
         .map { it?.detailsBannerId }.distinctUntilChanged()
-        .flatMapLatest { it?.let { attachmentsRepository.getAttachmentFlow(it) } ?: flowOf(null) }
+        .flatMapLatest { it?.let { attachmentsRepository.findAttachmentFlow(it) } ?: flowOf(null) }
         .map { it?.takeIf { it.isDownloaded }?.getFile(toolFileSystem) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsFragmentDataModel.kt
@@ -18,11 +18,11 @@ import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.getAsFlow
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.ToolFileSystem
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.model.Tool
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.GodToolsDao
-import org.keynote.godtools.android.db.repository.AttachmentsRepository
 import org.keynote.godtools.android.db.repository.ToolsRepository
 
 @HiltViewModel

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
@@ -62,7 +62,7 @@ class ToolViewModels @Inject constructor(
 
         val banner = tool
             .map { it?.bannerId }.distinctUntilChanged()
-            .flatMapLatest { it?.let { attachmentsRepository.getAttachmentFlow(it) } ?: flowOf(null) }
+            .flatMapLatest { it?.let { attachmentsRepository.findAttachmentFlow(it) } ?: flowOf(null) }
             .map { it?.takeIf { it.isDownloaded } }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
         val bannerFile = tool.attachmentFileFlow { it?.bannerId }
@@ -131,7 +131,7 @@ class ToolViewModels @Inject constructor(
 
     private fun Flow<Tool?>.attachmentFileFlow(transform: (value: Tool?) -> Long?) = this
         .map(transform).distinctUntilChanged()
-        .flatMapLatest { it?.let { attachmentsRepository.getAttachmentFlow(it) } ?: flowOf(null) }
+        .flatMapLatest { it?.let { attachmentsRepository.findAttachmentFlow(it) } ?: flowOf(null) }
         .map { it?.takeIf { it.isDownloaded } }
         .map { it?.getFile(fileSystem) }
         .distinctUntilChanged()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
@@ -20,13 +20,13 @@ import org.ccci.gto.android.common.kotlin.coroutines.flow.StateFlowValue
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.base.tool.service.ManifestManager
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
-import org.keynote.godtools.android.db.repository.AttachmentsRepository
 import org.keynote.godtools.android.db.repository.ToolsRepository
 import org.keynote.godtools.android.db.repository.TranslationsRepository
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/DatabaseModule.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/DatabaseModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.FollowupsRepository
 import org.cru.godtools.db.repository.GlobalActivityRepository
 import org.cru.godtools.db.repository.LanguagesRepository
@@ -22,6 +23,7 @@ import org.cru.godtools.db.repository.UserRepository
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.cru.godtools.db.room.enableMigrations
 import org.keynote.godtools.android.db.GodToolsDatabase
+import org.keynote.godtools.android.db.repository.LegacyAttachmentsRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -32,6 +34,10 @@ internal object DatabaseModule {
         Room.databaseBuilder(context, GodToolsRoomDatabase::class.java, GodToolsRoomDatabase.DATABASE_NAME)
             .enableMigrations()
             .build()
+
+    @Provides
+    @Reusable
+    fun LegacyAttachmentsRepository.attachmentsRepository(): AttachmentsRepository = this
 
     @Provides
     @Reusable

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -4,7 +4,10 @@ import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.model.Attachment
 
 interface AttachmentsRepository {
+    suspend fun findAttachment(id: Long): Attachment?
     fun findAttachmentFlow(id: Long): Flow<Attachment?>
+
+    suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 
     // TODO: temporary for testing
     fun insert(vararg attachments: Attachment)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -11,6 +11,8 @@ interface AttachmentsRepository {
 
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 
-    // TODO: temporary for testing
-    fun insert(vararg attachments: Attachment)
+    // region Sync Methods
+    fun storeAttachmentsFromSync(attachments: Collection<Attachment>)
+    fun removeAttachmentsMissingFromSync(toolId: Long, syncedAttachments: Collection<Attachment>)
+    // endregion Sync Methods
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -12,6 +12,10 @@ interface AttachmentsRepository {
 
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 
+    // region Initial Content Methods
+    fun storeInitialAttachments(attachments: Collection<Attachment>)
+    // endregion Initial Content Methods
+
     // region Sync Methods
     fun storeAttachmentsFromSync(attachments: Collection<Attachment>)
     fun removeAttachmentsMissingFromSync(toolId: Long, syncedAttachments: Collection<Attachment>)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -1,0 +1,8 @@
+package org.cru.godtools.db.repository
+
+import kotlinx.coroutines.flow.Flow
+import org.cru.godtools.model.Attachment
+
+interface AttachmentsRepository {
+    fun getAttachmentFlow(id: Long): Flow<Attachment?>
+}

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.db.repository
 
 import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.model.Attachment
+import org.cru.godtools.model.Tool
 
 interface AttachmentsRepository {
     suspend fun findAttachment(id: Long): Attachment?
@@ -14,5 +15,6 @@ interface AttachmentsRepository {
     // region Sync Methods
     fun storeAttachmentsFromSync(attachments: Collection<Attachment>)
     fun removeAttachmentsMissingFromSync(toolId: Long, syncedAttachments: Collection<Attachment>)
+    fun deleteAttachmentsFor(tool: Tool)
     // endregion Sync Methods
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -7,6 +7,7 @@ interface AttachmentsRepository {
     suspend fun findAttachment(id: Long): Attachment?
     fun findAttachmentFlow(id: Long): Flow<Attachment?>
     suspend fun getAttachments(): List<Attachment>
+    fun getAttachmentsFlow(): Flow<List<Attachment>>
 
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.model.Attachment
 
 interface AttachmentsRepository {
-    fun getAttachmentFlow(id: Long): Flow<Attachment?>
+    fun findAttachmentFlow(id: Long): Flow<Attachment?>
 
     // TODO: temporary for testing
     fun insert(vararg attachments: Attachment)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -6,6 +6,7 @@ import org.cru.godtools.model.Attachment
 interface AttachmentsRepository {
     suspend fun findAttachment(id: Long): Attachment?
     fun findAttachmentFlow(id: Long): Flow<Attachment?>
+    suspend fun getAttachments(): List<Attachment>
 
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -5,4 +5,7 @@ import org.cru.godtools.model.Attachment
 
 interface AttachmentsRepository {
     fun getAttachmentFlow(id: Long): Flow<Attachment?>
+
+    // TODO: temporary for testing
+    fun insert(vararg attachments: Attachment)
 }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -329,8 +329,6 @@ object Contract : BaseContract() {
         private const val SQL_COLUMN_NAME = "$COLUMN_NAME TEXT"
         private val SQL_PRIMARY_KEY = uniqueIndex(COLUMN_NAME)
 
-        val SQL_JOIN_ATTACHMENT =
-            TABLE.join(AttachmentTable.TABLE).on(FIELD_NAME.eq(AttachmentTable.FIELD_LOCALFILENAME))
         val SQL_JOIN_TRANSLATION_FILE =
             TABLE.join(TranslationFileTable.TABLE).on(FIELD_NAME.eq(TranslationFileTable.FIELD_FILE))
 

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/Contract.kt
@@ -273,7 +273,7 @@ object Contract : BaseContract() {
         // endregion DB migrations
     }
 
-    object AttachmentTable : BaseTable() {
+    internal object AttachmentTable : BaseTable() {
         internal const val TABLE_NAME = "attachments"
         internal val TABLE = Table.forClass<Attachment>()
 
@@ -283,10 +283,8 @@ object Contract : BaseContract() {
         internal const val COLUMN_LOCALFILENAME = "local_filename"
         const val COLUMN_DOWNLOADED = "downloaded"
 
-        val FIELD_ID = TABLE.field(COLUMN_ID)
+        private val FIELD_ID = TABLE.field(COLUMN_ID)
         val FIELD_TOOL = TABLE.field(COLUMN_TOOL)
-        internal val FIELD_LOCALFILENAME = TABLE.field(COLUMN_LOCALFILENAME)
-        val FIELD_DOWNLOADED = TABLE.field(COLUMN_DOWNLOADED)
 
         internal val PROJECTION_ALL =
             arrayOf(COLUMN_ID, COLUMN_TOOL, COLUMN_FILENAME, COLUMN_SHA256, COLUMN_LOCALFILENAME, COLUMN_DOWNLOADED)
@@ -297,12 +295,7 @@ object Contract : BaseContract() {
         private const val SQL_COLUMN_LOCALFILENAME = "$COLUMN_LOCALFILENAME TEXT"
         private const val SQL_COLUMN_DOWNLOADED = "$COLUMN_DOWNLOADED INTEGER"
 
-        val SQL_JOIN_TOOL = TABLE.join(ToolTable.TABLE).on(FIELD_TOOL.eq(ToolTable.FIELD_ID))
-        val SQL_JOIN_LOCAL_FILE = TABLE.join(LocalFileTable.TABLE).on(FIELD_LOCALFILENAME.eq(LocalFileTable.FIELD_NAME))
-
         internal val SQL_WHERE_PRIMARY_KEY = FIELD_ID.eq(bind())
-        val SQL_WHERE_DOWNLOADED = FIELD_DOWNLOADED.eq(true)
-        val SQL_WHERE_NOT_DOWNLOADED = FIELD_DOWNLOADED.eq(false)
 
         internal val SQL_CREATE_TABLE = create(
             TABLE_NAME,

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -10,15 +10,16 @@ import kotlinx.coroutines.flow.shareIn
 import org.ccci.gto.android.common.androidx.collection.WeakLruCache
 import org.ccci.gto.android.common.androidx.collection.getOrPut
 import org.ccci.gto.android.common.db.findAsFlow
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.model.Attachment
 import org.keynote.godtools.android.db.GodToolsDao
 
 @Singleton
-class AttachmentsRepository @Inject constructor(private val dao: GodToolsDao) {
+internal class LegacyAttachmentsRepository @Inject constructor(private val dao: GodToolsDao) : AttachmentsRepository {
     private val coroutineScope = CoroutineScope(SupervisorJob())
 
     private val attachmentsCache = WeakLruCache<Long, Flow<Attachment?>>(15)
-    fun getAttachmentFlow(id: Long) = attachmentsCache.getOrPut(id) {
+    override fun getAttachmentFlow(id: Long) = attachmentsCache.getOrPut(id) {
         dao.findAsFlow<Attachment>(id)
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
     }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -23,4 +23,8 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
         dao.findAsFlow<Attachment>(id)
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
     }
+
+    override fun insert(vararg attachments: Attachment) {
+        attachments.forEach { dao.insert(it) }
+    }
 }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.shareIn
 import org.ccci.gto.android.common.androidx.collection.WeakLruCache
 import org.ccci.gto.android.common.androidx.collection.getOrPut
+import org.ccci.gto.android.common.db.Query
 import org.ccci.gto.android.common.db.findAsFlow
 import org.ccci.gto.android.common.db.findAsync
 import org.cru.godtools.db.repository.AttachmentsRepository
@@ -27,6 +28,8 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
         dao.findAsFlow<Attachment>(id)
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
     }
+
+    override suspend fun getAttachments() = dao.getAsync(Query.select<Attachment>()).await()
 
     override suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean) {
         val attachment = Attachment().apply {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -1,5 +1,6 @@
 package org.keynote.godtools.android.db.repository
 
+import android.database.sqlite.SQLiteDatabase
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
@@ -41,6 +42,12 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
         }
         dao.updateAsync(attachment, AttachmentTable.COLUMN_DOWNLOADED).await()
     }
+
+    // region Initial Content Methods
+    override fun storeInitialAttachments(attachments: Collection<Attachment>) {
+        attachments.forEach { dao.insert(it, SQLiteDatabase.CONFLICT_IGNORE) }
+    }
+    // endregion Initial Content Methods
 
     // region Sync Methods
     override fun storeAttachmentsFromSync(attachments: Collection<Attachment>) {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -19,7 +19,7 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
     private val coroutineScope = CoroutineScope(SupervisorJob())
 
     private val attachmentsCache = WeakLruCache<Long, Flow<Attachment?>>(15)
-    override fun getAttachmentFlow(id: Long) = attachmentsCache.getOrPut(id) {
+    override fun findAttachmentFlow(id: Long) = attachmentsCache.getOrPut(id) {
         dao.findAsFlow<Attachment>(id)
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
     }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -30,6 +30,7 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
     }
 
     override suspend fun getAttachments() = dao.getAsync(Query.select<Attachment>()).await()
+    override fun getAttachmentsFlow() = dao.getAsFlow(Query.select<Attachment>())
 
     override suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean) {
         val attachment = Attachment().apply {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -15,6 +15,7 @@ import org.ccci.gto.android.common.db.findAsync
 import org.ccci.gto.android.common.db.get
 import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.model.Attachment
+import org.cru.godtools.model.Tool
 import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.GodToolsDao
 
@@ -56,6 +57,10 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
         Query.select<Attachment>().where(AttachmentTable.FIELD_TOOL.eq(toolId)).get(dao)
             .filterNot { it.id in keep }
             .forEach { dao.delete(it) }
+    }
+
+    override fun deleteAttachmentsFor(tool: Tool) {
+        dao.delete(Attachment::class.java, AttachmentTable.FIELD_TOOL.eq(tool.id))
     }
     // endregion Sync Methods
 }

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -10,18 +10,30 @@ import kotlinx.coroutines.flow.shareIn
 import org.ccci.gto.android.common.androidx.collection.WeakLruCache
 import org.ccci.gto.android.common.androidx.collection.getOrPut
 import org.ccci.gto.android.common.db.findAsFlow
+import org.ccci.gto.android.common.db.findAsync
 import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.model.Attachment
+import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.GodToolsDao
 
 @Singleton
 internal class LegacyAttachmentsRepository @Inject constructor(private val dao: GodToolsDao) : AttachmentsRepository {
     private val coroutineScope = CoroutineScope(SupervisorJob())
 
+    override suspend fun findAttachment(id: Long) = dao.findAsync<Attachment>(id).await()
+
     private val attachmentsCache = WeakLruCache<Long, Flow<Attachment?>>(15)
     override fun findAttachmentFlow(id: Long) = attachmentsCache.getOrPut(id) {
         dao.findAsFlow<Attachment>(id)
             .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
+    }
+
+    override suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean) {
+        val attachment = Attachment().apply {
+            this.id = id
+            this.isDownloaded = isDownloaded
+        }
+        dao.updateAsync(attachment, AttachmentTable.COLUMN_DOWNLOADED).await()
     }
 
     override fun insert(vararg attachments: Attachment) {

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -45,6 +45,30 @@ abstract class AttachmentsRepositoryIT {
     }
 
     @Test
+    fun `getAttachments()`() = testScope.runTest {
+        repository.insert(
+            Attachment().apply {
+                id = 1
+                filename = "name1.bin"
+                isDownloaded = true
+            },
+            Attachment().apply {
+                id = 2
+                filename = "name2.bin"
+            }
+        )
+
+        val attachments = repository.getAttachments()
+        assertEquals(2, attachments.size)
+        val attachment1 = attachments.first { it.id == 1L }
+        val attachment2 = attachments.first { it.id == 2L }
+        assertEquals("name1.bin", attachment1.filename)
+        assertTrue(attachment1.isDownloaded)
+        assertEquals("name2.bin", attachment2.filename)
+        assertFalse(attachment2.isDownloaded)
+    }
+
+    @Test
     fun `updateAttachmentDownloaded()`() = testScope.runTest {
         repository.insert(
             Attachment().apply {

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -22,7 +22,7 @@ abstract class AttachmentsRepositoryIT {
             filename = "test.ext"
         }
 
-        repository.getAttachmentFlow(1).test {
+        repository.findAttachmentFlow(1).test {
             assertNull(awaitItem())
 
             repository.insert(attachment)

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -3,8 +3,10 @@ package org.cru.godtools.db.repository
 import app.cash.turbine.test
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -14,6 +16,18 @@ import org.cru.godtools.model.Attachment
 abstract class AttachmentsRepositoryIT {
     protected val testScope = TestScope()
     abstract val repository: AttachmentsRepository
+
+    @Test
+    fun `findAttachment()`() = testScope.runTest {
+        assertNull(repository.findAttachment(1))
+
+        val attachment = Attachment().apply {
+            id = 1
+            filename = "test.ext"
+        }
+        repository.insert(attachment)
+        assertEquals(attachment.filename, assertNotNull(repository.findAttachment(1)).filename)
+    }
 
     @Test
     fun `findAttachmentFlow()`() = testScope.runTest {
@@ -28,5 +42,25 @@ abstract class AttachmentsRepositoryIT {
             repository.insert(attachment)
             assertEquals(attachment.filename, assertNotNull(awaitItem()).filename)
         }
+    }
+
+    @Test
+    fun `updateAttachmentDownloaded()`() = testScope.runTest {
+        repository.insert(
+            Attachment().apply {
+                id = 1
+                isDownloaded = false
+            }
+        )
+        assertFalse(assertNotNull(repository.findAttachment(1)).isDownloaded)
+
+        repository.updateAttachmentDownloaded(1, true)
+        assertTrue(assertNotNull(repository.findAttachment(1)).isDownloaded)
+
+        repository.updateAttachmentDownloaded(1, true)
+        assertTrue(assertNotNull(repository.findAttachment(1)).isDownloaded)
+
+        repository.updateAttachmentDownloaded(1, false)
+        assertFalse(assertNotNull(repository.findAttachment(1)).isDownloaded)
     }
 }

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.model.Attachment
+import org.cru.godtools.model.Tool
 
 @OptIn(ExperimentalCoroutinesApi::class)
 abstract class AttachmentsRepositoryIT {
@@ -158,4 +159,20 @@ abstract class AttachmentsRepositoryIT {
         }
     }
     // endregion removeAttachmentsMissingFromSync()
+
+    // region deleteAttachmentsFor()
+    @Test
+    fun `deleteAttachmentsFor()`() = testScope.runTest {
+        val tool = Tool().apply { id = Random.nextLong() }
+        val attachments = List(2) { Attachment().apply { id = Random.nextLong() } }
+        attachments[0].toolId = tool.id
+        repository.storeAttachmentsFromSync(attachments)
+
+        repository.deleteAttachmentsFor(tool)
+        assertNotNull(repository.getAttachments()) {
+            assertEquals(1, it.size)
+            assertEquals(attachments[1].id, it[0].id)
+        }
+    }
+    // endregion deleteAttachmentsFor()
 }

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -27,7 +27,7 @@ abstract class AttachmentsRepositoryIT {
             id = 1
             filename = "test.ext"
         }
-        repository.storeAttachmentsFromSync(listOf(attachment))
+        repository.storeInitialAttachments(listOf(attachment))
         assertEquals(attachment.filename, assertNotNull(repository.findAttachment(1)).filename)
     }
 
@@ -41,14 +41,14 @@ abstract class AttachmentsRepositoryIT {
         repository.findAttachmentFlow(1).test {
             assertNull(awaitItem())
 
-            repository.storeAttachmentsFromSync(listOf(attachment))
+            repository.storeInitialAttachments(listOf(attachment))
             assertEquals(attachment.filename, assertNotNull(awaitItem()).filename)
         }
     }
 
     @Test
     fun `getAttachments()`() = testScope.runTest {
-        repository.storeAttachmentsFromSync(
+        repository.storeInitialAttachments(
             listOf(
                 Attachment().apply {
                     id = 1
@@ -74,7 +74,7 @@ abstract class AttachmentsRepositoryIT {
 
     @Test
     fun `updateAttachmentDownloaded()`() = testScope.runTest {
-        repository.storeAttachmentsFromSync(
+        repository.storeInitialAttachments(
             listOf(
                 Attachment().apply {
                     id = 1
@@ -93,6 +93,23 @@ abstract class AttachmentsRepositoryIT {
         repository.updateAttachmentDownloaded(1, false)
         assertFalse(assertNotNull(repository.findAttachment(1)).isDownloaded)
     }
+
+    // region storeInitialAttachments()
+    @Test
+    fun `storeInitialAttachments() - Don't replace already existing attachments`() = testScope.runTest {
+        val attachment = Attachment().apply {
+            id = Random.nextLong()
+            filename = "sync.bin"
+        }
+        repository.storeAttachmentsFromSync(listOf(attachment))
+
+        attachment.filename = "initial.bin"
+        repository.storeInitialAttachments(listOf(attachment))
+        assertNotNull(repository.findAttachment(attachment.id)) {
+            assertEquals("sync.bin", it.filename)
+        }
+    }
+    // endregion storeInitialAttachments()
 
     // region storeAttachmentsFromSync()
     @Test

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -1,0 +1,32 @@
+package org.cru.godtools.db.repository
+
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.cru.godtools.model.Attachment
+
+@OptIn(ExperimentalCoroutinesApi::class)
+abstract class AttachmentsRepositoryIT {
+    protected val testScope = TestScope()
+    abstract val repository: AttachmentsRepository
+
+    @Test
+    fun `findAttachmentFlow()`() = testScope.runTest {
+        val attachment = Attachment().apply {
+            id = 1
+            filename = "test.ext"
+        }
+
+        repository.getAttachmentFlow(1).test {
+            assertNull(awaitItem())
+
+            repository.insert(attachment)
+            assertEquals(attachment.filename, assertNotNull(awaitItem()).filename)
+        }
+    }
+}

--- a/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepositoryIT.kt
@@ -1,0 +1,21 @@
+package org.keynote.godtools.android.db.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlin.test.BeforeTest
+import org.cru.godtools.db.repository.AttachmentsRepository
+import org.cru.godtools.db.repository.AttachmentsRepositoryIT
+import org.junit.Rule
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class LegacyAttachmentsRepositoryIT : AttachmentsRepositoryIT() {
+    @get:Rule
+    val dbRule = GodToolsDaoRule()
+
+    override lateinit var repository: AttachmentsRepository
+
+    @BeforeTest
+    fun setup() {
+        repository = LegacyAttachmentsRepository(dbRule.dao)
+    }
+}

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerDispatcherTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerDispatcherTest.kt
@@ -13,9 +13,7 @@ import io.mockk.verifyAll
 import java.util.Locale
 import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -25,6 +23,7 @@ import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.download.manager.db.DownloadManagerRepository
 import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.LocalFile
+import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.model.TranslationKey
 import org.junit.Before
@@ -38,14 +37,14 @@ class GodToolsDownloadManagerDispatcherTest {
     private val favoritedTranslationsFlow = MutableSharedFlow<List<Translation>>()
     private val attachmentsFlow = MutableSharedFlow<List<Attachment>>(replay = 1)
     private val localFilesFlow = MutableSharedFlow<List<LocalFile>>(replay = 1)
-    private val toolBannerAttachmentsChannel = Channel<List<Attachment>>()
+    private val toolsFlow = MutableSharedFlow<List<Tool>>(replay = 1)
 
     private val attachmentsRepository: AttachmentsRepository = mockk {
         every { getAttachmentsFlow() } returns attachmentsFlow
     }
     private val dao = mockk<GodToolsDao> {
         every { getAsFlow(Query.select<LocalFile>()) } returns localFilesFlow
-        every { getAsFlow(QUERY_TOOL_BANNER_ATTACHMENTS) } returns toolBannerAttachmentsChannel.consumeAsFlow()
+        every { getAsFlow(Query.select<Tool>()) } returns toolsFlow
     }
     private val downloadManager = mockk<GodToolsDownloadManager> {
         coEvery { downloadLatestPublishedTranslation(any()) } returns true
@@ -134,13 +133,30 @@ class GodToolsDownloadManagerDispatcherTest {
     fun `toolBannerAttachmentsJob should download any banner attachments`() = testScope.runTest {
         verify { downloadManager wasNot Called }
 
-        val attachment1 = Attachment().apply { id = Random.nextLong() }
-        val attachment2 = Attachment().apply { id = Random.nextLong() }
-        toolBannerAttachmentsChannel.send(listOf(attachment1, attachment2))
+        val attachments = List(7) { i ->
+            Attachment().apply {
+                id = Random.nextLong()
+                isDownloaded = i < 3
+            }
+        }
+        val tool1 = Tool().apply {
+            bannerId = attachments[0].id
+            detailsBannerId = attachments[1].id
+            detailsBannerAnimationId = attachments[2].id
+        }
+        val tool2 = Tool().apply {
+            bannerId = attachments[3].id
+            detailsBannerId = attachments[4].id
+            detailsBannerAnimationId = attachments[5].id
+        }
+
+        attachmentsFlow.emit(attachments)
+        toolsFlow.emit(listOf(tool1, tool2))
         runCurrent()
         coVerify(exactly = 1) {
-            downloadManager.downloadAttachment(attachment1.id)
-            downloadManager.downloadAttachment(attachment2.id)
+            downloadManager.downloadAttachment(attachments[3].id)
+            downloadManager.downloadAttachment(attachments[4].id)
+            downloadManager.downloadAttachment(attachments[5].id)
         }
         confirmVerified(downloadManager)
     }

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.test
 import app.cash.turbine.testIn
 import io.mockk.Called
 import io.mockk.coEvery
+import io.mockk.coExcludeRecords
 import io.mockk.coVerify
 import io.mockk.coVerifyAll
 import io.mockk.coVerifyOrder
@@ -22,7 +23,6 @@ import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyAll
 import io.mockk.verifyOrder
-import io.mockk.verifySequence
 import java.io.File
 import java.io.IOException
 import java.util.Locale
@@ -49,6 +49,7 @@ import org.ccci.gto.android.common.db.find
 import org.cru.godtools.api.AttachmentsApi
 import org.cru.godtools.api.TranslationsApi
 import org.cru.godtools.base.ToolFileSystem
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.LocalFile
 import org.cru.godtools.model.Translation
@@ -67,7 +68,6 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.TranslationsRepository
@@ -84,6 +84,7 @@ class GodToolsDownloadManagerTest {
     }
 
     private val attachmentsApi = mockk<AttachmentsApi>()
+    private val attachmentsRepository: AttachmentsRepository = mockk(relaxUnitFun = true)
     private val dao = mockk<GodToolsDao>(relaxUnitFun = true) {
         every { transaction(any(), any<() -> Any>()) } answers { (it.invocation.args[1] as () -> Any).invoke() }
         excludeRecords { transaction(any(), any()) }
@@ -121,6 +122,7 @@ class GodToolsDownloadManagerTest {
         Dispatchers.setMain(dispatcher)
         val downloadManager = GodToolsDownloadManager(
             attachmentsApi,
+            attachmentsRepository,
             dao,
             fs,
             manifestParser,
@@ -176,12 +178,11 @@ class GodToolsDownloadManagerTest {
 
     @Before
     fun setupAttachmentMocks() {
-        every { dao.find<Attachment>(attachment.id) } returns attachment
+        coEvery { attachmentsRepository.findAttachment(attachment.id) } returns attachment
         every { dao.find<LocalFile>(attachment.localFilename!!) } returns attachment.asLocalFile()
-        every { dao.update(any<Attachment>(), AttachmentTable.COLUMN_DOWNLOADED) } returns 1
 
-        excludeRecords {
-            dao.find<Attachment>(attachment.id)
+        coExcludeRecords {
+            attachmentsRepository.findAttachment(attachment.id)
             dao.find<LocalFile>(attachment.localFilename!!)
         }
     }
@@ -200,7 +201,7 @@ class GodToolsDownloadManagerTest {
         coVerifySequence {
             attachmentsApi.download(attachment.id)
             dao.updateOrInsert(attachment.asLocalFile())
-            dao.update(attachment, AttachmentTable.COLUMN_DOWNLOADED)
+            attachmentsRepository.updateAttachmentDownloaded(attachment.id, true)
         }
     }
 
@@ -227,7 +228,7 @@ class GodToolsDownloadManagerTest {
         coVerifySequence {
             attachmentsApi.download(attachment.id)
             dao.updateOrInsert(attachment.asLocalFile())
-            dao.update(attachment, AttachmentTable.COLUMN_DOWNLOADED)
+            attachmentsRepository.updateAttachmentDownloaded(attachment.id, true)
         }
     }
 
@@ -244,7 +245,7 @@ class GodToolsDownloadManagerTest {
         verify(inverse = true) { dao.updateOrInsert(attachment.asLocalFile()) }
         coVerifySequence {
             attachmentsApi.download(attachment.id)
-            dao.update(attachment, AttachmentTable.COLUMN_DOWNLOADED)
+            attachmentsRepository.updateAttachmentDownloaded(attachment.id, false)
         }
     }
 
@@ -269,9 +270,9 @@ class GodToolsDownloadManagerTest {
         }
         assertArrayEquals(testData, file.readBytes())
         assertTrue(attachment.isDownloaded)
-        verifySequence {
+        coVerifySequence {
             dao.updateOrInsert(attachment.asLocalFile())
-            dao.update(attachment, AttachmentTable.COLUMN_DOWNLOADED)
+            attachmentsRepository.updateAttachmentDownloaded(attachment.id, true)
         }
     }
 
@@ -310,12 +311,11 @@ class GodToolsDownloadManagerTest {
             testData.inputStream().use { downloadManager.importAttachment(attachment.id, it) }
         }
         assertTrue(attachment.isDownloaded)
-        verify { dao.update(attachment, AttachmentTable.COLUMN_DOWNLOADED) }
-        coVerify(inverse = true) {
-            fs.file(any())
-            dao.updateOrInsert(any())
+        coVerify {
+            attachmentsRepository.updateAttachmentDownloaded(attachment.id, true)
+            dao wasNot Called
         }
-        confirmVerified(dao)
+        coVerify(exactly = 0) { fs.file(any()) }
     }
 
     private fun Attachment.asLocalFile() = LocalFile(localFilename!!)
@@ -327,6 +327,11 @@ class GodToolsDownloadManagerTest {
         toolCode = TOOL
         languageCode = Locale.FRENCH
         isDownloaded = false
+    }
+
+    @Before
+    fun setupTranslationMocks() {
+        every { dao.update(any<Translation>(), TranslationTable.COLUMN_DOWNLOADED) } returns 1
     }
 
     // region downloadLatestPublishedTranslation()

--- a/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
+++ b/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
@@ -20,13 +20,12 @@ import org.ccci.gto.android.common.jsonapi.JsonApiConverter
 import org.ccci.gto.android.common.util.includeFallbacks
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.util.deviceLocale
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.download.manager.GodToolsDownloadManager
-import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
-import org.keynote.godtools.android.db.Contract.AttachmentTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.ToolsRepository
@@ -43,6 +42,7 @@ internal const val NUMBER_OF_FAVORITES = 4
 @Reusable
 internal class Tasks @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val attachmentsRepository: AttachmentsRepository,
     private val dao: GodToolsDao,
     private val downloadManager: GodToolsDownloadManager,
     private val jsonApiConverter: JsonApiConverter,
@@ -136,8 +136,8 @@ internal class Tasks @Inject constructor(
             val files = context.assets.list("attachments")?.toSet().orEmpty()
 
             // find any attachments that aren't downloaded, but came bundled with the resource for
-            dao.get(Query.select<Attachment>().where(AttachmentTable.SQL_WHERE_NOT_DOWNLOADED))
-                .filter { files.contains(it.localFilename) }
+            attachmentsRepository.getAttachments()
+                .filter { !it.isDownloaded && it.localFilename in files }
                 .forEach { attachment ->
                     launch(Dispatchers.IO) {
                         context.assets.open("attachments/${attachment.localFilename}").use {

--- a/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
+++ b/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
@@ -87,7 +87,7 @@ internal class Tasks @Inject constructor(
                 tools.forEach { tool ->
                     if (dao.insert(tool, SQLiteDatabase.CONFLICT_IGNORE) == -1L) return@forEach
                     tool.latestTranslations?.forEach { dao.insert(it, SQLiteDatabase.CONFLICT_IGNORE) }
-                    tool.attachments?.forEach { dao.insert(it, SQLiteDatabase.CONFLICT_IGNORE) }
+                    tool.attachments?.let { attachmentsRepository.storeInitialAttachments(it) }
                 }
             }
         }

--- a/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
+++ b/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
@@ -20,7 +20,6 @@ import org.cru.godtools.base.Settings
 import org.cru.godtools.download.manager.GodToolsDownloadManager
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
-import org.junit.Before
 import org.junit.Test
 import org.keynote.godtools.android.db.GodToolsDao
 import org.keynote.godtools.android.db.repository.ToolsRepository
@@ -43,12 +42,8 @@ class TasksTest {
     }
     private val toolsRepository = mockk<ToolsRepository>(relaxUnitFun = true)
 
-    private lateinit var tasks: Tasks
-
-    @Before
-    fun setup() {
-        tasks = Tasks(context, dao, downloadManager, jsonApiConverter, mockk(), settings, toolsRepository, mockk())
-    }
+    private val tasks =
+        Tasks(context, mockk(), dao, downloadManager, jsonApiConverter, mockk(), settings, toolsRepository, mockk())
 
     // region initFavoriteTools()
     @Test

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -22,6 +22,7 @@ import org.ccci.gto.android.common.kotlin.coroutines.withLock
 import org.cru.godtools.api.ToolsApi
 import org.cru.godtools.api.ViewsApi
 import org.cru.godtools.api.model.ToolViews
+import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
@@ -40,11 +41,12 @@ private val API_GET_INCLUDES = arrayOf(
 
 @Singleton
 internal class ToolSyncTasks @Inject internal constructor(
+    attachmentsRepository: AttachmentsRepository,
     dao: GodToolsDao,
     private val toolsApi: ToolsApi,
     private val viewsApi: ViewsApi,
     languagesRepository: LanguagesRepository,
-) : BaseDataSyncTasks(dao, languagesRepository) {
+) : BaseDataSyncTasks(attachmentsRepository, dao, languagesRepository) {
     private val toolsMutex = Mutex()
     private val toolMutex = MutexMap()
     private val sharesMutex = Mutex()

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/BaseDataSyncTasksTest.kt
@@ -18,7 +18,7 @@ class BaseDataSyncTasksTest {
 
     @Before
     fun setup() {
-        tasks = object : BaseDataSyncTasks(mockk(), languagesRepository) {}
+        tasks = object : BaseDataSyncTasks(mockk(), mockk(), languagesRepository) {}
     }
 
     @Test


### PR DESCRIPTION
This abstracts all database interactions around Attachments into a centralized `AttachmentsRepository`. This will allow us to change the underlying database implementation to utilize Room to track Attachments