### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -56,7 +56,7 @@ import org.cru.godtools.ui.account.globalactivity.AccountGlobalActivityLayout
 internal val ACCOUNT_PAGE_MARGIN_HORIZONTAL = 16.dp
 
 @Composable
-@OptIn(ExperimentalMaterialApi::class, ExperimentalPagerApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 internal fun AccountLayout(onEvent: (AccountLayoutEvent) -> Unit = {}) {
     val viewModel = viewModel<AccountViewModel>()
     val user by viewModel.user.collectAsState()

--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -115,7 +115,7 @@ private fun AccountLayoutHeader(
                         Icon(Icons.Filled.ArrowBack, null)
                     }
                 },
-                colors = TopAppBarDefaults.smallTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     navigationIconContentColor = MaterialTheme.colorScheme.primary
                 )
             )

--- a/app/src/main/kotlin/org/cru/godtools/ui/account/activity/AccountActivityBadges.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/activity/AccountActivityBadges.kt
@@ -15,14 +15,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
@@ -65,7 +63,6 @@ internal fun AccountActivityBadges(
 }
 
 @Composable
-@OptIn(ExperimentalTextApi::class)
 private fun ActivityBadge(badge: Badge, modifier: Modifier = Modifier) {
     val textStyle = MaterialTheme.typography.labelSmall.merge(ParagraphStyle(lineBreak = LineBreak.Heading))
     val contentHeight = 8.dp + BADGE_SIZE + 8.dp + computeHeightForDefaultText(textStyle, 2) + 8.dp
@@ -143,7 +140,6 @@ private val Badge.icon
         }
     }
 
