### PR TITLE
GT-2046 GT-2057 Fix proguard rules for AGP 8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,7 @@ android {
         proguardFile("proguard-rules-eventbus.pro")
         proguardFile("proguard-rules-firebase-inappmessaging.pro")
         proguardFile("proguard-rules-guava.pro")
+        proguardFile("proguard-rules-retrofit2.pro")
         proguardFile("proguard-searchview.pro")
 
         vectorDrawables.useSupportLibrary = true

--- a/app/proguard-rules-retrofit2.pro
+++ b/app/proguard-rules-retrofit2.pro
@@ -1,0 +1,51 @@
+### Rules not in a release yet
+### copied from https://github.com/square/retrofit/blob/dcc890bc1e13895309c83bb7ca448cc885c41d6b/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro
+
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep inherited services.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# R8 full mode strips generic signatures from return types if not kept.
+-keep,allowobfuscation,allowshrinking class retrofit2.Response

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,9 +2,6 @@
 # see: https://issuetracker.google.com/issues/133167042
 -dontobfuscate
 
-
--optimizationpasses 10
-
 # Strip built-in logging
 -assumenosideeffects class android.util.Log {
     public static boolean isLoggable(java.lang.String, int);


### PR DESCRIPTION
- add missing retrofit Proguard rules
- the optimizationpasses directive does nothing in R8
