### PR TITLE
GT-1949 Remove unnecessary LiveData variant of a TranslationsRepository method

### DIFF
--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/TranslationsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/TranslationsRepository.kt
@@ -1,6 +1,5 @@
 package org.keynote.godtools.android.db.repository
 
-import androidx.lifecycle.asLiveData
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -72,12 +71,5 @@ class TranslationsRepository @Inject constructor(private val dao: GodToolsDao) {
                 )
         }
     }
-
-    fun getLatestTranslationLiveData(
-        code: String?,
-        locale: Locale?,
-        isDownloaded: Boolean = false,
-        trackAccess: Boolean = false
-    ) = getLatestTranslationFlow(code, locale, isDownloaded = isDownloaded, trackAccess = trackAccess).asLiveData()
     // endregion Latest Translations
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/activity/MultiLanguageToolActivityDataModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -77,8 +78,9 @@ class MultiLanguageToolActivityDataModel @Inject constructor(
 
     private val translationCache = object : LruCache<TranslationKey, LiveData<Translation?>>(10) {
         override fun create(key: TranslationKey) =
-            translationsRepository.getLatestTranslationLiveData(key.tool, key.locale, trackAccess = true)
+            translationsRepository.getLatestTranslationFlow(key.tool, key.locale, trackAccess = true)
                 .distinctUntilChanged()
+                .asLiveData()
     }
     // endregion LiveData Caches
 

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/MockDatabaseModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/MockDatabaseModule.kt
@@ -1,12 +1,12 @@
 package org.cru.godtools.tool.cyoa
 
-import androidx.lifecycle.MutableLiveData
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.cru.godtools.db.DatabaseModule
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
@@ -28,7 +28,7 @@ class MockDatabaseModule {
     @get:Provides
     val translationsRepository: TranslationsRepository by lazy {
         mockk {
-            every { getLatestTranslationLiveData(any(), any(), any(), any()) } answers { MutableLiveData(null) }
+            every { getLatestTranslationFlow(any(), any(), any(), any()) } returns flowOf(null)
         }
     }
 }

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/MockDatabaseModule.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/MockDatabaseModule.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.tool.tract
 
-import androidx.lifecycle.MutableLiveData
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -38,7 +37,7 @@ class MockDatabaseModule {
     @get:Provides
     val translationsRepository: TranslationsRepository by lazy {
         mockk {
-            every { getLatestTranslationLiveData(any(), any(), any(), any()) } answers { MutableLiveData(null) }
+            every { getLatestTranslationFlow(any(), any(), any(), any()) } returns flowOf(null)
         }
     }
 }

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/activity/TractActivityTest.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.testing.HiltTestApplication
 import io.mockk.every
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.flow.flowOf
 import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
 import org.ccci.gto.android.common.db.Query
 import org.cru.godtools.base.EXTRA_LANGUAGES
@@ -266,7 +267,7 @@ class TractActivityTest {
     @Test
     @Ignore("The Share menu item was moved to the Settings Dialog")
     fun verifyShareMenuVisible() {
-        everyGetTranslation() returns MutableLiveData(Translation())
+        everyGetTranslation() returns flowOf(Translation())
         everyGetManifest() returns ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH))
 
         scenario {
@@ -283,7 +284,7 @@ class TractActivityTest {
     @Test
     @Ignore("The Share menu item was moved to the Settings Dialog")
     fun verifyShareMenuVisibleForDeepLink() {
-        everyGetTranslation() returns MutableLiveData(Translation())
+        everyGetTranslation() returns flowOf(Translation())
         everyGetManifest() returns ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH))
 
         deepLinkScenario(Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en")) {
@@ -300,7 +301,7 @@ class TractActivityTest {
     @Test
     @Ignore("The Share menu item was moved to the Settings Dialog")
     fun verifyShareMenuHiddenWhenNoManifest() {
-        everyGetTranslation() returns MutableLiveData(Translation())
+        everyGetTranslation() returns flowOf(Translation())
         everyGetManifest() returns ImmutableLiveData(null)
 
         scenario {
@@ -317,7 +318,7 @@ class TractActivityTest {
     @Test
     @Ignore("The Share menu item was moved to the Settings Dialog")
     fun verifyShareMenuHiddenWhenShowingTips() {
-        everyGetTranslation() returns MutableLiveData(Translation())
+        everyGetTranslation() returns flowOf(Translation())
         everyGetManifest()
             .returns(ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH, tips = { listOf(Tip()) })))
 
@@ -335,7 +336,7 @@ class TractActivityTest {
     @Test
     @Ignore("The Share menu item was moved to the Settings Dialog")
     fun verifyShareMenuHiddenWhenLiveShareSubscriber() {
-        everyGetTranslation() returns MutableLiveData(Translation())
+        everyGetTranslation() returns flowOf(Translation())
         everyGetManifest() returns ImmutableLiveData(Manifest(code = "test", locale = Locale.ENGLISH))
 
         deepLinkScenario(Uri.parse("https://knowgod.com/en/kgp?primaryLanguage=en&$PARAM_LIVE_SHARE_STREAM=asdf")) {
@@ -354,7 +355,7 @@ class TractActivityTest {
     private val TractActivity.dataModel get() = viewModels<MultiLanguageToolActivityDataModel>().value
 
     private fun everyGetTranslation(tool: String? = null, locale: Locale? = null) =
-        every { translationsRepository.getLatestTranslationLiveData(tool ?: any(), locale ?: any(), any(), any()) }
+        every { translationsRepository.getLatestTranslationFlow(tool ?: any(), locale ?: any(), any(), any()) }
     private fun everyGetManifest(tool: String? = null, locale: Locale? = null) =
         every { (manifestManager.getLatestPublishedManifestLiveData(tool ?: any(), locale ?: any())) }
 }


### PR DESCRIPTION
- update ManifestManager to no longer use getLatestTranslationLiveData
- stop using getLatestTranslationLiveData() for MultiLanguageToolActivityDataModel
- remove unused getLatestTranslationLiveData method
