### PR TITLE
GT-1975 fix manifest merge errors for tests when Okta is on the classpath

### DIFF
--- a/buildSrc/src/main/kotlin/AndroidConfiguration.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfiguration.kt
@@ -165,8 +165,8 @@ private fun TestedExtension.configureTestOptions(project: Project) {
         addProvider("testImplementation", project.libs.findBundle("test-framework").get())
 
         // HACK: Fix Manifest merge errors for any classpath that contains the Okta module
-        addProvider("androidTestImplementation", testFixtures(project.libs.findLibrary("gtoSupport-okta").get()))
-        addProvider("testImplementation", testFixtures(project.libs.findLibrary("gtoSupport-okta").get()))
+        testVariants.configureEach { mergedFlavor.manifestPlaceholders["webAuthenticationRedirectScheme"] = "test" }
+        unitTestVariants.configureEach { mergedFlavor.manifestPlaceholders["webAuthenticationRedirectScheme"] = "test" }
     }
 
     project.configurations.configureEach {


### PR DESCRIPTION
There seems to be some buggy behavior with how test fixtures, manifest placeholders, and removing xml nodes via manifest mergers works.

- Okta requires a manifest placeholder when using their library
- If that library is on the classpath for tests it throws an error if no placeholder is defined
- You can remove the merged parts of the AndroidManifest.xml that use the placeholder to avoid the merger error
- Moving the removal xml into a test fixture AndroidManifest.xml sometimes works and sometimes doesn't
   - This behavior was very inconsistent, with a straightforward usage not working, but adding the dependency through gradle buildSrc working until you upgrade to the latest version of jetpack compose.
   - When we define a manifest placeholder for testing and still merge the test fixture AndroidManifest.xml with the removal, it removes the troublesome XML node.

My hunch is there is some sort of deterministic race condition within the manifest merger logic, where certain inputs cause manifest placeholders to be processed first, and other inputs cause the xml to be merged first.

To avoid all of that, I'm switching to defining manifestPlaceholders for test variants only