-@OptIn(ExperimentalComposeUiApi::class)
 private val Badge.label
     @Composable
     get() = when (type) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/banner/Banner.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/banner/Banner.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.LocalMinimumTouchTargetEnforcement
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -39,7 +39,7 @@ internal fun Banner(
     modifier: Modifier = Modifier,
 ) = Surface(modifier = modifier.fillMaxWidth()) {
     Column {
-        CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
+        CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
             val iconNode = "icon"
             val textNode = "text"
             val primaryActionNode = "primaryAction"

--- a/app/src/main/kotlin/org/cru/godtools/ui/banner/Banner.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/banner/Banner.kt
@@ -31,12 +31,12 @@ import androidx.compose.ui.unit.offset
 internal fun Banner(
     text: String,
     primaryButton: String,
+    modifier: Modifier = Modifier,
     primaryAction: () -> Unit = {},
     secondaryButton: String? = null,
     secondaryAction: () -> Unit = {},
     icon: Painter? = null,
     iconTint: Color = if (icon != null) LocalContentColor.current else Color.Unspecified,
-    modifier: Modifier = Modifier,
 ) = Surface(modifier = modifier.fillMaxWidth()) {
     Column {
         CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.ui.dashboard
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -40,7 +39,6 @@ import org.cru.godtools.ui.dashboard.lessons.LessonsLayout
 import org.cru.godtools.ui.dashboard.tools.ToolsLayout
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 internal fun DashboardLayout(
     viewModel: DashboardViewModel = viewModel(),
     onOpenTool: (Tool?, Translation?, Translation?) -> Unit,

--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -67,7 +66,6 @@ import org.cru.godtools.ui.languages.startLanguageSettingsActivity
 import org.cru.godtools.ui.login.startLoginActivity
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 fun DrawerMenuLayout(content: @Composable () -> Unit) {
     val scope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
@@ -86,7 +84,6 @@ fun DrawerMenuLayout(content: @Composable () -> Unit) {
 
 @Composable
 @Preview
-@OptIn(ExperimentalMaterial3Api::class)
 fun DrawerContentLayout(
     scope: CoroutineScope = rememberCoroutineScope(),
     viewModel: DrawerViewModel = viewModel(),

--- a/app/src/main/kotlin/org/cru/godtools/ui/login/LoginLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/login/LoginLayout.kt
@@ -57,7 +57,7 @@ fun LoginLayout(onEvent: (event: LoginLayoutEvent) -> Unit) {
                     }
                 },
                 title = {},
-                colors = TopAppBarDefaults.smallTopAppBarColors(
+                colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = GodToolsTheme.GT_BLUE,
                     navigationIconContentColor = Color.White
                 ),

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -67,7 +66,7 @@ private val TOOL_DETAILS_HORIZONTAL_MARGIN = 32.dp
 internal const val TEST_TAG_ACTION_TOOL_TRAINING = "action_tool_training"
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalPagerApi::class)
+@OptIn(ExperimentalPagerApi::class)
 fun ToolDetailsLayout(
     viewModel: ToolDetailsViewModel = viewModel(),
     onOpenTool: (Tool?, Translation?, Translation?) -> Unit = { _, _, _ -> },

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/FavoriteAction.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/FavoriteAction.kt
@@ -3,7 +3,6 @@ package org.cru.godtools.ui.tools
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -26,7 +25,6 @@ import org.cru.godtools.R
 import org.cru.godtools.model.getName
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 internal fun FavoriteAction(
     viewModel: ToolViewModels.ToolViewModel,
     modifier: Modifier = Modifier,

--- a/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/FileSystemTest.kt
@@ -4,14 +4,12 @@ import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
 import java.io.File
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FileSystemTest {
     private val rootDir = File.createTempFile("abc", null).parentFile!!
     private val context = mockk<Context> { every { filesDir } returns rootDir }

--- a/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
@@ -4,7 +4,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import java.util.Locale
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.junit.Assert.assertEquals
@@ -18,7 +17,6 @@ import org.junit.runner.RunWith
 private const val FEATURE_TEST = "testFeature"
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class SettingsTest {
     private lateinit var settings: Settings
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/FollowupsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/FollowupsRepositoryIT.kt
@@ -4,14 +4,12 @@ import java.time.temporal.ChronoUnit
 import java.util.Locale
 import java.util.UUID
 import kotlin.random.Random
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.model.Followup
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class FollowupsRepositoryIT {
     protected val testScope = TestScope()
     abstract val repository: FollowupsRepository

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/GlobalActivityRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/GlobalActivityRepositoryIT.kt
@@ -2,14 +2,12 @@ package org.cru.godtools.db.repository
 
 import app.cash.turbine.test
 import kotlin.random.Random
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.model.GlobalActivityAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class GlobalActivityRepositoryIT {
     internal abstract val repository: GlobalActivityRepository
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/LanguagesRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/LanguagesRepositoryIT.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.db.repository
 
 import app.cash.turbine.test
 import java.util.Locale
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.model.Language
@@ -16,7 +15,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class LanguagesRepositoryIT {
     protected val testScope = TestScope()
     abstract val repository: LanguagesRepository

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepositoryIT.kt
@@ -31,9 +31,9 @@ abstract class LastSyncTimeRepositoryIT {
     }
 
     @Test
-    @Suppress("BlockingMethodInNonBlockingContext")
     fun `updateLastSyncTime() - Replace entry`() = runTest {
         repository.updateLastSyncTime(KEY)
+        @Suppress("BlockingMethodInNonBlockingContext")
         sleep(10)
         val before = System.currentTimeMillis()
         assertThat(repository.getLastSyncTime(KEY), allOf(not(equalTo(0)), lessThan(before)))
@@ -63,18 +63,18 @@ abstract class LastSyncTimeRepositoryIT {
 
     // region isLastSyncStale()
     @Test
-    @Suppress("BlockingMethodInNonBlockingContext")
     fun `isLastSyncStale()`() = runTest {
         repository.updateLastSyncTime(KEY)
+        @Suppress("BlockingMethodInNonBlockingContext")
         sleep(10)
         assertTrue(repository.isLastSyncStale(KEY, staleAfter = 0))
         assertFalse(repository.isLastSyncStale(KEY, staleAfter = DAY_IN_MS))
     }
 
     @Test
-    @Suppress("BlockingMethodInNonBlockingContext")
     fun `isLastSyncStale() - compound key`() = runTest {
         repository.updateLastSyncTime(*COMPOUND_KEY)
+        @Suppress("BlockingMethodInNonBlockingContext")
         sleep(10)
         assertTrue(repository.isLastSyncStale(*COMPOUND_KEY, staleAfter = 0))
         assertFalse(repository.isLastSyncStale(*COMPOUND_KEY, staleAfter = DAY_IN_MS))
@@ -88,9 +88,9 @@ abstract class LastSyncTimeRepositoryIT {
     // endregion isLastSyncStale()
 
     // region resetLastSyncTime()
-    @Suppress("BlockingMethodInNonBlockingContext")
     private suspend fun createMultipleSyncTimes() {
         repository.updateLastSyncTime(KEY)
+        @Suppress("BlockingMethodInNonBlockingContext")
         sleep(5)
         repository.updateLastSyncTime(KEY, 1)
     }

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/LastSyncTimeRepositoryIT.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.db.repository
 
 import java.lang.Thread.sleep
 import java.util.UUID
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.base.TimeConstants.DAY_IN_MS
 import org.hamcrest.MatcherAssert.assertThat
@@ -20,7 +19,6 @@ import org.junit.Test
 private const val KEY = "key"
 private val COMPOUND_KEY = arrayOf(KEY, 1, true)
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class LastSyncTimeRepositoryIT {
     internal abstract val repository: LastSyncTimeRepository
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/UserCountersRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/UserCountersRepositoryIT.kt
@@ -1,6 +1,5 @@
 package org.cru.godtools.db.repository
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.model.UserCounter
 import org.hamcrest.MatcherAssert.assertThat
@@ -14,7 +13,6 @@ import org.junit.Test
 private const val COUNTER = "counter"
 private const val COUNTER2 = "counter2"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 abstract class UserCountersRepositoryIT {
     internal abstract val repository: UserCountersRepository
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/FollowupsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/FollowupsRoomRepositoryIT.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.FollowupsRepositoryIT
@@ -10,7 +9,6 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class FollowupsRoomRepositoryIT : FollowupsRepositoryIT() {
     @get:Rule
     internal val dbRule = RoomDatabaseRule(

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepositoryIT.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.LanguagesRepositoryIT
@@ -10,7 +9,6 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class LanguagesRoomRepositoryIT : LanguagesRepositoryIT() {
     @get:Rule
     internal val dbRule = RoomDatabaseRule(

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.TrainingTipsRepositoryIT
@@ -10,7 +9,6 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class TrainingTipsRoomRepositoryIT : TrainingTipsRepositoryIT() {
     @get:Rule
     internal val dbRule = RoomDatabaseRule(

--- a/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyDownloadedFilesRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyDownloadedFilesRepositoryIT.kt
@@ -2,7 +2,6 @@ package org.keynote.godtools.android.db.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlin.test.BeforeTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.cru.godtools.db.repository.DownloadedFilesRepository
 import org.cru.godtools.db.repository.DownloadedFilesRepositoryIT
@@ -10,7 +9,6 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class LegacyDownloadedFilesRepositoryIT : DownloadedFilesRepositoryIT() {
     @get:Rule
     val dbRule = GodToolsDaoRule(StandardTestDispatcher(testScope.testScheduler))

--- a/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/keynote/godtools/android/db/repository/LegacyToolsRepositoryIT.kt
@@ -2,7 +2,6 @@ package org.keynote.godtools.android.db.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlin.test.BeforeTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.ToolsRepository
@@ -11,7 +10,6 @@ import org.junit.Rule
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class LegacyToolsRepositoryIT : ToolsRepositoryIT() {
     @get:Rule
     val dbRule = GodToolsDaoRule(StandardTestDispatcher(testScope.testScheduler))

--- a/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManager.kt
@@ -432,7 +432,6 @@ class GodToolsDownloadManager @VisibleForTesting internal constructor(
     }
 
     @Singleton
-    @OptIn(ExperimentalCoroutinesApi::class)
     internal class Dispatcher @VisibleForTesting internal constructor(
         attachmentsRepository: AttachmentsRepository,
         private val downloadManager: GodToolsDownloadManager,

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/download/manager/GodToolsDownloadManagerTest.kt
@@ -67,7 +67,6 @@ import retrofit2.Response
 private const val TOOL = "tool"
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("BlockingMethodInNonBlockingContext")
 class GodToolsDownloadManagerTest {
     private val resourcesDir = File.createTempFile("resources", "").also {
         it.delete()

--- a/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
+++ b/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
@@ -12,7 +12,6 @@ import io.mockk.just
 import io.mockk.mockk
 import java.io.ByteArrayInputStream
 import java.util.Locale
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.jsonapi.JsonApiConverter
 import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
@@ -25,7 +24,6 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TasksTest {
     private val context = mockk<Context> {
         every { assets } returns mockk {

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/FollowupSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/FollowupSyncTasksTest.kt
@@ -8,7 +8,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import java.util.Locale
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.cru.godtools.api.FollowupApi
@@ -22,7 +21,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import retrofit2.Response
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FollowupSyncTasksTest {
 
     private val api: FollowupApi = mockk()

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserCounterSyncTasksTest.kt
@@ -7,7 +7,6 @@ import io.mockk.coVerify
 import io.mockk.coVerifyAll
 import io.mockk.mockk
 import io.mockk.spyk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.base.TimeConstants.WEEK_IN_MS
 import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
@@ -24,7 +23,6 @@ import retrofit2.Response
 private const val USER_ID = "user_id"
 private const val USER_ID_OTHER = "user_id_other"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UserCounterSyncTasksTest {
     private val accountManager: GodToolsAccountManager = mockk {
         coEvery { isAuthenticated() } returns true

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/UserSyncTasksTest.kt
@@ -9,7 +9,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlin.random.Random
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
 import org.cru.godtools.account.GodToolsAccountManager
@@ -24,7 +23,6 @@ import retrofit2.Response
 
 private const val USER_ID = "user_id"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UserSyncTasksTest {
     private val accountManager: GodToolsAccountManager = mockk {
         coEvery { isAuthenticated() } returns true

--- a/library/user-data/src/test/kotlin/org/cru/godtools/user/data/UserManagerTest.kt
+++ b/library/user-data/src/test/kotlin/org/cru/godtools/user/data/UserManagerTest.kt
@@ -7,7 +7,6 @@ import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -18,7 +17,6 @@ import org.cru.godtools.model.User
 
 private const val USER_ID = "user_id"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class UserManagerTest {
     private val accountInfoFlow = MutableStateFlow<AccountInfo?>(null)
     private val userIdFlow = MutableStateFlow<String?>(null)

--- a/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -14,6 +14,7 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -254,7 +255,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
         // endregion Stale AemImports Refresh
 
         // region Cleanup
-        @OptIn(ObsoleteCoroutinesApi::class)
+        @OptIn(DelicateCoroutinesApi::class, ObsoleteCoroutinesApi::class)
         private val cleanupActor = coroutineScope.actor<Unit>(capacity = Channel.CONFLATED) {
             withTimeoutOrNull(CLEANUP_DELAY_INITIAL) { channel.receiveCatching() }
             while (!channel.isClosedForReceive) {

--- a/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/service/AemArticleManager.kt
+++ b/ui/article-aem-renderer/src/main/kotlin/org/cru/godtools/article/aem/service/AemArticleManager.kt
@@ -254,7 +254,7 @@ class AemArticleManager @VisibleForTesting internal constructor(
         // endregion Stale AemImports Refresh
 
         // region Cleanup
-        @OptIn(ExperimentalCoroutinesApi::class, ObsoleteCoroutinesApi::class)
+        @OptIn(ObsoleteCoroutinesApi::class)
         private val cleanupActor = coroutineScope.actor<Unit>(capacity = Channel.CONFLATED) {
             withTimeoutOrNull(CLEANUP_DELAY_INITIAL) { channel.receiveCatching() }
             while (!channel.isClosedForReceive) {

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryIT.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryIT.kt
@@ -2,7 +2,6 @@ package org.cru.godtools.article.aem.db
 
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
@@ -15,7 +14,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class AemImportRepositoryIT {
     private val testScope = TestScope()
 

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryTest.kt
@@ -7,13 +7,11 @@ import io.mockk.coVerifySequence
 import io.mockk.just
 import io.mockk.mockk
 import java.util.Date
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.base.TimeConstants.WEEK_IN_MS
 import org.cru.godtools.article.aem.model.AemImport
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AemImportRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : AemImportRepository(db) {}
 

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/ArticleRepositoryTest.kt
@@ -6,12 +6,10 @@ import io.mockk.coVerifyAll
 import io.mockk.just
 import io.mockk.mockk
 import java.util.UUID
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.article.aem.model.Article
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ArticleRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : ArticleRepository(db) {}
 

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryTest.kt
@@ -8,7 +8,6 @@ import io.mockk.coVerifySequence
 import io.mockk.just
 import io.mockk.verify
 import java.util.Locale
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.article.aem.model.TranslationRef
 import org.cru.godtools.article.aem.model.toTranslationRefKey
@@ -21,7 +20,6 @@ private const val TOOL = "kgp"
 private val LOCALE = Locale.ENGLISH
 private const val VERSION = 1
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class TranslationRepositoryTest : AbstractArticleRoomDatabaseTest() {
     private val repo = object : TranslationRepository(db) {}
     private val translation = Translation().apply {

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/service/AemArticleManagerFileManagerTest.kt
@@ -15,7 +15,6 @@ import java.io.File
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import kotlin.io.path.createTempDirectory
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.cru.godtools.article.aem.db.ResourceDao
@@ -30,7 +29,6 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class AemArticleManagerFileManagerTest {
     private val testDir = createTempDirectory().toFile()
 

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/service/AemArticleManagerTest.kt
@@ -9,7 +9,6 @@ import io.mockk.coVerifyAll
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -27,7 +26,6 @@ import org.junit.runner.RunWith
 import retrofit2.Response
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class AemArticleManagerTest {
     private val resourceDao = mockk<ResourceDao> {
         coEvery { find(any()) } returns null

--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/analytics/model/ContentAnalyticsEventAnalyticsActionEvent.kt
@@ -8,7 +8,7 @@ import org.cru.godtools.analytics.model.AnalyticsSystem
 import org.cru.godtools.shared.tool.parser.model.AnalyticsEvent
 
 class ContentAnalyticsEventAnalyticsActionEvent(@get:VisibleForTesting val event: AnalyticsEvent) :
-    AnalyticsActionEvent(action = event.action.orEmpty(), locale = event.manifest.locale) {
+    AnalyticsActionEvent(action = event.action, locale = event.manifest.locale) {
     override fun isForSystem(system: AnalyticsSystem) = when (system) {
         AnalyticsSystem.FACEBOOK -> event.isForSystem(AnalyticsEvent.System.FACEBOOK)
         AnalyticsSystem.FIREBASE ->
@@ -20,7 +20,7 @@ class ContentAnalyticsEventAnalyticsActionEvent(@get:VisibleForTesting val event
 
     override val firebaseEventName get() = when {
         event.isForSystem(AnalyticsEvent.System.FIREBASE) -> super.firebaseEventName
-        event.isForSystem(AnalyticsEvent.System.ADOBE) -> event.action?.sanitizeAdobeNameForFirebase().orEmpty()
+        event.isForSystem(AnalyticsEvent.System.ADOBE) -> event.action.sanitizeAdobeNameForFirebase()
         else -> super.firebaseEventName
     }
 

--- a/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/service/ManifestManagerTest.kt
+++ b/ui/base-tool/src/test/kotlin/org/cru/godtools/base/tool/service/ManifestManagerTest.kt
@@ -5,7 +5,6 @@ import io.mockk.coVerify
 import io.mockk.coVerifyAll
 import io.mockk.confirmVerified
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.cru.godtools.db.repository.TranslationsRepository
 import org.cru.godtools.model.Translation
@@ -18,7 +17,6 @@ import org.junit.Test
 
 private const val MANIFEST_NAME = "manifest.xml"
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class ManifestManagerTest {
     private val parser: ManifestParser = mockk()
     private val translationsRepository: TranslationsRepository = mockk(relaxUnitFun = true)

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/theme/GodToolsTheme.kt
@@ -96,7 +96,7 @@ fun GodToolsTheme(content: @Composable () -> Unit) {
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-val GodToolsAppBarColors @Composable get() = TopAppBarDefaults.smallTopAppBarColors(
+val GodToolsAppBarColors @Composable get() = TopAppBarDefaults.topAppBarColors(
     containerColor = MaterialTheme.colorScheme.primary,
     scrolledContainerColor = MaterialTheme.colorScheme.primary,
     navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
@@ -116,7 +116,7 @@ private inline fun TutorialAppBar(
             }
         }
     },
-    colors = TopAppBarDefaults.smallTopAppBarColors(
+    colors = TopAppBarDefaults.topAppBarColors(
         navigationIconContentColor = MaterialTheme.colorScheme.primary,
         actionIconContentColor = MaterialTheme.colorScheme.primary
     ),

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
-import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.rememberPagerState
@@ -40,7 +39,6 @@ import org.cru.godtools.tutorial.R
 import org.cru.godtools.tutorial.analytics.model.TutorialAnalyticsScreenEvent
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalPagerApi::class)
 internal fun TutorialLayout(
     pageSet: PageSet,
     onTutorialAction: (Action) -> Unit = {},

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/onboarding/TutorialOnboardingLinksLayout.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/onboarding/TutorialOnboardingLinksLayout.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -19,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -93,7 +91,6 @@ internal fun TutorialOnboardingLinksLayout(
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalTextApi::class)
 private fun LinkBox(
     description: String,
     action: String,

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/theme/GodToolsTutorialTheme.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/theme/GodToolsTutorialTheme.kt
@@ -2,12 +2,10 @@ package org.cru.godtools.tutorial.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.style.LineBreak
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 
 @Composable
-@OptIn(ExperimentalTextApi::class)
 internal fun GodToolsTutorialTheme(content: @Composable () -> Unit) = GodToolsTheme {
     val typography = MaterialTheme.typography
     MaterialTheme(


### PR DESCRIPTION
- event.action is now non-null
- replace deprecated smallTopAppBarColors with topAppBarColors
- remove a bunch of no longer necessary OptIn annotations
- OptIn to the delicate isClosedForReceive val
- LocalMinimumTouchTargetEnforcement has been renamed to LocalMinimumInteractiveComponentEnforcement
- suppress BlockingMethodInNonBlockingContext on the statement instead of the entire method
- remove unnecessary suppression
- make the Modifier the first optional parameter
