### PR TITLE
GT-1900 Migrate some more DB interactions to the AttachmentsRepository

### DIFF
--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -10,6 +10,8 @@ interface AttachmentsRepository {
     suspend fun getAttachments(): List<Attachment>
     fun getAttachmentsFlow(): Flow<List<Attachment>>
 
+    fun attachmentsChangeFlow(emitOnStart: Boolean = true): Flow<Any?>
+
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 
     // region Initial Content Methods

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -35,6 +35,9 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
     override suspend fun getAttachments() = dao.getAsync(Query.select<Attachment>()).await()
     override fun getAttachmentsFlow() = dao.getAsFlow(Query.select<Attachment>())
 
+    override fun attachmentsChangeFlow(emitOnStart: Boolean) =
+        dao.invalidationFlow(Attachment::class.java, emitOnStart = emitOnStart)
+
     override suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean) {
         val attachment = Attachment().apply {
             this.id = id

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -75,8 +75,8 @@ class GodToolsShortcutManagerTest {
         }
 
         shortcutManager = GodToolsShortcutManager(
-            app,
-            dao = mockk(),
+            attachmentsRepository = mockk(),
+            context = app,
             eventBus = mockk(relaxUnitFun = true),
             fs = mockk(),
             picasso = mockk(),


### PR DESCRIPTION
- monitor for changes to attachments via the AttachmentsRepository
- use the AttachmentsRepository to lookup an attachment
