### PR TITLE
cleanup

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -14,6 +14,7 @@ import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 
+private const val BUILD_TYPE_DEBUG = "debug"
 internal const val BUILD_TYPE_QA = "qa"
 const val FLAVOR_DIMENSION_ENV = "env"
 const val FLAVOR_ENV_STAGE = "stage"
@@ -125,8 +126,8 @@ fun CommonExtension<*, *, *, *>.configureCompose(project: Project) {
 fun CommonExtension<*, *, *, *>.configureQaBuildType(project: Project) {
     buildTypes {
         register(BUILD_TYPE_QA) {
-            initWith(getByName("debug"))
-            matchingFallbacks += listOf("debug")
+            initWith(getByName(BUILD_TYPE_DEBUG))
+            matchingFallbacks += listOf(BUILD_TYPE_DEBUG)
         }
     }
 
@@ -139,7 +140,8 @@ fun CommonExtension<*, *, *, *>.configureQaBuildType(project: Project) {
     }
 
     project.configurations {
-        named("${BUILD_TYPE_QA}Implementation") { extendsFrom(getByName("debugImplementation")) }
+        named("${BUILD_TYPE_QA}Api") { extendsFrom(getByName("${BUILD_TYPE_DEBUG}Api")) }
+        named("${BUILD_TYPE_QA}Implementation") { extendsFrom(getByName("${BUILD_TYPE_DEBUG}Implementation")) }
     }
 }
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/UserCountersDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/UserCountersDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.db.room.entity.UserCounterEntity
 import org.cru.godtools.db.room.entity.partial.MigrationUserCounter
@@ -27,10 +28,10 @@ internal interface UserCountersDao {
     @Query("SELECT * FROM user_counters WHERE delta != 0")
     suspend fun getDirtyCounters(): List<UserCounterEntity>
 
-    @Insert(entity = UserCounterEntity::class, onConflict = OnConflictStrategy.IGNORE)
-    suspend fun insertOrIgnore(counters: Collection<SyncUserCounter>)
     @Update(entity = UserCounterEntity::class)
     suspend fun update(counters: Collection<SyncUserCounter>)
+    @Upsert(entity = UserCounterEntity::class)
+    suspend fun upsert(counters: Collection<SyncUserCounter>)
     // endregion Sync Methods
 
     // region Migration

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/UserCountersRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/UserCountersRoomRepository.kt
@@ -31,10 +31,7 @@ internal abstract class UserCountersRoomRepository(private val db: GodToolsRoomD
 
     @Transaction
     override suspend fun storeCountersFromSync(counters: Collection<UserCounter>) {
-        val syncCounters = counters.map { SyncUserCounter(it) }
-        // TODO: switch to an Upsert operation after we upgrade to Room 2.5.0
-        dao.insertOrIgnore(syncCounters)
-        dao.update(syncCounters)
+        dao.upsert(counters.map { SyncUserCounter(it) })
     }
 
     override suspend fun resetCountersMissingFromSync(counters: Collection<UserCounter>) {

--- a/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -488,8 +488,9 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
             // Download Favorite tool translations in the primary, parallel, and default languages
             settings.primaryLanguageFlow
                 .combineTransform(settings.parallelLanguageFlow) { prim, para ->
-                    emit(listOfNotNull(prim, para, Settings.defaultLanguage))
+                    emit(setOfNotNull(prim, para, Settings.defaultLanguage))
                 }
+                .distinctUntilChanged()
                 .flatMapLatest { repository.getFavoriteTranslationsThatNeedDownload(it) }
                 .map { it.map { TranslationKey(it) }.toSet() }
                 .distinctUntilChanged()

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.download.manager
 
-import androidx.lifecycle.Observer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
@@ -103,11 +102,6 @@ class GodToolsDownloadManagerTest {
     private val translationsRepository = mockk<TranslationsRepository>()
     private val workManager = mockk<WorkManager> {
         every { enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) } returns mockk()
-    }
-
-    private val downloadProgress = mutableListOf<DownloadProgress?>()
-    private val observer = mockk<Observer<DownloadProgress?>> {
-        every { onChanged(captureNullable(downloadProgress)) } returns Unit
     }
 
     @OptIn(ExperimentalContracts::class)

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -260,6 +260,7 @@ class GodToolsDownloadManagerTest {
     }
     // endregion downloadAttachment()
 
+    // region importAttachment()
     @Test
     fun verifyImportAttachment() = runTest {
         every { dao.find<LocalFile>(attachment.localFilename!!) } returns null
@@ -317,6 +318,7 @@ class GodToolsDownloadManagerTest {
         }
         coVerify(exactly = 0) { fs.file(any()) }
     }
+    // endregion importAttachment()
 
     private fun Attachment.asLocalFile() = LocalFile(localFilename!!)
     // endregion Attachments


### PR DESCRIPTION
- define a debug build type constant for buildSrc
- switch to using Upsert for UserCountersDao
- Add a region to the download manager tests
- track the distinct set of langauges
- remove unused observer mock
