### PR TITLE
GT-1991 Switch to an event object for callbacks on the Dashboard

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardActivity.kt
@@ -35,8 +35,15 @@ class DashboardActivity : BaseActivity() {
         setContent {
             GodToolsTheme {
                 DashboardLayout(
-                    onOpenTool = { t, lang1, lang2 -> openTool(t, *listOfNotNull(lang1, lang2).toTypedArray()) },
-                    onOpenToolDetails = { startToolDetailsActivity(it) }
+                    onEvent = {
+                        when (it) {
+                            is DashboardEvent.OpenTool ->
+                                openTool(it.tool, *listOfNotNull(it.lang1, it.lang2).toTypedArray())
+                            is DashboardEvent.OpenToolDetails -> {
+                                it.tool?.code?.let { startToolDetailsActivity(it) }
+                            }
+                        }
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -50,6 +50,7 @@ import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.model.Tool
 import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.dashboard.home.AllFavoritesList
+import org.cru.godtools.ui.dashboard.home.DashboardHomeEvent
 import org.cru.godtools.ui.dashboard.home.HomeContent
 import org.cru.godtools.ui.dashboard.lessons.LessonsLayout
 import org.cru.godtools.ui.dashboard.tools.ToolsLayout
@@ -114,13 +115,18 @@ internal fun DashboardLayout(
                             )
 
                             Page.HOME -> HomeContent(
-                                onOpenTool = onOpenTool,
-                                onOpenToolDetails = onOpenToolDetails,
-                                onViewAllFavorites = {
-                                    saveableStateHolder.removeState(Page.FAVORITE_TOOLS)
-                                    viewModel.updateCurrentPage(Page.FAVORITE_TOOLS, false)
-                                },
-                                onViewAllTools = { viewModel.updateCurrentPage(Page.ALL_TOOLS) },
+                                onEvent = {
+                                    when (it) {
+                                        is DashboardHomeEvent.OpenTool -> onOpenTool(it.tool, it.lang1, it.lang2)
+                                        is DashboardHomeEvent.OpenToolDetails ->
+                                            it.tool?.code?.let { onOpenToolDetails(it) }
+                                        DashboardHomeEvent.ViewAllFavorites -> {
+                                            saveableStateHolder.removeState(Page.FAVORITE_TOOLS)
+                                            viewModel.updateCurrentPage(Page.FAVORITE_TOOLS, false)
+                                        }
+                                        DashboardHomeEvent.ViewAllTools -> viewModel.updateCurrentPage(Page.ALL_TOOLS)
+                                    }
+                                }
                             )
 
                             Page.FAVORITE_TOOLS -> AllFavoritesList(

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -52,6 +52,7 @@ import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 import org.cru.godtools.ui.dashboard.home.AllFavoritesList
 import org.cru.godtools.ui.dashboard.home.DashboardHomeEvent
 import org.cru.godtools.ui.dashboard.home.HomeContent
+import org.cru.godtools.ui.dashboard.lessons.DashboardLessonsEvent
 import org.cru.godtools.ui.dashboard.lessons.LessonsLayout
 import org.cru.godtools.ui.dashboard.tools.ToolsLayout
 import org.cru.godtools.ui.drawer.DrawerMenuLayout
@@ -105,13 +106,11 @@ internal fun DashboardLayout(
                     saveableStateHolder.SaveableStateProvider(page) {
                         when (page) {
                             Page.LESSONS -> LessonsLayout(
-                                onOpenLesson = { tool, translation ->
-                                    onOpenTool(
-                                        tool,
-                                        translation?.languageCode,
-                                        null
-                                    )
-                                }
+                                onEvent = {
+                                    when (it) {
+                                        is DashboardLessonsEvent.OpenLesson -> onOpenTool(it.tool, it.lang, null)
+                                    }
+                                },
                             )
 
                             Page.HOME -> HomeContent(

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -56,6 +56,7 @@ import org.cru.godtools.ui.dashboard.lessons.DashboardLessonsEvent
 import org.cru.godtools.ui.dashboard.lessons.LessonsLayout
 import org.cru.godtools.ui.dashboard.tools.ToolsLayout
 import org.cru.godtools.ui.drawer.DrawerMenuLayout
+import org.cru.godtools.ui.tools.ToolCardEvent
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
@@ -129,8 +130,13 @@ internal fun DashboardLayout(
                             )
 
                             Page.FAVORITE_TOOLS -> AllFavoritesList(
-                                onOpenTool = onOpenTool,
-                                onOpenToolDetails = onOpenToolDetails
+                                onEvent = {
+                                    when(it) {
+                                        is ToolCardEvent.OpenTool,
+                                        is ToolCardEvent.Click -> onOpenTool(it.tool, it.lang1, it.lang2)
+                                        is ToolCardEvent.OpenToolDetails -> it.tool?.code?.let(onOpenToolDetails)
+                                    }
+                                },
                             )
 
                             Page.ALL_TOOLS -> ToolsLayout(

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
@@ -19,17 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import java.util.Locale
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.rememberReorderableLazyListState
 import org.burnoutcrew.reorderable.reorderable
 import org.cru.godtools.R
-import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_FAVORITE
-import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
@@ -1,0 +1,120 @@
+package org.cru.godtools.ui.dashboard.home
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import java.util.Locale
+import org.burnoutcrew.reorderable.ReorderableItem
+import org.burnoutcrew.reorderable.detectReorderAfterLongPress
+import org.burnoutcrew.reorderable.rememberReorderableLazyListState
+import org.burnoutcrew.reorderable.reorderable
+import org.cru.godtools.R
+import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent
+import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
+import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
+import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_FAVORITE
+import org.cru.godtools.model.Tool
+import org.cru.godtools.ui.tools.PreloadTool
+import org.cru.godtools.ui.tools.ToolCard
+import org.cru.godtools.ui.tools.ToolCardEvent
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+internal fun AllFavoritesList(
+    onEvent: (ToolCardEvent) -> Unit,
+    viewModel: HomeViewModel = viewModel(),
+) {
+    val favoriteTools by viewModel.reorderableFavoriteTools.collectAsState()
+
+    val reorderableState = rememberReorderableLazyListState(
+        // only support reordering tool items
+        canDragOver = { (_, k), _ -> (k as? String)?.startsWith("tool:") == true },
+        onMove = { from, to ->
+            val fromPos = favoriteTools.indexOfFirst { it.code == (from.key as? String)?.removePrefix("tool:") }
+            val toPos = favoriteTools.indexOfFirst { it.code == (to.key as? String)?.removePrefix("tool:") }
+            if (fromPos != -1 && toPos != -1) viewModel.moveFavoriteTool(fromPos, toPos)
+        },
+        onDragEnd = { _, _ -> viewModel.commitFavoriteToolOrder() }
+    )
+
+    LazyColumn(
+        contentPadding = PaddingValues(16.dp),
+        state = reorderableState.listState,
+        modifier = Modifier
+            .reorderable(reorderableState)
+            .detectReorderAfterLongPress(reorderableState)
+    ) {
+        item("header", "header") {
+            Text(
+                stringResource(R.string.dashboard_home_section_favorites_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateItemPlacement()
+            )
+        }
+
+        items(favoriteTools, key = { "tool:${it.code}" }) { tool ->
+            ReorderableItem(reorderableState, "tool:${tool.code}") { isDragging ->
+                val interactionSource = remember { MutableInteractionSource() }
+                interactionSource.reorderableDragInteractions(isDragging)
+
+                PreloadTool(tool)
+                ToolCard(
+                    toolCode = tool.code.orEmpty(),
+                    confirmRemovalFromFavorites = true,
+                    interactionSource = interactionSource,
+                    onEvent = {
+                        when (it) {
+                            is ToolCardEvent.Click,
+                            is ToolCardEvent.OpenTool -> viewModel.recordOpenClickInAnalytics(
+                                ACTION_OPEN_TOOL,
+                                it.tool?.code,
+                                SOURCE_FAVORITE
+                            )
+                            is ToolCardEvent.OpenToolDetails -> viewModel.recordOpenClickInAnalytics(
+                                ACTION_OPEN_TOOL_DETAILS,
+                                it.tool?.code,
+                                SOURCE_FAVORITE
+                            )
+                        }
+                        onEvent(it)
+                    },
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MutableInteractionSource.reorderableDragInteractions(isDragging: Boolean) {
+    val dragState = remember { object { var start: DragInteraction.Start? = null } }
+    LaunchedEffect(isDragging) {
+        when (val start = dragState.start) {
+            null -> if (isDragging) dragState.start = DragInteraction.Start().also { emit(it) }
+            else -> if (!isDragging) {
+                dragState.start = null
+                emit(DragInteraction.Stop(start))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.DragInteraction
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -37,10 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import java.util.Locale
-import org.burnoutcrew.reorderable.ReorderableItem
-import org.burnoutcrew.reorderable.detectReorderAfterLongPress
-import org.burnoutcrew.reorderable.rememberReorderableLazyListState
-import org.burnoutcrew.reorderable.reorderable
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.R
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_LESSON
@@ -53,7 +47,6 @@ import org.cru.godtools.ui.banner.Banners
 import org.cru.godtools.ui.tools.LessonToolCard
 import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.SquareToolCard
-import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent
 
 private val PADDING_HORIZONTAL = 16.dp
@@ -291,90 +284,6 @@ private fun NoFavoriteTools(
                 .align(Alignment.CenterHorizontally)
         ) {
             Text(stringResource(R.string.dashboard_home_section_favorites_action_all_tools))
-        }
-    }
-}
-
-@Composable
-@OptIn(ExperimentalFoundationApi::class)
-internal fun AllFavoritesList(
-    viewModel: HomeViewModel = viewModel(),
-    onOpenTool: (Tool?, Locale?, Locale?) -> Unit,
-    onOpenToolDetails: (String) -> Unit,
-) {
-    val favoriteTools by viewModel.reorderableFavoriteTools.collectAsState()
-
-    val reorderableState = rememberReorderableLazyListState(
-        // only support reordering tool items
-        canDragOver = { (_, k), _ -> (k as? String)?.startsWith("tool:") == true },
-        onMove = { from, to ->
-            val fromPos = favoriteTools.indexOfFirst { it.code == (from.key as? String)?.removePrefix("tool:") }
-            val toPos = favoriteTools.indexOfFirst { it.code == (to.key as? String)?.removePrefix("tool:") }
-            if (fromPos != -1 && toPos != -1) viewModel.moveFavoriteTool(fromPos, toPos)
-        },
-        onDragEnd = { _, _ -> viewModel.commitFavoriteToolOrder() }
-    )
-
-    LazyColumn(
-        contentPadding = PaddingValues(16.dp),
-        state = reorderableState.listState,
-        modifier = Modifier
-            .reorderable(reorderableState)
-            .detectReorderAfterLongPress(reorderableState)
-    ) {
-        item("header", "header") {
-            Text(
-                stringResource(R.string.dashboard_home_section_favorites_title),
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .animateItemPlacement()
-            )
-        }
-
-        items(favoriteTools, key = { "tool:${it.code}" }) { tool ->
-            ReorderableItem(reorderableState, "tool:${tool.code}") { isDragging ->
-                val interactionSource = remember { MutableInteractionSource() }
-                interactionSource.reorderableDragInteractions(isDragging)
-
-                PreloadTool(tool)
-                ToolCard(
-                    toolCode = tool.code.orEmpty(),
-                    confirmRemovalFromFavorites = true,
-                    interactionSource = interactionSource,
-                    onEvent = {
-                        when (it) {
-                            is ToolCardEvent.Click, is ToolCardEvent.OpenTool -> {
-                                viewModel.recordOpenClickInAnalytics(ACTION_OPEN_TOOL, it.tool?.code, SOURCE_FAVORITE)
-                                onOpenTool(it.tool, it.lang1, it.lang2)
-                            }
-                            is ToolCardEvent.OpenToolDetails -> {
-                                it.tool?.code?.let {
-                                    viewModel.recordOpenClickInAnalytics(ACTION_OPEN_TOOL_DETAILS, it, SOURCE_FAVORITE)
-                                    onOpenToolDetails(it)
-                                }
-                            }
-                        }
-                    },
-                    modifier = Modifier
-                        .padding(top = 16.dp)
-                        .fillMaxWidth()
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun MutableInteractionSource.reorderableDragInteractions(isDragging: Boolean) {
-    val dragState = remember { object { var start: DragInteraction.Start? = null } }
-    LaunchedEffect(isDragging) {
-        when (val start = dragState.start) {
-            null -> if (isDragging) dragState.start = DragInteraction.Start().also { emit(it) }
-            else -> if (!isDragging) {
-                dragState.start = null
-                emit(DragInteraction.Stop(start))
-            }
         }
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.util.Locale
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.R
 import org.cru.godtools.model.Tool
@@ -23,11 +24,15 @@ import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.tools.LessonToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent
 
+internal sealed interface DashboardLessonsEvent {
+    class OpenLesson(val tool: Tool?, val lang: Locale?) : DashboardLessonsEvent
+}
+
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
-fun LessonsLayout(
+internal fun LessonsLayout(
     viewModel: LessonsViewModel = viewModel(),
-    onOpenLesson: (Tool?, Translation?) -> Unit = { _, _ -> },
+    onEvent: (DashboardLessonsEvent) -> Unit = {},
 ) {
     val lessons by viewModel.lessons.collectAsState()
     LazyColumn(contentPadding = PaddingValues(16.dp)) {
@@ -38,11 +43,10 @@ fun LessonsLayout(
                 lesson,
                 onEvent = {
                     when (it) {
-                        is ToolCardEvent.Click -> {
+                        is ToolCardEvent.OpenTool, is ToolCardEvent.Click -> {
                             viewModel.recordOpenLessonInAnalytics(it.tool?.code)
-                            onOpenLesson(it.tool, it.translation1)
+                            onEvent(DashboardLessonsEvent.OpenLesson(it.tool, it.lang1))
                         }
-                        is ToolCardEvent.OpenTool -> TODO()
                         is ToolCardEvent.OpenToolDetails -> {
                             if (BuildConfig.DEBUG) error("$it is currently unsupported for Lessons")
                         }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -20,7 +20,6 @@ import java.util.Locale
 import org.cru.godtools.BuildConfig
 import org.cru.godtools.R
 import org.cru.godtools.model.Tool
-import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.tools.LessonToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import org.cru.godtools.BuildConfig
 import org.cru.godtools.R
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.ui.tools.LessonToolCard
+import org.cru.godtools.ui.tools.ToolCardEvent
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
@@ -31,12 +33,20 @@ fun LessonsLayout(
     LazyColumn(contentPadding = PaddingValues(16.dp)) {
         item("header", "header") { LessonsHeader() }
 
-        items(lessons, { it }, { "lesson" }) {
+        items(lessons, { it }, { "lesson" }) { lesson ->
             LessonToolCard(
-                it,
-                onClick = { tool, translation ->
-                    viewModel.recordOpenLessonInAnalytics(tool?.code)
-                    onOpenLesson(tool, translation)
+                lesson,
+                onEvent = {
+                    when (it) {
+                        is ToolCardEvent.Click -> {
+                            viewModel.recordOpenLessonInAnalytics(it.tool?.code)
+                            onOpenLesson(it.tool, it.translation1)
+                        }
+                        is ToolCardEvent.OpenTool -> TODO()
+                        is ToolCardEvent.OpenToolDetails -> {
+                            if (BuildConfig.DEBUG) error("$it is currently unsupported for Lessons")
+                        }
+                    }
                 },
                 modifier = Modifier
                     .animateItemPlacement()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -36,8 +36,8 @@ internal val MARGIN_TOOLS_LAYOUT_HORIZONTAL = 16.dp
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
 internal fun ToolsLayout(
+    onEvent: (ToolCardEvent) -> Unit,
     viewModel: ToolsViewModel = viewModel(),
-    onToolClicked: (String) -> Unit = {}
 ) {
     val banner by viewModel.banner.collectAsState()
     val spotlightTools by viewModel.spotlightTools.collectAsState()
@@ -61,7 +61,7 @@ internal fun ToolsLayout(
             item("tool-spotlight", "tool-spotlight") {
                 ToolSpotlight(
                     viewModel,
-                    onToolClicked = onToolClicked,
+                    onEvent = onEvent,
                     modifier = Modifier
                         .animateItemPlacement()
                         .padding(top = 16.dp)
@@ -92,11 +92,12 @@ internal fun ToolsLayout(
                 showActions = false,
                 onEvent = {
                     when (it) {
-                        is ToolCardEvent.Click, is ToolCardEvent.OpenTool, is ToolCardEvent.OpenToolDetails -> {
+                        is ToolCardEvent.Click,
+                        is ToolCardEvent.OpenTool,
+                        is ToolCardEvent.OpenToolDetails ->
                             viewModel.recordOpenToolDetailsInAnalytics(it.tool?.code, SOURCE_ALL_TOOLS)
-                            it.tool?.code?.let(onToolClicked)
-                        }
                     }
+                    onEvent(it)
                 },
                 modifier = Modifier
                     .animateItemPlacement()
@@ -109,8 +110,8 @@ internal fun ToolsLayout(
 @Composable
 internal fun ToolSpotlight(
     viewModel: ToolsViewModel,
+    onEvent: (ToolCardEvent) -> Unit,
     modifier: Modifier = Modifier,
-    onToolClicked: (String) -> Unit = {}
 ) = Column(modifier = modifier.fillMaxWidth()) {
     val spotlightTools by viewModel.spotlightTools.collectAsState()
 
@@ -145,11 +146,12 @@ internal fun ToolSpotlight(
                 confirmRemovalFromFavorites = false,
                 onEvent = {
                     when (it) {
-                        is ToolCardEvent.Click, is ToolCardEvent.OpenTool, is ToolCardEvent.OpenToolDetails -> {
+                        is ToolCardEvent.Click,
+                        is ToolCardEvent.OpenTool,
+                        is ToolCardEvent.OpenToolDetails ->
                             viewModel.recordOpenToolDetailsInAnalytics(it.tool?.code, SOURCE_SPOTLIGHT)
-                            it.tool?.code?.let(onToolClicked)
-                        }
                     }
+                    onEvent(it)
                 },
             )
         }

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -29,6 +29,7 @@ import org.cru.godtools.ui.banner.Banners
 import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.SquareToolCard
 import org.cru.godtools.ui.tools.ToolCard
+import org.cru.godtools.ui.tools.ToolCardEvent
 
 internal val MARGIN_TOOLS_LAYOUT_HORIZONTAL = 16.dp
 
@@ -89,9 +90,13 @@ internal fun ToolsLayout(
                 tool.code.orEmpty(),
                 additionalLanguage = selectedLanguage,
                 showActions = false,
-                onClick = { it, _, _ ->
-                    viewModel.recordOpenToolDetailsInAnalytics(it?.code, SOURCE_ALL_TOOLS)
-                    it?.code?.let(onToolClicked)
+                onEvent = {
+                    when (it) {
+                        is ToolCardEvent.Click, is ToolCardEvent.OpenTool, is ToolCardEvent.OpenToolDetails -> {
+                            viewModel.recordOpenToolDetailsInAnalytics(it.tool?.code, SOURCE_ALL_TOOLS)
+                            it.tool?.code?.let(onToolClicked)
+                        }
+                    }
                 },
                 modifier = Modifier
                     .animateItemPlacement()
@@ -138,10 +143,14 @@ internal fun ToolSpotlight(
                 showActions = false,
                 floatParallelLanguageUp = false,
                 confirmRemovalFromFavorites = false,
-                onClick = { tool, _, _ ->
-                    viewModel.recordOpenToolDetailsInAnalytics(tool?.code, SOURCE_SPOTLIGHT)
-                    tool?.code?.let(onToolClicked)
-                }
+                onEvent = {
+                    when (it) {
+                        is ToolCardEvent.Click, is ToolCardEvent.OpenTool, is ToolCardEvent.OpenToolDetails -> {
+                            viewModel.recordOpenToolDetailsInAnalytics(it.tool?.code, SOURCE_SPOTLIGHT)
+                            it.tool?.code?.let(onToolClicked)
+                        }
+                    }
+                },
             )
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -58,6 +58,7 @@ import org.cru.godtools.model.getName
 import org.cru.godtools.ui.tooldetails.analytics.model.ToolDetailsScreenEvent
 import org.cru.godtools.ui.tools.DownloadProgressIndicator
 import org.cru.godtools.ui.tools.PreloadTool
+import org.cru.godtools.ui.tools.ToolCardEvent
 import org.cru.godtools.ui.tools.ToolViewModels
 import org.cru.godtools.ui.tools.VariantToolCard
 
@@ -277,7 +278,12 @@ private fun ToolDetailsVariants(
             VariantToolCard(
                 code,
                 isSelected = currentTool == code,
-                onClick = { onVariantSelected(code) }
+                onEvent = {
+                    when (it) {
+                        is ToolCardEvent.OpenToolDetails, is ToolCardEvent.Click -> onVariantSelected(code)
+                        is ToolCardEvent.OpenTool -> error("OpenTool is not supported")
+                    }
+                },
             )
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardActions.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardActions.kt
@@ -18,9 +18,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import java.util.Locale
 import org.cru.godtools.R
-import org.cru.godtools.model.Tool
+import org.cru.godtools.ui.tools.ToolCardEvent.OpenTool as OpenToolEvent
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -29,8 +28,7 @@ internal fun ToolCardActions(
     modifier: Modifier = Modifier,
     buttonModifier: Modifier = Modifier,
     buttonWeightFill: Boolean = true,
-    onOpenTool: (Tool?, Locale?, Locale?) -> Unit = { _, _, _ -> },
-    onOpenToolDetails: (String) -> Unit = {},
+    onEvent: (ToolCardEvent) -> Unit = {},
 ) = Row(modifier = modifier) {
     val tool by viewModel.tool.collectAsState()
     val firstTranslation by viewModel.firstTranslation.collectAsState()
@@ -41,7 +39,7 @@ internal fun ToolCardActions(
 
     CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
         OutlinedButton(
-            onClick = { onOpenToolDetails(viewModel.code) },
+            onClick = { onEvent(ToolCardEvent.OpenToolDetails(tool)) },
             contentPadding = buttonContentPadding,
             modifier = buttonModifier
                 .alignByBaseline()
@@ -55,7 +53,9 @@ internal fun ToolCardActions(
         }
         Spacer(Modifier.width(8.dp))
         Button(
-            onClick = { onOpenTool(tool, firstTranslation.value?.languageCode, secondTranslation?.languageCode) },
+            onClick = {
+                onEvent(OpenToolEvent(tool, firstTranslation.value?.languageCode, secondTranslation?.languageCode))
+            },
             contentPadding = buttonContentPadding,
             modifier = buttonModifier
                 .alignByBaseline()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -88,6 +88,17 @@ private val toolCardInfoLabelColor: Color @Composable get() {
 }
 internal val toolCardInfoLabelStyle @Composable get() = MaterialTheme.typography.labelSmall
 
+sealed class ToolCardEvent(val tool: Tool?, val lang1: Locale?, val lang2: Locale?) {
+    class Click(
+        tool: Tool?,
+        val translation1: Translation? = null,
+        lang1: Locale? = translation1?.languageCode,
+        lang2: Locale? = null,
+    ) : ToolCardEvent(tool, lang1, lang2)
+    class OpenTool(tool: Tool?, lang1: Locale? = null, lang2: Locale? = null) : ToolCardEvent(tool, lang1, lang2)
+    class OpenToolDetails(tool: Tool?) : ToolCardEvent(tool, null, null)
+}
+
 @Composable
 fun PreloadTool(tool: Tool) {
     val code = tool.code ?: return
@@ -99,7 +110,7 @@ fun PreloadTool(tool: Tool) {
 fun LessonToolCard(
     toolCode: String,
     modifier: Modifier = Modifier,
-    onClick: (Tool?, Translation?) -> Unit = { _, _ -> }
+    onEvent: (ToolCardEvent) -> Unit = {},
 ) {
     val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
@@ -108,7 +119,7 @@ fun LessonToolCard(
     ProvideLayoutDirectionFromLocale(locale = { translation.value?.languageCode }) {
         ElevatedCard(
             elevation = toolCardElevation,
-            onClick = { onClick(tool, translation.value) },
+            onClick = { onEvent(ToolCardEvent.Click(tool, translation.value)) },
             modifier = modifier.fillMaxWidth()
         ) {
             ToolBanner(viewModel, modifier = Modifier.aspectRatio(335f / 80f))
@@ -147,9 +158,7 @@ fun ToolCard(
     confirmRemovalFromFavorites: Boolean = false,
     showActions: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    onOpenTool: (Tool?, Locale?, Locale?) -> Unit = { _, _, _ -> },
-    onOpenToolDetails: (String) -> Unit = {},
-    onClick: (Tool?, Locale?, Locale?) -> Unit = onOpenTool
+    onEvent: (ToolCardEvent) -> Unit = {},
 ) {
     val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
@@ -160,7 +169,15 @@ fun ToolCard(
         ElevatedCard(
             elevation = toolCardElevation,
             interactionSource = interactionSource,
-            onClick = { onClick(tool, firstTranslation.value?.languageCode, additionalLanguage?.code) },
+            onClick = {
+                onEvent(
+                    ToolCardEvent.Click(
+                        tool,
+                        lang1 = firstTranslation.value?.languageCode,
+                        lang2 = additionalLanguage?.code,
+                    )
+                )
+            },
             modifier = modifier
         ) {
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -215,8 +232,7 @@ fun ToolCard(
                         viewModel,
                         buttonWeightFill = false,
                         buttonModifier = Modifier.widthIn(min = 92.dp),
-                        onOpenTool = onOpenTool,
-                        onOpenToolDetails = onOpenToolDetails,
+                        onEvent = onEvent,
                         modifier = Modifier
                             .padding(top = 4.dp)
                             .align(Alignment.End)
@@ -236,9 +252,7 @@ fun SquareToolCard(
     showActions: Boolean = true,
     floatParallelLanguageUp: Boolean = true,
     confirmRemovalFromFavorites: Boolean = false,
-    onOpenTool: (Tool?, Locale?, Locale?) -> Unit = { _, _, _ -> },
-    onOpenToolDetails: (String) -> Unit = {},
-    onClick: (Tool?, Locale?, Locale?) -> Unit = onOpenTool
+    onEvent: (ToolCardEvent) -> Unit = {},
 ) {
     val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
@@ -249,7 +263,15 @@ fun SquareToolCard(
     ProvideLayoutDirectionFromLocale(locale = { firstTranslation.value?.languageCode }) {
         ElevatedCard(
             elevation = toolCardElevation,
-            onClick = { onClick(tool, firstTranslation.value?.languageCode, secondTranslation?.languageCode) },
+            onClick = {
+                onEvent(
+                    ToolCardEvent.Click(
+                        tool,
+                        lang1 = firstTranslation.value?.languageCode,
+                        lang2 = secondTranslation?.languageCode,
+                    )
+                )
+            },
             modifier = modifier.width(189.dp)
         ) {
             Box(modifier = Modifier.fillMaxWidth()) {
@@ -304,8 +326,7 @@ fun SquareToolCard(
                 if (showActions) {
                     ToolCardActions(
                         viewModel,
-                        onOpenTool = onOpenTool,
-                        onOpenToolDetails = onOpenToolDetails,
+                        onEvent = onEvent,
                         modifier = Modifier.padding(top = 8.dp)
                     )
                 }
@@ -320,7 +341,7 @@ fun VariantToolCard(
     toolCode: String,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit = {}
+    onEvent: (ToolCardEvent) -> Unit = {},
 ) {
     val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
@@ -329,7 +350,7 @@ fun VariantToolCard(
     ProvideLayoutDirectionFromLocale(locale = { firstTranslation.value?.languageCode }) {
         ElevatedCard(
             elevation = toolCardElevation,
-            onClick = { onClick() },
+            onClick = { onEvent(ToolCardEvent.Click(tool)) },
             modifier = modifier
         ) {
             ToolBanner(

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -54,7 +54,6 @@ import org.cru.godtools.base.ui.util.getCategory
 import org.cru.godtools.base.ui.util.getFontFamilyOrNull
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
-import org.cru.godtools.model.Translation
 import org.cru.godtools.model.getName
 import org.cru.godtools.model.getTagline
 
@@ -91,8 +90,7 @@ internal val toolCardInfoLabelStyle @Composable get() = MaterialTheme.typography
 sealed class ToolCardEvent(val tool: Tool?, val lang1: Locale?, val lang2: Locale?) {
     class Click(
         tool: Tool?,
-        val translation1: Translation? = null,
-        lang1: Locale? = translation1?.languageCode,
+        lang1: Locale? = null,
         lang2: Locale? = null,
     ) : ToolCardEvent(tool, lang1, lang2)
     class OpenTool(tool: Tool?, lang1: Locale? = null, lang2: Locale? = null) : ToolCardEvent(tool, lang1, lang2)
@@ -119,7 +117,7 @@ fun LessonToolCard(
     ProvideLayoutDirectionFromLocale(locale = { translation.value?.languageCode }) {
         ElevatedCard(
             elevation = toolCardElevation,
-            onClick = { onEvent(ToolCardEvent.Click(tool, translation.value)) },
+            onClick = { onEvent(ToolCardEvent.Click(tool, translation.value?.languageCode)) },
             modifier = modifier.fillMaxWidth()
         ) {
             ToolBanner(viewModel, modifier = Modifier.aspectRatio(335f / 80f))


### PR DESCRIPTION
- introduce a ToolCardEvent class to capture all the events that can come out of tool cards
- introduce a DashboardHomeEvent to capture all the events HomeContent can emit
- introduce a DashboardLessonsEvent that represents events that can happen in the Lessons layout
- make the AllFavoritesList have a generic onEvent method
- finish updating DashboardLayout to use event objects for callbacks
