### PR TITLE
cleanup

### DIFF
--- a/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -223,7 +223,7 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
 
     // region Translations
     @AnyThread
-    fun downloadLatestPublishedTranslationAsync(code: String, locale: Locale) = coroutineScope.launch {
+    fun downloadLatestPublishedTranslationAsync(code: String, locale: Locale) = coroutineScope.async {
         downloadLatestPublishedTranslation(TranslationKey(code, locale))
     }
 

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
@@ -2,18 +2,19 @@ package org.cru.godtools.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
+import io.mockk.Awaits
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerifyAll
 import io.mockk.every
 import io.mockk.excludeRecords
+import io.mockk.just
 import io.mockk.mockk
 import java.io.IOException
 import javax.inject.Provider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
@@ -67,8 +68,7 @@ class GodToolsSyncServiceTest {
 
     @Test
     fun `syncTools() - Cancelled`() = testScope.runTest {
-        // the Semaphore will deadlock and suspend indefinitely
-        coEvery { toolsSyncTasks.syncTools(any()) } coAnswers { Semaphore(1, 1).acquire(); true }
+        coEvery { toolsSyncTasks.syncTools(any()) } just Awaits
         every { workManager.scheduleSyncToolsWork() } returns mockk()
 
         val job = async { syncService.syncTools(false) }

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/article/ExternalSingletonsModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -36,7 +37,7 @@ class ExternalSingletonsModule {
     @get:Provides
     val downloadManager by lazy {
         mockk<GodToolsDownloadManager> {
-            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns Job().apply { complete() }
+            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns CompletableDeferred(true)
         }
     }
     @get:Provides

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ExternalSingletonsModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
@@ -43,7 +44,7 @@ class ExternalSingletonsModule {
     val downloadManager by lazy {
         mockk<GodToolsDownloadManager> {
             every { getDownloadProgressFlow(any(), any()) } returns flowOf(null)
-            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns Job().apply { complete() }
+            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns CompletableDeferred(true)
         }
     }
     @get:Provides

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/ExternalSingletonsModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -35,7 +36,7 @@ class ExternalSingletonsModule {
     @get:Provides
     val downloadManager by lazy {
         mockk<GodToolsDownloadManager> {
-            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns Job().apply { complete() }
+            every { downloadLatestPublishedTranslationAsync(any(), any()) } returns CompletableDeferred(true)
         }
     }
     @get:Provides


### PR DESCRIPTION
- return a Deferred object for getLatestPublishedTranslationAsync
- MockK provides a `just Await` that will cause a mocked suspendable function to suspend indefinitely
