### PR TITLE
GT-1977 Disable the ShortcutManager for Instant Apps

### DIFF
--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -281,7 +281,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     }
 
     @Singleton
-    class Dispatcher @VisibleForTesting internal constructor(
+    internal class Dispatcher @VisibleForTesting internal constructor(
         private val manager: GodToolsShortcutManager,
         attachmentsRepository: AttachmentsRepository,
         settings: Settings,

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -11,6 +11,7 @@ import androidx.core.content.getSystemService
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
+import com.google.android.gms.common.wrappers.InstantApps
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
@@ -97,12 +98,15 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     @get:RequiresApi(Build.VERSION_CODES.N_MR1)
     private val shortcutManager by lazy { context.getSystemService<ShortcutManager>() }
 
-    init {
-        // register event listeners
-        eventBus.register(this)
-    }
+    @VisibleForTesting
+    internal val isEnabled = !InstantApps.isInstantApp(context)
 
     // region Events
+    init {
+        // register event listeners
+        if (isEnabled) eventBus.register(this)
+    }
+
     @AnyThread
     @Subscribe
     fun onToolUsed(event: ToolUsedEvent) {
@@ -116,15 +120,19 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     private val pendingShortcuts = mutableMapOf<String, WeakReference<PendingShortcut>>()
 
     @AnyThread
-    fun canPinToolShortcut(tool: Tool?) = when (tool?.type) {
-        Tool.Type.ARTICLE,
-        Tool.Type.CYOA,
-        Tool.Type.TRACT -> ShortcutManagerCompat.isRequestPinShortcutSupported(context)
-        else -> false
+    fun canPinToolShortcut(tool: Tool?) = when {
+        !isEnabled -> false
+        else -> when (tool?.type) {
+            Tool.Type.ARTICLE,
+            Tool.Type.CYOA,
+            Tool.Type.TRACT -> ShortcutManagerCompat.isRequestPinShortcutSupported(context)
+            else -> false
+        }
     }
 
     @AnyThread
     fun getPendingToolShortcut(code: String?): PendingShortcut? {
+        if (!isEnabled) return null
         val id = code?.toolShortcutId ?: return null
 
         return synchronized(pendingShortcuts) {
@@ -299,6 +307,8 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
         @VisibleForTesting
         internal val updatePendingShortcutsJob = coroutineScope.launch {
+            if (!manager.isEnabled) return@launch
+
             merge(
                 settings.primaryLanguageFlow,
                 settings.parallelLanguageFlow,
@@ -313,6 +323,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
         @VisibleForTesting
         internal val updateShortcutsJob = coroutineScope.launch {
+            if (!manager.isEnabled) return@launch
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return@launch
 
             merge(

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/ShortcutModule.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/ShortcutModule.kt
@@ -12,7 +12,7 @@ import org.greenrobot.eventbus.meta.SubscriberInfoIndex
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class ShortcutModule {
+internal abstract class ShortcutModule {
     @Binds
     @IntoSet
     @EagerSingleton(threadMode = EagerSingleton.ThreadMode.ASYNC)

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -7,6 +7,7 @@ import io.mockk.clearMocks
 import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.excludeRecords
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Locale
@@ -54,7 +55,10 @@ class GodToolsShortcutManagerDispatcherTest {
         every { primaryLanguageFlow } returns this@GodToolsShortcutManagerDispatcherTest.primaryLanguageFlow
         every { parallelLanguageFlow } returns this@GodToolsShortcutManagerDispatcherTest.parallelLanguageFlow
     }
-    private val shortcutManager: GodToolsShortcutManager = mockk(relaxUnitFun = true)
+    private val shortcutManager: GodToolsShortcutManager = mockk(relaxUnitFun = true) {
+        every { isEnabled } returns true
+        excludeRecords { isEnabled }
+    }
     private val testScope = TestScope()
     private val toolsRepository: ToolsRepository = mockk {
         every { toolsChangeFlow(false) } returns toolsChangeFlow

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -8,12 +8,15 @@ import android.os.Build
 import androidx.core.content.getSystemService
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.gms.common.wrappers.InstantApps
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerifyAll
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.spyk
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.util.EnumSet
 import kotlinx.coroutines.CancellationException
@@ -26,6 +29,8 @@ import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.testing.timber.ExceptionRaisingTree
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.model.Tool
+import org.greenrobot.eventbus.EventBus
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -47,16 +52,33 @@ private const val INSTALL_SHORTCUT_PERMISSION = "com.android.launcher.permission
 @OptIn(ExperimentalCoroutinesApi::class)
 class GodToolsShortcutManagerTest {
     private lateinit var app: Application
+    private val eventBus: EventBus = mockk(relaxUnitFun = true)
     private lateinit var shortcutManagerService: ShortcutManager
     private val testScope = TestScope()
     private val toolsRepository: ToolsRepository = mockk {
         coEvery { findTool(any()) } returns null
     }
 
-    private lateinit var shortcutManager: GodToolsShortcutManager
+    private val shortcutManager by lazy {
+        GodToolsShortcutManager(
+            attachmentsRepository = mockk(),
+            context = app,
+            eventBus = eventBus,
+            fs = mockk(),
+            picasso = mockk(),
+            settings = mockk(),
+            toolsRepository = toolsRepository,
+            translationsRepository = mockk(),
+            coroutineScope = testScope.backgroundScope,
+            ioDispatcher = UnconfinedTestDispatcher(testScope.testScheduler)
+        )
+    }
 
     @Before
     fun setup() {
+        mockkStatic(InstantApps::class)
+        every { InstantApps.isInstantApp(any()) } returns false
+
         val rawApp = ApplicationProvider.getApplicationContext<Application>()
         Shadows.shadowOf(rawApp).grantPermissions(INSTALL_SHORTCUT_PERMISSION)
         app = spyk(rawApp) {
@@ -73,19 +95,11 @@ class GodToolsShortcutManagerTest {
                 every { getSystemService(ShortcutManager::class.java) } returns shortcutManagerService
             }
         }
+    }
 
-        shortcutManager = GodToolsShortcutManager(
-            attachmentsRepository = mockk(),
-            context = app,
-            eventBus = mockk(relaxUnitFun = true),
-            fs = mockk(),
-            picasso = mockk(),
-            settings = mockk(),
-            toolsRepository = toolsRepository,
-            translationsRepository = mockk(),
-            coroutineScope = testScope.backgroundScope,
-            ioDispatcher = UnconfinedTestDispatcher(testScope.testScheduler)
-        )
+    @After
+    fun cleanup() {
+        unmockkStatic(InstantApps::class)
     }
 
     // region Pending Shortcuts
@@ -151,10 +165,22 @@ class GodToolsShortcutManagerTest {
     // region Instant App
     @Test
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
-    fun verifyUpdateDynamicShortcutsOnInstantAppIsANoop() = testScope.runTest {
+    fun `Instant App - canPinToolShortcut() - GT-1977`() {
+        every { InstantApps.isInstantApp(any()) } returns true
         // Instant Apps don't have access to the system ShortcutManager
         every { app.getSystemService<ShortcutManager>() } returns null
 
+        assertFalse(shortcutManager.canPinToolShortcut(Tool("kgp", type = Tool.Type.TRACT)))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
+    fun `Instant App - updateDynamicShortcuts()`() = testScope.runTest {
+        every { InstantApps.isInstantApp(any()) } returns true
+        // Instant Apps don't have access to the system ShortcutManager
+        every { app.getSystemService<ShortcutManager>() } returns null
+
+        // This should be a no-op
         shortcutManager.updateDynamicShortcuts(emptyMap())
         verify { toolsRepository wasNot Called }
     }

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerTest.kt
@@ -164,6 +164,14 @@ class GodToolsShortcutManagerTest {
 
     // region Instant App
     @Test
+    fun `Instant App - Don't register with EventBus`() {
+        every { InstantApps.isInstantApp(any()) } returns true
+
+        assertFalse(shortcutManager.isEnabled)
+        verify { eventBus wasNot Called }
+    }
+
+    @Test
     @Config(sdk = [Build.VERSION_CODES.N_MR1, NEWEST_SDK])
     fun `Instant App - canPinToolShortcut() - GT-1977`() {
         every { InstantApps.isInstantApp(any()) } returns true


### PR DESCRIPTION
- add a unit test to ensure that canPinToolShortcut() doesn't crash for instant apps
- fully disable the shortcut manager when running as an InstantApp
- there is no need to expose the ShortcutManager.Dispatcher
