### PR TITLE
Workaround flakiness in SSL certificate validation for S3

### DIFF
--- a/build-logic/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/DownloadApiResourcesTask.kt
+++ b/build-logic/src/main/kotlin/org/cru/godtools/gradle/bundledcontent/DownloadApiResourcesTask.kt
@@ -39,6 +39,9 @@ abstract class DownloadApiResourcesTask : DefaultTask() {
                 overwrite(false)
                 retries(2)
                 tempAndMove(true)
+                // HACK: disable SSL certificate validation to workaround flaky SSLPeerUnverifiedException for s3
+                //       see: https://github.com/michel-kraemer/gradle-download-task/issues/317#issuecomment-1635088067
+                acceptAnyCertificate(true)
             }.execute(true)
         }.forEach { it.get() }
     }


### PR DESCRIPTION
This is being caused by an outdated Public Suffix List occassionaly being loaded from the wrong jar file instead of the correct more up to date one
