### PR TITLE
cleanup

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -13,7 +13,7 @@ interface AttachmentsRepository {
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 
     // region Initial Content Methods
-    fun storeInitialAttachments(attachments: Collection<Attachment>)
+    suspend fun storeInitialAttachments(attachments: Collection<Attachment>)
     // endregion Initial Content Methods
 
     // region Sync Methods

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/UserRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/UserRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import org.cru.godtools.model.User
 
 interface UserRepository {
-    fun getUserFlow(userId: String): Flow<User?>
+    fun findUserFlow(userId: String): Flow<User?>
 
     // region Sync Methods
     suspend fun storeUserFromSync(user: User)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/UserRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/UserRoomRepository.kt
@@ -11,7 +11,7 @@ import org.cru.godtools.model.User
 internal abstract class UserRoomRepository(private val db: GodToolsRoomDatabase) : UserRepository {
     private val dao get() = db.userDao
 
-    override fun getUserFlow(userId: String) = dao.findUserFlow(userId).map { it?.toModel() }
+    override fun findUserFlow(userId: String) = dao.findUserFlow(userId).map { it?.toModel() }
 
     override suspend fun storeUserFromSync(user: User) {
         dao.insertOrReplace(UserEntity(user))

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -44,9 +44,9 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
     }
 
     // region Initial Content Methods
-    override fun storeInitialAttachments(attachments: Collection<Attachment>) {
+    override suspend fun storeInitialAttachments(attachments: Collection<Attachment>) = dao.transactionAsync {
         attachments.forEach { dao.insert(it, SQLiteDatabase.CONFLICT_IGNORE) }
-    }
+    }.await()
     // endregion Initial Content Methods
 
     // region Sync Methods

--- a/library/user-data/src/main/kotlin/org/cru/godtools/user/data/UserManager.kt
+++ b/library/user-data/src/main/kotlin/org/cru/godtools/user/data/UserManager.kt
@@ -25,7 +25,7 @@ class UserManager @Inject internal constructor(
     private val coroutineScope = CoroutineScope(SupervisorJob())
 
     val userFlow = accountManager.userIdFlow()
-        .flatMapLatest { it?.let { userRepository.getUserFlow(it) } ?: flowOf(null) }
+        .flatMapLatest { it?.let { userRepository.findUserFlow(it) } ?: flowOf(null) }
         .combine(accountManager.accountInfoFlow()) { user, accountInfo -> user + accountInfo }
         .shareIn(coroutineScope, SharingStarted.WhileSubscribed(), 1)
         .distinctUntilChanged()

--- a/library/user-data/src/test/kotlin/org/cru/godtools/user/data/UserManagerTest.kt
+++ b/library/user-data/src/test/kotlin/org/cru/godtools/user/data/UserManagerTest.kt
@@ -29,7 +29,7 @@ class UserManagerTest {
         coEvery { userIdFlow() } returns userIdFlow
     }
     private val userRepository: UserRepository = mockk {
-        every { getUserFlow(USER_ID) } returns userFlow
+        every { findUserFlow(USER_ID) } returns userFlow
     }
     private val testScope = TestScope()
 

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -6,7 +6,6 @@ import android.content.pm.ShortcutManager
 import android.os.Build
 import androidx.annotation.AnyThread
 import androidx.annotation.RequiresApi
-import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
 import androidx.core.content.pm.ShortcutInfoCompat
@@ -314,12 +313,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
                 delay(DELAY_UPDATE_SHORTCUTS)
                 manager.updateShortcuts()
             }
-        }
-
-        @RestrictTo(RestrictTo.Scope.TESTS)
-        internal fun shutdown() {
-            updatePendingShortcutsJob.cancel()
-            updateShortcutsJob.cancel()
         }
     }
 }

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -221,7 +221,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     }
 
     @AnyThread
-    private suspend fun createToolShortcut(tool: Tool) = withContext(Dispatchers.IO) {
+    private suspend fun createToolShortcut(tool: Tool) = withContext(ioDispatcher) {
         val code = tool.code ?: return@withContext null
 
         // generate the list of locales to use for this tool
@@ -287,7 +287,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         constructor(
             manager: GodToolsShortcutManager,
             dao: GodToolsDao,
-            settings: Settings
+            settings: Settings,
         ) : this(manager, dao, settings, CoroutineScope(Dispatchers.Default + SupervisorJob()))
 
         @VisibleForTesting


### PR DESCRIPTION
- make storeInitialAttachments suspendable
- s/getUserFlow/findUserFlow/
- update the GodToolsShortcutManagerTests to better utilize kotlin coroutines
