### PR TITLE
GT-1992 correctly handle exceptions when running syncUserCounters()

### DIFF
--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -137,9 +137,11 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
 
     suspend fun syncDirtyUserCounters() = executeSync<UserCounterSyncTasks> { syncDirtyCounters() }
     suspend fun syncUserCounters(force: Boolean = false) = executeSync<UserCounterSyncTasks> {
-        val resp = syncCounters(force)
-        coroutineScope.launch { syncDirtyCounters() }
-        resp
+        try {
+            syncCounters(force)
+        } finally {
+            coroutineScope.launch { syncDirtyUserCounters() }
+        }
     }
 
     fun syncToolShares(): SyncTask = GtSyncTask(bundleOf(EXTRA_SYNCTYPE to SYNCTYPE_TOOL_SHARES))

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.sync.task.ToolSyncTasks
+import org.cru.godtools.sync.task.UserCounterSyncTasks
 import org.cru.godtools.sync.work.scheduleSyncToolsWork
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -29,6 +31,10 @@ import timber.log.Timber
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsSyncServiceTest {
     private val toolsSyncTasks = mockk<ToolSyncTasks> { coEvery { syncTools(any()) } returns true }
+    private val userCounterSyncTasks: UserCounterSyncTasks = mockk {
+        coEvery { syncCounters(any()) } returns true
+        coEvery { syncDirtyCounters() } returns true
+    }
 
     private val timber: Timber.Tree = mockk(relaxed = true)
     private val workManager: WorkManager = mockk()
@@ -39,9 +45,10 @@ class GodToolsSyncServiceTest {
         workManager = { workManager },
         syncTasks = mapOf(
             ToolSyncTasks::class.java to Provider { toolsSyncTasks },
+            UserCounterSyncTasks::class.java to Provider { userCounterSyncTasks },
         ),
         coroutineDispatcher = UnconfinedTestDispatcher(testScope.testScheduler),
-        coroutineScope = testScope
+        coroutineScope = testScope.backgroundScope
     )
 
     @Before
@@ -122,4 +129,75 @@ class GodToolsSyncServiceTest {
         }
     }
     // endregion syncTools()
+
+    // region syncUserCounters()
+    @Test
+    fun `syncUserCounters(force = true)`() = testScope.runTest {
+        assertTrue(syncService.syncUserCounters(force = true))
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(true)
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+
+    @Test
+    fun `syncUserCounters(force = false)`() = testScope.runTest {
+        assertTrue(syncService.syncUserCounters(force = false))
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(false)
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+
+    @Test
+    fun `syncUserCounters() - Don't wait for dirty sync to finish`() = testScope.runTest {
+        coEvery { userCounterSyncTasks.syncDirtyCounters() } just Awaits
+
+        assertTrue(syncService.syncUserCounters())
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(any())
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+
+    @Test
+    fun `syncUserCounters() - Failure - syncCounters() returns false`() = testScope.runTest {
+        coEvery { userCounterSyncTasks.syncCounters(any()) } returns false
+
+        assertFalse(syncService.syncUserCounters())
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(any())
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+
+    @Test
+    fun `syncUserCounters() - Failure - syncCounters() throws Exception`() = testScope.runTest {
+        coEvery { userCounterSyncTasks.syncCounters(any()) } throws Exception()
+
+        assertFalse(syncService.syncUserCounters())
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(any())
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+
+    @Test
+    fun `syncUserCounters() - Jira - GT-1992`() = testScope.runTest {
+        // syncDirtyCounters throwing an exception wasn't being handled within syncUserCounters()
+        coEvery { userCounterSyncTasks.syncDirtyCounters() } throws Exception()
+
+        assertTrue(syncService.syncUserCounters())
+        runCurrent()
+        coVerifyAll {
+            userCounterSyncTasks.syncCounters(any())
+            userCounterSyncTasks.syncDirtyCounters()
+        }
+    }
+    // endregion syncUserCounters()
 }

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/GodToolsSyncServiceTest.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.sync
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
 import io.mockk.Awaits
 import io.mockk.Called
@@ -19,30 +18,31 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.cru.godtools.sync.task.BaseSyncTasks
 import org.cru.godtools.sync.task.ToolSyncTasks
 import org.cru.godtools.sync.work.scheduleSyncToolsWork
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import timber.log.Timber
 
-@RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsSyncServiceTest {
     private val toolsSyncTasks = mockk<ToolSyncTasks> { coEvery { syncTools(any()) } returns true }
 
-    private val syncTasks = mapOf<Class<out BaseSyncTasks>, Provider<BaseSyncTasks>>(
-        ToolSyncTasks::class.java to Provider { toolsSyncTasks }
-    )
     private val timber: Timber.Tree = mockk(relaxed = true)
     private val workManager: WorkManager = mockk()
     private val testScope = TestScope()
 
-    private val syncService =
-        GodToolsSyncService(mockk(relaxUnitFun = true), { workManager }, syncTasks, UnconfinedTestDispatcher())
+    private val syncService = GodToolsSyncService(
+        eventBus = mockk(relaxUnitFun = true),
+        workManager = { workManager },
+        syncTasks = mapOf(
+            ToolSyncTasks::class.java to Provider { toolsSyncTasks },
+        ),
+        coroutineDispatcher = UnconfinedTestDispatcher(testScope.testScheduler),
+        coroutineScope = testScope
+    )
 
     @Before
     fun setup() {


### PR DESCRIPTION
- cleanup GodToolsSyncServiceTest
- correctly handle exceptions when running syncUserCounters()
