### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsActivity.kt
@@ -5,12 +5,10 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import dagger.hilt.android.AndroidEntryPoint
-import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.base.Settings.Companion.FEATURE_LANGUAGE_SETTINGS
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.base.ui.startAppLanguageActivity
 import org.cru.godtools.base.ui.theme.GodToolsTheme
-import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.drawer.DrawerMenuLayout
 import org.cru.godtools.ui.languages.downloadable.startDownloadableLanguagesActivity
 
@@ -46,7 +44,6 @@ class LanguageSettingsActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
         settings.setFeatureDiscovered(FEATURE_LANGUAGE_SETTINGS)
-        eventBus.post(AnalyticsScreenEvent(AnalyticsScreenNames.SETTINGS_LANGUAGES))
     }
     // endregion Lifecycle
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
@@ -35,8 +35,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.cru.godtools.R
+import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
+import org.cru.godtools.analytics.model.AnalyticsScreenEvent
 import org.cru.godtools.base.ui.theme.GodToolsAppBarColors
 import org.cru.godtools.base.ui.theme.GodToolsTheme
+import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 
 internal sealed interface LanguageSettingsEvent {
     object NavigateUp : LanguageSettingsEvent
@@ -54,6 +57,8 @@ internal fun LanguageSettingsLayout(
     viewModel: LanguageSettingsViewModel = viewModel(),
     onEvent: (LanguageSettingsEvent) -> Unit = {},
 ) {
+    RecordAnalyticsScreen(AnalyticsScreenEvent(AnalyticsScreenNames.SETTINGS_LANGUAGES))
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/res/layout/compose_layout.xml
+++ b/app/src/main/res/layout/compose_layout.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/compose"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/util/ModelUtils.kt
@@ -3,12 +3,16 @@
 package org.cru.godtools.base.ui.util
 
 import android.content.Context
+import android.content.res.Resources
 import android.os.Build
 import androidx.annotation.DeprecatedSinceApi
 import java.util.Locale
 import org.ccci.gto.android.common.util.content.localizeIfPossible
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
+import org.cru.godtools.ui.BuildConfig
+import org.cru.godtools.ui.R
+import timber.log.Timber
 
 @JvmName("getTranslationName")
 fun Translation?.getName(tool: Tool?, context: Context?) =
@@ -33,10 +37,20 @@ fun Tool?.getCategory(context: Context, locale: Locale? = null) = getToolCategor
 fun getToolCategoryName(category: String?, context: Context, locale: Locale? = null) =
     category?.let { c -> context.localizeIfPossible(locale).getToolCategoryStringRes(c) ?: c }.orEmpty()
 
-private const val STRING_RES_CATEGORY_NAME_PREFIX = "tool_category_"
 private fun Context.getToolCategoryStringRes(category: String) =
-    when (val id = resources.getIdentifier("$STRING_RES_CATEGORY_NAME_PREFIX$category", "string", packageName)) {
-        0 -> null
-        else -> resources.getString(id)
+    when (category.lowercase(Locale.ROOT)) {
+        "gospel" -> getString(R.string.tool_category_gospel)
+        "articles" -> getString(R.string.tool_category_articles)
+        "conversation_starter" -> getString(R.string.tool_category_conversation_starter)
+        "growth" -> getString(R.string.tool_category_growth)
+        "training" -> getString(R.string.tool_category_training)
+        else -> {
+            val e = Resources.NotFoundException("tool_category_$category was not found")
+            when {
+                BuildConfig.DEBUG -> throw e
+                else -> Timber.tag("ToolCategory").e(e, "Missing Tool Category string: $category")
+            }
+            null
+        }
     }
 // endregion Tool Category

--- a/ui/base/src/test/kotlin/org/cru/godtools/base/ui/util/ModelUtilsRobolectricTest.kt
+++ b/ui/base/src/test/kotlin/org/cru/godtools/base/ui/util/ModelUtilsRobolectricTest.kt
@@ -1,45 +1,63 @@
 package org.cru.godtools.base.ui.util
 
-import android.app.Activity
 import android.content.Context
+import android.content.res.Resources
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.Locale
 import org.cru.godtools.model.Tool
+import org.cru.godtools.ui.BuildConfig
+import org.cru.godtools.ui.R
 import org.junit.Assert.assertEquals
-import org.junit.Before
+import org.junit.Assume.assumeFalse
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class ModelUtilsRobolectricTest {
-    private lateinit var context: Context
-    private val tool = Tool().apply {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val tool = Tool("tool") {
         category = "gospel"
     }
     private val toolNull: Tool? = null
 
-    @Before
-    fun setup() {
-        context = Robolectric.buildActivity(Activity::class.java).get()
-    }
-
     @Test
-    fun testToolGetCategoryNullTool() {
+    fun `getCategory() - Null Tool`() {
         assertEquals("", toolNull.getCategory(context, null))
         assertEquals("", toolNull.getCategory(context, Locale.FRENCH))
     }
 
     @Test
-    fun testToolGetCategoryValidCategory() {
+    fun `getCategory() - Valid Category`() {
         assertEquals("Gospel Invitation", tool.getCategory(context, null))
         assertEquals("Invitation à Évangile", tool.getCategory(context, Locale.FRENCH))
     }
 
+    @Test(expected = Resources.NotFoundException::class)
+    fun `getCategory(unknown) - Debug`() {
+        assumeTrue(BuildConfig.DEBUG)
+        tool.category = "unknown"
+        tool.getCategory(context)
+    }
+
     @Test
-    fun testToolGetCategoryUnknownCategory() {
+    fun `getCategory(unknown) - Release`() {
+        assumeFalse(BuildConfig.DEBUG)
         tool.category = "unknown"
         assertEquals("unknown", tool.getCategory(context, null))
         assertEquals("unknown", tool.getCategory(context, Locale.FRENCH))
+    }
+
+    @Test
+    fun `getToolCategoryName()`() {
+        assertEquals(context.getString(R.string.tool_category_gospel), getToolCategoryName("gospel", context))
+        assertEquals(context.getString(R.string.tool_category_articles), getToolCategoryName("articles", context))
+        assertEquals(
+            context.getString(R.string.tool_category_conversation_starter),
+            getToolCategoryName("conversation_starter", context)
+        )
+        assertEquals(context.getString(R.string.tool_category_growth), getToolCategoryName("growth", context))
+        assertEquals(context.getString(R.string.tool_category_training), getToolCategoryName("training", context))
     }
 }

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -231,7 +231,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
         // generate the list of locales to use for this tool
         val locales = buildList {
             val translation = translationsRepository.findLatestTranslation(code, settings.primaryLanguage)
-                ?: translationsRepository.findLatestTranslation(code, Locale.ENGLISH)
+                ?: translationsRepository.findLatestTranslation(code, Settings.defaultLanguage)
                 ?: return@withContext null
             add(translation.languageCode)
             settings.parallelLanguage?.let { add(it) }


### PR DESCRIPTION
- record the Language Settings analytics event from the compose layout
- avoid using `resources.getIdentifier()` when displaying the tool category name
- remove unused layout
- use the defaultLanguage property instead of hard-coding this to Locale.ENGLISH
