### PR TITLE
GT-1361 Update DownloadManager coroutines test logic

### DIFF
--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -123,14 +122,13 @@ class GodToolsDownloadManagerTest {
             translationsApi,
             translationsRepository,
             { workManager },
-            this,
+            backgroundScope,
             dispatcher
         )
         try {
             if (!enableCleanupActor) downloadManager.cleanupActor.close()
             block(downloadManager)
         } finally {
-            downloadManager.cleanupActor.close()
             Dispatchers.resetMain()
         }
     }
@@ -538,7 +536,7 @@ class GodToolsDownloadManagerTest {
             assertCleanupActorRan(0)
             runCurrent()
             assertCleanupActorRan(1)
-            advanceUntilIdle()
+            advanceTimeBy(50 * CLEANUP_DELAY)
             assertCleanupActorRan(1)
         }
     }
@@ -548,10 +546,10 @@ class GodToolsDownloadManagerTest {
         setupCleanupActorMocks()
 
         withDownloadManager(enableCleanupActor = true) {
-            advanceUntilIdle()
+            advanceTimeBy(50 * CLEANUP_DELAY)
             assertCleanupActorRan(1)
             it.cleanupActor.send(Unit)
-            advanceUntilIdle()
+            advanceTimeBy(50 * CLEANUP_DELAY)
             assertCleanupActorRan(2)
         }
     }

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -30,15 +30,12 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.random.Random
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import okhttp3.internal.http.RealResponseBody
 import okio.Buffer
 import okio.buffer
@@ -113,7 +110,6 @@ class GodToolsDownloadManagerTest {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
         }
-        Dispatchers.setMain(dispatcher)
         val downloadManager = GodToolsDownloadManager(
             attachmentsApi,
             attachmentsRepository,
@@ -126,12 +122,8 @@ class GodToolsDownloadManagerTest {
             testScope.backgroundScope,
             dispatcher
         )
-        try {
-            if (!enableCleanupActor) downloadManager.cleanupActor.close()
-            block(downloadManager)
-        } finally {
-            Dispatchers.resetMain()
-        }
+        if (!enableCleanupActor) downloadManager.cleanupActor.close()
+        block(downloadManager)
     }
 
     // region Download Progress


### PR DESCRIPTION
- use the backgroundScope for DownloadManager tests
- create a common TestScope so we can setup the DownloadManager before a test starts executing
- there is no need to set a Main Dispatcher anymore
- remove unnecessary withDownloadManager inline function
