### PR TITLE
GT-1950 refresh the facebook access_token on auth failure

### DIFF
--- a/library/account/src/main/kotlin/org/cru/godtools/account/provider/facebook/FacebookAccountProvider.kt
+++ b/library/account/src/main/kotlin/org/cru/godtools/account/provider/facebook/FacebookAccountProvider.kt
@@ -71,21 +71,21 @@ internal class FacebookAccountProvider @Inject constructor(
     // endregion Login/Logout
 
     override suspend fun authenticateWithMobileContentApi(): AuthToken? {
-        var accessToken = accessTokenManager.currentAccessToken ?: return null
-        var resp = authenticateWithMobileContentApi(accessToken) ?: return null
+        var accessToken = accessTokenManager.currentAccessToken
+        var resp = authenticateWithMobileContentApi(accessToken)
 
         // try refreshing the access token if the API rejected it
-        if (resp.code() == 400) {
+        if (resp?.code() == 400) {
             accessToken = try {
-                accessTokenManager.refreshCurrentAccessToken() ?: return null
+                accessTokenManager.refreshCurrentAccessToken()
             } catch (e: FacebookException) {
-                return null
+                null
             }
-            resp = authenticateWithMobileContentApi(accessToken) ?: return null
+            resp = authenticateWithMobileContentApi(accessToken)
         }
 
-        val token = resp.takeIf { it.isSuccessful }?.body()?.takeUnless { it.hasErrors() }?.dataSingle
-        if (token != null) prefs.edit { putString(PREF_USER_ID(accessToken), token.userId) }
+        val token = resp?.takeIf { it.isSuccessful }?.body()?.takeUnless { it.hasErrors() }?.dataSingle
+        if (accessToken != null && token != null) prefs.edit { putString(PREF_USER_ID(accessToken), token.userId) }
         return token
     }
 

--- a/library/api/src/main/kotlin/org/cru/godtools/api/model/AuthToken.kt
+++ b/library/api/src/main/kotlin/org/cru/godtools/api/model/AuthToken.kt
@@ -17,7 +17,7 @@ data class AuthToken(
     var token: String? = null
 ) {
     @JsonApiType("auth-token-request")
-    class Request(
+    data class Request(
         @JsonApiAttribute(ATTR_FACEBOOK_ACCESS_TOKEN) val fbAccessToken: String? = null,
         @JsonApiAttribute(ATTR_GOOGLE_ID_TOKEN) val googleIdToken: String? = null,
         @JsonApiAttribute(ATTR_OKTA_TOKEN) val oktaAccessToken: String? = null,


### PR DESCRIPTION
If authentication fails because of a bad access_token, try refreshing the token before giving up
