### PR TITLE
Make some tweaks to the DB repositories

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeViewModel.kt
@@ -57,7 +57,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun commitFavoriteToolOrder() {
-        viewModelScope.launch { toolsRepository.updateToolOrder(favoriteToolsOrder.value.mapNotNull { it.code }) }
+        viewModelScope.launch { toolsRepository.storeToolOrder(favoriteToolsOrder.value.mapNotNull { it.code }) }
     }
     // endregion Favorite Tools
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/AttachmentsRepository.kt
@@ -10,7 +10,11 @@ interface AttachmentsRepository {
     suspend fun getAttachments(): List<Attachment>
     fun getAttachmentsFlow(): Flow<List<Attachment>>
 
-    fun attachmentsChangeFlow(emitOnStart: Boolean = true): Flow<Any?>
+    /**
+     * Returns a Flow that emits a value every time the Attachments table changes.
+     * This will always emit an initial value on collection.
+     */
+    fun attachmentsChangeFlow(): Flow<Any?>
 
     suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean)
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
@@ -27,7 +27,7 @@ interface ToolsRepository {
     suspend fun pinTool(code: String)
     suspend fun unpinTool(code: String)
 
-    suspend fun updateToolOrder(tools: List<String>)
+    suspend fun storeToolOrder(tools: List<String>)
     suspend fun updateToolViews(code: String, delta: Int)
 
     // region Initial Content Methods

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.db.repository
 
 import androidx.annotation.WorkerThread
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.cru.godtools.model.Lesson
 import org.cru.godtools.model.Resource
 import org.cru.godtools.model.Tool
@@ -19,7 +20,8 @@ interface ToolsRepository {
     fun getResourcesFlow(): Flow<List<Resource>>
     fun getToolsFlow(): Flow<List<Tool>>
     fun getMetaToolsFlow(): Flow<List<Tool>>
-    fun getFavoriteToolsFlow(): Flow<List<Tool>>
+    fun getFavoriteToolsFlow(): Flow<List<Tool>> =
+        getToolsFlow().map { it.filter { it.isAdded }.sortedWith(Tool.COMPARATOR_FAVORITE_ORDER) }
     fun getLessonsFlow(): Flow<List<Lesson>>
 
     fun toolsChangeFlow(): Flow<Any?>

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
@@ -22,7 +22,7 @@ interface ToolsRepository {
     fun getFavoriteToolsFlow(): Flow<List<Tool>>
     fun getLessonsFlow(): Flow<List<Lesson>>
 
-    fun toolsChangeFlow(emitOnStart: Boolean = true): Flow<Any?>
+    fun toolsChangeFlow(): Flow<Any?>
 
     suspend fun pinTool(code: String)
     suspend fun unpinTool(code: String)

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyAttachmentsRepository.kt
@@ -35,8 +35,7 @@ internal class LegacyAttachmentsRepository @Inject constructor(private val dao: 
     override suspend fun getAttachments() = dao.getAsync(Query.select<Attachment>()).await()
     override fun getAttachmentsFlow() = dao.getAsFlow(Query.select<Attachment>())
 
-    override fun attachmentsChangeFlow(emitOnStart: Boolean) =
-        dao.invalidationFlow(Attachment::class.java, emitOnStart = emitOnStart)
+    override fun attachmentsChangeFlow() = dao.invalidationFlow(Attachment::class.java, emitOnStart = true)
 
     override suspend fun updateAttachmentDownloaded(id: Long, isDownloaded: Boolean) {
         val attachment = Attachment().apply {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
@@ -66,8 +66,7 @@ internal class LegacyToolsRepository @Inject constructor(
         .orderBy(ToolTable.COLUMN_DEFAULT_ORDER)
         .getAsFlow(dao)
 
-    override fun toolsChangeFlow(emitOnStart: Boolean) =
-        dao.invalidationFlow(Tool::class.java, emitOnStart = emitOnStart)
+    override fun toolsChangeFlow() = dao.invalidationFlow(Tool::class.java)
 
     override suspend fun pinTool(code: String) {
         val tool = Tool().also {

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
@@ -22,6 +22,7 @@ import org.cru.godtools.model.Lesson
 import org.cru.godtools.model.Resource
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
+import org.keynote.godtools.android.db.Contract.BaseTable
 import org.keynote.godtools.android.db.Contract.ToolTable
 import org.keynote.godtools.android.db.Contract.TranslationTable
 import org.keynote.godtools.android.db.GodToolsDao
@@ -108,7 +109,7 @@ internal class LegacyToolsRepository @Inject constructor(
     override fun storeToolFromSync(tool: Tool) {
         dao.updateOrInsert(
             tool, SQLiteDatabase.CONFLICT_REPLACE,
-            ToolTable.COLUMN_CODE, ToolTable.COLUMN_TYPE, ToolTable.COLUMN_NAME, ToolTable.COLUMN_DESCRIPTION,
+            BaseTable.COLUMN_ID, ToolTable.COLUMN_TYPE, ToolTable.COLUMN_NAME, ToolTable.COLUMN_DESCRIPTION,
             ToolTable.COLUMN_CATEGORY, ToolTable.COLUMN_SHARES, ToolTable.COLUMN_BANNER,
             ToolTable.COLUMN_DETAILS_BANNER, ToolTable.COLUMN_DETAILS_BANNER_ANIMATION,
             ToolTable.COLUMN_DETAILS_BANNER_YOUTUBE, ToolTable.COLUMN_DEFAULT_ORDER, ToolTable.COLUMN_HIDDEN,

--- a/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepository.kt
@@ -84,7 +84,7 @@ internal class LegacyToolsRepository @Inject constructor(
         dao.updateAsync(tool, ToolTable.COLUMN_ADDED).await()
     }
 
-    override suspend fun updateToolOrder(tools: List<String>) {
+    override suspend fun storeToolOrder(tools: List<String>) {
         dao.transactionAsync(exclusive = false) {
             val tool = Tool()
             dao.update(tool, null, ToolTable.COLUMN_ORDER)

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/AttachmentsRepositoryIT.kt
@@ -75,8 +75,9 @@ abstract class AttachmentsRepositoryIT {
 
     // region attachmentsChangeFlow()
     @Test
-    fun `attachmentsChangeFlow(emitOnStart = true)`() = testScope.runTest {
-        repository.attachmentsChangeFlow(emitOnStart = true).test {
+    fun `attachmentsChangeFlow()`() = testScope.runTest {
+        repository.attachmentsChangeFlow().test {
+            runCurrent()
             expectMostRecentItem()
 
             val attachment = Attachment().apply {
@@ -91,14 +92,6 @@ abstract class AttachmentsRepositoryIT {
             repository.updateAttachmentDownloaded(attachment.id, true)
             runCurrent()
             expectMostRecentItem()
-        }
-    }
-
-    @Test
-    fun `attachmentsChangeFlow(emitOnStart = false)`() = testScope.runTest {
-        repository.attachmentsChangeFlow(emitOnStart = false).test {
-            runCurrent()
-            expectNoEvents()
         }
     }
     // endregion attachmentsChangeFlow()

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
@@ -284,6 +284,26 @@ abstract class ToolsRepositoryIT {
         }
     }
 
+    // region storeToolOrder()
+    @Test
+    fun `storeToolOrder()`() = testScope.runTest {
+        val tool1 = Tool("tool1") { order = 7 }
+        val tool2 = Tool("tool2") { order = 6 }
+        val tool3 = Tool("tool3") { order = 5 }
+        repository.storeInitialResources(listOf(tool1, tool2, tool3))
+        assertEquals(
+            listOf("tool3", "tool2", "tool1"),
+            repository.getTools().sortedBy { it.order }.map { it.code }
+        )
+
+        repository.storeToolOrder(listOf("tool1", "tool3"))
+        assertEquals(
+            listOf("tool1", "tool3", "tool2"),
+            repository.getTools().sortedBy { it.order }.map { it.code }
+        )
+    }
+    // endregion storeToolOrder()
+
     // region updateToolShares()
     @Test
     fun `updateToolViews()`() = testScope.runTest {

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
@@ -238,8 +238,9 @@ abstract class ToolsRepositoryIT {
 
     // region toolsChangeFlow()
     @Test
-    fun `toolsChangeFlow(emitOnStart = true)`() = testScope.runTest {
-        repository.toolsChangeFlow(emitOnStart = true).test {
+    fun `toolsChangeFlow()`() = testScope.runTest {
+        repository.toolsChangeFlow().test {
+            runCurrent()
             expectMostRecentItem()
 
             val tool = Tool().apply {
@@ -253,14 +254,6 @@ abstract class ToolsRepositoryIT {
             repository.pinTool("tool")
             runCurrent()
             expectMostRecentItem()
-        }
-    }
-
-    @Test
-    fun `toolsChangeFlow(emitOnStart = false)`() = testScope.runTest {
-        repository.toolsChangeFlow(emitOnStart = false).test {
-            runCurrent()
-            expectNoEvents()
         }
     }
     // endregion toolsChangeFlow()

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
@@ -19,6 +19,7 @@ import org.cru.godtools.model.Attachment
 import org.cru.godtools.model.Resource
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.ToolMatchers.tool
+import org.cru.godtools.model.randomTool
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.containsInAnyOrder
@@ -182,7 +183,7 @@ abstract class ToolsRepositoryIT {
         val tool2 = Tool("tool2") { isAdded = false }
         val fav1 = Tool("fav1") { isAdded = true }
         val fav2 = Tool("fav2") { isAdded = true }
-        repository.storeToolsFromSync(listOf(tool1, tool2, fav1, fav2))
+        repository.storeInitialResources(listOf(tool1, tool2, fav1, fav2))
 
         assertThat(
             repository.getFavoriteToolsFlow().first(),
@@ -261,7 +262,7 @@ abstract class ToolsRepositoryIT {
     @Test
     fun verifyPinTool() = testScope.runTest {
         val code = "pinTool"
-        repository.storeToolFromSync(Tool(code))
+        repository.storeInitialResources(listOf(Tool(code)))
 
         repository.findToolFlow(code).test {
             assertFalse(assertNotNull(awaitItem()).isAdded)
@@ -274,7 +275,7 @@ abstract class ToolsRepositoryIT {
     @Test
     fun verifyUnpinTool() = testScope.runTest {
         val code = "pinTool"
-        repository.storeToolFromSync(Tool(code) { isAdded = true })
+        repository.storeInitialResources(listOf(Tool(code) { isAdded = true }))
 
         repository.findToolFlow(code).test {
             assertTrue(assertNotNull(awaitItem()).isAdded)
@@ -332,12 +333,58 @@ abstract class ToolsRepositoryIT {
 
     // region storeToolFromSync()
     @Test
-    fun `storeToolFromSync()`() = testScope.runTest {
+    fun `storeToolFromSync() - New Tool`() = testScope.runTest {
         assertNull(repository.findTool("tool"))
-        val tool = Tool("tool")
+        val tool = randomTool("tool", Tool.Type.LESSON)
 
         repository.storeToolFromSync(tool)
-        assertThat(repository.findTool("tool"), tool(tool))
+        assertNotNull(repository.findTool("tool")) {
+            assertEquals(tool.id, it.id)
+            assertEquals(tool.code, it.code)
+            assertEquals(tool.type, it.type)
+            assertEquals(tool.name, it.name)
+            assertEquals(tool.category, it.category)
+            assertEquals(tool.description, it.description)
+            assertEquals(tool.shares, it.shares)
+            assertEquals(tool.bannerId, it.bannerId)
+            assertEquals(tool.detailsBannerId, it.detailsBannerId)
+            assertEquals(tool.detailsBannerAnimationId, it.detailsBannerAnimationId)
+            assertEquals(tool.detailsBannerYoutubeVideoId, it.detailsBannerYoutubeVideoId)
+            assertEquals(tool.isScreenShareDisabled, it.isScreenShareDisabled)
+            assertEquals(tool.defaultOrder, it.defaultOrder)
+            assertEquals(tool.metatoolCode, it.metatoolCode)
+            assertEquals(tool.defaultVariantCode, it.defaultVariantCode)
+            assertEquals(tool.isHidden, it.isHidden)
+            assertEquals(tool.isSpotlight, it.isSpotlight)
+        }
+    }
+
+    @Test
+    fun `storeToolFromSync() - Update Tool`() = testScope.runTest {
+        val initial = randomTool("tool", Tool.Type.TRACT)
+        repository.storeToolFromSync(initial)
+        val updated = randomTool("tool", Tool.Type.LESSON)
+
+        repository.storeToolFromSync(updated)
+        assertNotNull(repository.findTool("tool")) {
+            assertEquals(updated.id, it.id)
+            assertEquals(updated.code, it.code)
+            assertEquals(updated.type, it.type)
+            assertEquals(updated.name, it.name)
+            assertEquals(updated.category, it.category)
+            assertEquals(updated.description, it.description)
+            assertEquals(updated.shares, it.shares)
+            assertEquals(updated.bannerId, it.bannerId)
+            assertEquals(updated.detailsBannerId, it.detailsBannerId)
+            assertEquals(updated.detailsBannerAnimationId, it.detailsBannerAnimationId)
+            assertEquals(updated.detailsBannerYoutubeVideoId, it.detailsBannerYoutubeVideoId)
+            assertEquals(updated.isScreenShareDisabled, it.isScreenShareDisabled)
+            assertEquals(updated.defaultOrder, it.defaultOrder)
+            assertEquals(updated.metatoolCode, it.metatoolCode)
+            assertEquals(updated.defaultVariantCode, it.defaultVariantCode)
+            assertEquals(updated.isHidden, it.isHidden)
+            assertEquals(updated.isSpotlight, it.isSpotlight)
+        }
     }
 
     @Test
@@ -349,6 +396,18 @@ abstract class ToolsRepositoryIT {
 
         repository.storeToolFromSync(tool)
         assertNotNull(repository.findTool("tool")) { assertTrue(it.isAdded) }
+    }
+
+    @Test
+    fun `storeToolFromSync() - Don't pave over pending tool views`() = testScope.runTest {
+        val tool = Tool("tool") { pendingShares = 0 }
+        repository.storeToolFromSync(tool)
+        assertNotNull(repository.findTool("tool")) { assertEquals(0, it.pendingShares) }
+        repository.updateToolViews("tool", 5)
+        assertNotNull(repository.findTool("tool")) { assertEquals(5, it.pendingShares) }
+
+        repository.storeToolFromSync(tool)
+        assertNotNull(repository.findTool("tool")) { assertEquals(5, it.pendingShares) }
     }
     // endregion storeToolFromSync()
 
@@ -370,7 +429,7 @@ abstract class ToolsRepositoryIT {
         val attachment1 = Attachment(tool = tool1)
         val attachment2 = Attachment(tool = tool2)
         val attachment3 = Attachment(tool = tool3)
-        repository.storeToolsFromSync(listOf(tool1, tool2, tool3))
+        repository.storeInitialResources(listOf(tool1, tool2, tool3))
         attachmentsRepository.storeAttachmentsFromSync(listOf(attachment1, attachment2, attachment3))
         assertNotNull(attachmentsRepository.findAttachment(attachment1.id))
         assertNotNull(attachmentsRepository.findAttachment(attachment2.id))
@@ -390,7 +449,7 @@ abstract class ToolsRepositoryIT {
 
     @Test
     fun `deleteIfNotFavoriteBlocking() - Don't delete favorited tools`() = testScope.runTest {
-        repository.storeToolFromSync(Tool("tool") { isAdded = true })
+        repository.storeInitialResources(listOf(Tool("tool") { isAdded = true }))
         assertNotNull(repository.findTool("tool"))
 
         repository.deleteIfNotFavoriteBlocking("tool")

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Tool.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Tool.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.model
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import java.util.UUID
 import kotlin.random.Random
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiAttribute
 import org.ccci.gto.android.common.jsonapi.annotation.JsonApiIgnore
@@ -157,5 +158,35 @@ fun Tool(
     this.code = code
     this.type = type
     latestTranslations = translations
+    config()
+}
+
+// TODO: move this to testFixtures once they support Kotlin source files
+@RestrictTo(RestrictTo.Scope.TESTS)
+fun randomTool(
+    code: String = UUID.randomUUID().toString(),
+    type: Tool.Type = Tool.Type.values().random(),
+    config: Tool.() -> Unit = {},
+) = Tool(code, type) {
+    id = Random.nextLong()
+    this.code = code
+    this.type = type
+    name = UUID.randomUUID().toString()
+    category = UUID.randomUUID().toString()
+    description = UUID.randomUUID().toString()
+    shares = Random.nextInt()
+    pendingShares = Random.nextInt()
+    bannerId = Random.nextLong()
+    detailsBannerId = Random.nextLong()
+    detailsBannerAnimationId = Random.nextLong()
+    detailsBannerYoutubeVideoId = UUID.randomUUID().toString()
+    isScreenShareDisabled = Random.nextBoolean()
+    defaultOrder = Random.nextInt()
+    order = Random.nextInt()
+    metatoolCode = UUID.randomUUID().toString()
+    defaultVariantCode = UUID.randomUUID().toString()
+    isAdded = Random.nextBoolean()
+    isHidden = Random.nextBoolean()
+    isSpotlight = Random.nextBoolean()
     config()
 }

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -48,8 +48,7 @@ class GodToolsShortcutManagerDispatcherTest {
     }
 
     private val attachmentsRepository: AttachmentsRepository = mockk {
-        every { attachmentsChangeFlow(false) } returns attachmentsChangeFlow
-        every { attachmentsChangeFlow(true) } returns attachmentsChangeFlow.onStart { emit(Unit) }
+        every { attachmentsChangeFlow() } returns attachmentsChangeFlow.onStart { emit(Unit) }
     }
     private val settings: Settings = mockk {
         every { primaryLanguageFlow } returns this@GodToolsShortcutManagerDispatcherTest.primaryLanguageFlow

--- a/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
+++ b/ui/shortcuts/src/test/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManagerDispatcherTest.kt
@@ -61,8 +61,7 @@ class GodToolsShortcutManagerDispatcherTest {
     }
     private val testScope = TestScope()
     private val toolsRepository: ToolsRepository = mockk {
-        every { toolsChangeFlow(false) } returns toolsChangeFlow
-        every { toolsChangeFlow(true) } returns toolsChangeFlow.onStart { emit(Unit) }
+        every { toolsChangeFlow() } returns toolsChangeFlow.onStart { emit(Unit) }
     }
     private val translationsRepository: TranslationsRepository = mockk {
         every { translationsChangeFlow(false) } returns translationsChangeFlow


### PR DESCRIPTION
- there is no need for toolsChangeFlow to not emit on start
- add a unit test for ToolsRepository.storeToolOrder
- update AttachmentsRepository.attachmentsChangeFlow() to always emit an initial value
- create a default implementation of getFavoriteToolsFlow()
