### PR TITLE
GT-1534 Stop recording analytics events for AppsFlyer

### DIFF
--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsService.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
-import androidx.annotation.WorkerThread
 import com.appsflyer.AFLogger
 import com.appsflyer.AppsFlyerConversionListener
 import com.appsflyer.AppsFlyerLib
@@ -18,13 +17,7 @@ import com.karumi.weak.weak
 import javax.inject.Inject
 import javax.inject.Singleton
 import org.cru.godtools.analytics.BuildConfig
-import org.cru.godtools.analytics.model.AnalyticsActionEvent
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.base.HOST_GET_GODTOOLSAPP_COM
-import org.greenrobot.eventbus.EventBus
-import org.greenrobot.eventbus.Subscribe
-import org.greenrobot.eventbus.ThreadMode
 import timber.log.Timber
 
 private const val TAG = "AppsFlyerAnalytics"
@@ -39,30 +32,14 @@ private const val STATUS_NON_ORGANIC = "Non-organic"
 @Singleton
 class AppsFlyerAnalyticsService @VisibleForTesting internal constructor(
     private val app: Application,
-    eventBus: EventBus,
     private val deepLinkResolvers: Set<AppsFlyerDeepLinkResolver>,
-    private val appsFlyer: AppsFlyerLib
+    appsFlyer: AppsFlyerLib
 ) : Application.ActivityLifecycleCallbacks {
     @Inject
     internal constructor(
         app: Application,
-        eventBus: EventBus,
         deepLinkResolvers: Set<@JvmSuppressWildcards AppsFlyerDeepLinkResolver>
-    ) : this(app, eventBus, deepLinkResolvers, AppsFlyerLib.getInstance())
-
-    // region Analytics Events
-    @WorkerThread
-    @Subscribe(threadMode = ThreadMode.ASYNC)
-    fun onAnalyticsScreenEvent(event: AnalyticsScreenEvent) {
-        if (event.isForSystem(AnalyticsSystem.APPSFLYER)) appsFlyer.logEvent(app, event.screen, emptyMap())
-    }
-
-    @WorkerThread
-    @Subscribe(threadMode = ThreadMode.ASYNC)
-    fun onAnalyticsActionEvent(event: AnalyticsActionEvent) {
-        if (event.isForSystem(AnalyticsSystem.APPSFLYER)) appsFlyer.logEvent(app, event.action, emptyMap())
-    }
-    // endregion Analytics Events
+    ) : this(app, deepLinkResolvers, AppsFlyerLib.getInstance())
 
     // region Application.ActivityLifecycleCallbacks
     private var activeActivity: Activity? by weak()
@@ -119,7 +96,6 @@ class AppsFlyerAnalyticsService @VisibleForTesting internal constructor(
             start(app)
         }
         app.registerActivityLifecycleCallbacks(this)
