### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           cache-read-only: false
 #          cache-read-only: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/heads/feature/') }}
-          arguments: test koverXmlReportDebug koverXmlReportProductionDebug --scan
+          arguments: test koverXmlReportDebug koverXmlReportProductionDebug --max-workers 1 --scan
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,6 @@ dependencyResolutionManagement {
         jcenter {
             content {
                 includeModule("com.duolingo.open", "rtl-viewpager")
-                includeModule("com.sergivonavi", "materialbanner")
             }
         }
     }


### PR DESCRIPTION
- we no longer use the materialbanner library
- use a single worker to help with GHA memory usage for unit tests
