### PR TITLE
GT-2074 Utilize the app language for shortcuts

### DIFF
--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -271,7 +271,7 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
             ?: IconCompat.createWithResource(context, org.cru.godtools.ui.R.mipmap.ic_launcher)
 
         // build the shortcut
-        ShortcutInfoCompat.Builder(context, tool.shortcutId)
+        ShortcutInfoCompat.Builder(context, code.toolShortcutId)
             .setAlwaysBadged()
             .setIntent(intent)
             .setShortLabel(label)
@@ -340,5 +340,5 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
     }
 }
 
-private val Tool.shortcutId get() = code.toolShortcutId
-private val String?.toolShortcutId get() = "$TYPE_TOOL$this"
+private val Tool.shortcutId get() = code?.toolShortcutId
+private val String.toolShortcutId get() = "$TYPE_TOOL$this"

--- a/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
+++ b/ui/shortcuts/src/main/kotlin/org/cru/godtools/shortcuts/GodToolsShortcutManager.kt
@@ -230,7 +230,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
                 ?: translationsRepository.findLatestTranslation(code, Settings.defaultLanguage)
                 ?: return@withContext null
             add(translation.languageCode)
-            settings.parallelLanguage?.let { add(it) }
         }
 
         // generate the target intent for this shortcut
@@ -306,7 +305,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
             merge(
                 settings.appLanguageFlow,
-                settings.parallelLanguageFlow,
                 attachmentsRepository.attachmentsChangeFlow(),
                 toolsRepository.toolsChangeFlow(),
                 translationsRepository.translationsChangeFlow(),
@@ -323,7 +321,6 @@ class GodToolsShortcutManager @VisibleForTesting internal constructor(
 
             merge(
                 settings.appLanguageFlow,
-                settings.parallelLanguageFlow,
                 attachmentsRepository.attachmentsChangeFlow(),
                 toolsRepository.toolsChangeFlow(),
                 translationsRepository.translationsChangeFlow(),


### PR DESCRIPTION
- don't generate a shortcut id for a null tool code
- use the appLanguage instead of the primaryLanguage when generating shortcuts
- don't use the parallel language when generating a shortcut