-        eventBus.register(this)
     }
 }
 

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsBaseEvent.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsBaseEvent.kt
@@ -9,7 +9,7 @@ abstract class AnalyticsBaseEvent internal constructor(
     private val systems: Collection<AnalyticsSystem> = DEFAULT_SYSTEMS
 ) {
     protected companion object {
-        val DEFAULT_SYSTEMS = setOf(*AnalyticsSystem.values()) - setOf(AnalyticsSystem.APPSFLYER, AnalyticsSystem.USER)
+        val DEFAULT_SYSTEMS = setOf(*AnalyticsSystem.values()) - AnalyticsSystem.USER
     }
 
     /**

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsScreenEvent.kt
@@ -3,15 +3,9 @@ package org.cru.godtools.analytics.model
 import java.util.Locale
 import javax.annotation.concurrent.Immutable
 import org.cru.godtools.shared.analytics.AnalyticsAppSectionNames
-import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 
 @Immutable
 open class AnalyticsScreenEvent(val screen: String, locale: Locale? = null) : AnalyticsBaseEvent(locale) {
-    override fun isForSystem(system: AnalyticsSystem) = when (screen) {
-        AnalyticsScreenNames.DASHBOARD_LESSONS -> system == AnalyticsSystem.APPSFLYER || super.isForSystem(system)
-        else -> super.isForSystem(system)
-    }
-
     override val appSection get() = AnalyticsAppSectionNames.forScreen(screen) ?: super.appSection
     override val appSubSection get() = AnalyticsAppSectionNames.subSectionForScreen(screen) ?: super.appSubSection
 

--- a/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsSystem.kt
+++ b/library/analytics/src/main/kotlin/org/cru/godtools/analytics/model/AnalyticsSystem.kt
@@ -1,5 +1,5 @@
 package org.cru.godtools.analytics.model
 
 enum class AnalyticsSystem {
-    APPSFLYER, FACEBOOK, FIREBASE, USER
+    FACEBOOK, FIREBASE, USER
 }

--- a/library/analytics/src/test/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsServiceTest.kt
+++ b/library/analytics/src/test/kotlin/org/cru/godtools/analytics/appsflyer/AppsFlyerAnalyticsServiceTest.kt
@@ -27,7 +27,6 @@ class AppsFlyerAnalyticsServiceTest {
 
         analyticsService = AppsFlyerAnalyticsService(
             mockk(relaxUnitFun = true),
-            eventBus = mockk(relaxUnitFun = true),
             deepLinkResolvers = setOf(deepLinkResolver),
             appsFlyer = mockk(relaxed = true)
         )

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
@@ -10,7 +10,6 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 class ContentAnalyticsEventAnalyticsActionEvent(@get:VisibleForTesting val event: AnalyticsEvent) :
     AnalyticsActionEvent(action = event.action.orEmpty(), locale = event.manifest.locale) {
     override fun isForSystem(system: AnalyticsSystem) = when (system) {
-        AnalyticsSystem.APPSFLYER -> false
         AnalyticsSystem.FACEBOOK -> event.isForSystem(AnalyticsEvent.System.FACEBOOK)
         AnalyticsSystem.FIREBASE ->
             event.isForSystem(AnalyticsEvent.System.ADOBE) || event.isForSystem(AnalyticsEvent.System.FIREBASE)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
@@ -10,7 +10,7 @@ import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 class ContentAnalyticsEventAnalyticsActionEvent(@get:VisibleForTesting val event: AnalyticsEvent) :
     AnalyticsActionEvent(action = event.action.orEmpty(), locale = event.manifest.locale) {
     override fun isForSystem(system: AnalyticsSystem) = when (system) {
-        AnalyticsSystem.APPSFLYER -> event.isForSystem(AnalyticsEvent.System.APPSFLYER)
+        AnalyticsSystem.APPSFLYER -> false
         AnalyticsSystem.FACEBOOK -> event.isForSystem(AnalyticsEvent.System.FACEBOOK)
         AnalyticsSystem.FIREBASE ->
             event.isForSystem(AnalyticsEvent.System.ADOBE) || event.isForSystem(AnalyticsEvent.System.FIREBASE)

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsScreenEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolAnalyticsScreenEvent.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.base.tool.analytics.model
 
 import java.util.Locale
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.shared.tool.parser.model.Manifest
 
 const val SCREEN_CATEGORIES = "Categories"
@@ -13,11 +12,6 @@ open class ToolAnalyticsScreenEvent(
     locale: Locale? = null
 ) : AnalyticsScreenEvent(screen, locale) {
     protected constructor(screen: String, manifest: Manifest) : this(screen, manifest.code, manifest.locale)
-
-    override fun isForSystem(system: AnalyticsSystem) = when (screen) {
-        SCREEN_CATEGORIES -> system == AnalyticsSystem.APPSFLYER || super.isForSystem(system)
-        else -> super.isForSystem(system)
-    }
 
     override val appSection get() = tool
 }

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolOpenedAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ToolOpenedAnalyticsActionEvent.kt
@@ -8,11 +8,10 @@ import org.cru.godtools.shared.user.activity.UserCounterNames
 
 class ToolOpenedAnalyticsActionEvent(
     tool: String,
-    private val type: Manifest.Type? = null,
+    type: Manifest.Type? = null,
     first: Boolean = false
 ) : ToolAnalyticsActionEvent(tool, action = if (first) ACTION_OPEN_FIRST else ACTION_OPEN) {
     override fun isForSystem(system: AnalyticsSystem) = when (system) {
-        AnalyticsSystem.APPSFLYER -> type in setOf(Manifest.Type.ARTICLE, Manifest.Type.CYOA, Manifest.Type.TRACT)
         AnalyticsSystem.USER -> true
         else -> false
     }

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEventTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/analytics/model/CyoaPageAnalyticsScreenEventTest.kt
@@ -22,7 +22,7 @@ class CyoaPageAnalyticsScreenEventTest {
 
     @Test
     fun `Property - screen`() {
-        assertEquals("tool:page", CyoaPageAnalyticsScreenEvent(page).screen)
+        assertEquals("$TOOL:$PAGE", CyoaPageAnalyticsScreenEvent(page).screen)
     }
 
     @Test
@@ -34,6 +34,6 @@ class CyoaPageAnalyticsScreenEventTest {
     @Test
     fun `isForSystem() - Not Supported`() {
         val event = CyoaPageAnalyticsScreenEvent(page)
-        assertFalse(event.isForSystem(AnalyticsSystem.APPSFLYER))
+        assertFalse(event.isForSystem(AnalyticsSystem.USER))
     }
 }

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonPageAnalyticsScreenEventTest.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/analytics/model/LessonPageAnalyticsScreenEventTest.kt
@@ -21,7 +21,6 @@ class LessonPageAnalyticsScreenEventTest {
         }
         val event = LessonPageAnalyticsScreenEvent(page)
         assertTrue(event.isForSystem(AnalyticsSystem.FIREBASE))
-        assertFalse(event.isForSystem(AnalyticsSystem.APPSFLYER))
         assertFalse(event.isForSystem(AnalyticsSystem.USER))
     }
 }

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEventTest.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tract/analytics/model/TractPageAnalyticsScreenEventTest.kt
@@ -38,7 +38,6 @@ class TractPageAnalyticsScreenEventTest {
     fun testSupportedSystems() {
         val event = TractPageAnalyticsScreenEvent(page)
         assertTrue(event.isForSystem(AnalyticsSystem.FIREBASE))
-        assertFalse(event.isForSystem(AnalyticsSystem.APPSFLYER))
         assertFalse(event.isForSystem(AnalyticsSystem.USER))
     }
 }

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/analytics/model/TutorialAnalyticsScreenEvent.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/analytics/model/TutorialAnalyticsScreenEvent.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.tutorial.analytics.model
 
 import java.util.Locale
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
-import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.tutorial.Page
 import org.cru.godtools.tutorial.PageSet
 
@@ -12,13 +11,6 @@ class TutorialAnalyticsScreenEvent internal constructor(
     pagePos: Int,
     locale: Locale?
 ) : AnalyticsScreenEvent("${tutorial.analyticsBaseScreenName}-${pagePos + 1}", locale) {
-    override fun isForSystem(system: AnalyticsSystem) = when (page) {
-        Page.ONBOARDING_WELCOME,
-        Page.ONBOARDING_SHARE_FINAL,
-        Page.ONBOARDING_LINKS -> system == AnalyticsSystem.APPSFLYER || super.isForSystem(system)
-        else -> super.isForSystem(system)
-    }
-
     override val appSection get() = when (tutorial) {
         PageSet.ONBOARDING -> APP_SECTION_ONBOARDING
         PageSet.FEATURES -> APP_SECTION_TUTORIAL


### PR DESCRIPTION
- remove the AppsFlyer analytics system configuration for individual events
- don't log any AppsFlyer analytics events
- remove AppsFlyer AnalyticsSystem value
