### PR TITLE
GT-1983 Remove primary & parallel language settings

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
@@ -47,9 +47,6 @@ class ToolViewModels @Inject constructor(
     private val appLanguage = settings.appLanguageFlow
         .flatMapLatest { languagesRepository.findLanguageFlow(it) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
-    private val primaryLanguage = settings.primaryLanguageFlow
-        .flatMapLatest { languagesRepository.findLanguageFlow(it) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
     private val parallelLanguage = settings.parallelLanguageFlow
         .flatMapLatest { it?.let { languagesRepository.findLanguageFlow(it) } ?: flowOf(null) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
@@ -81,10 +78,6 @@ class ToolViewModels @Inject constructor(
             .flatMapLatest { translationsRepository.findLatestTranslationFlow(code, it) }
             .map { StateFlowValue(it) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), StateFlowValue.Initial<Translation?>(null))
-        val primaryTranslation = settings.primaryLanguageFlow
-            .flatMapLatest { translationsRepository.findLatestTranslationFlow(code, it) }
-            .map { StateFlowValue(it) }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), StateFlowValue.Initial<Translation?>(null))
         private val defaultTranslation = translationsRepository
             .findLatestTranslationFlow(code, Settings.defaultLanguage)
             .map { StateFlowValue(it) }
@@ -99,7 +92,6 @@ class ToolViewModels @Inject constructor(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
         val appLanguage get() = this@ToolViewModels.appLanguage
-        val primaryLanguage get() = this@ToolViewModels.primaryLanguage
         val parallelLanguage get() = this@ToolViewModels.parallelLanguage
 
         val firstTranslation = appTranslation

--- a/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
@@ -9,7 +9,6 @@ import androidx.core.content.pm.PackageInfoCompat
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.distinctUntilChanged
-import androidx.lifecycle.map
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.util.Locale
 import javax.inject.Inject
@@ -21,15 +20,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import org.ccci.gto.android.common.androidx.lifecycle.getBooleanLiveData
 import org.ccci.gto.android.common.androidx.lifecycle.getIntLiveData
-import org.ccci.gto.android.common.androidx.lifecycle.getStringLiveData
 import org.ccci.gto.android.common.kotlin.coroutines.getBooleanFlow
-import org.ccci.gto.android.common.kotlin.coroutines.getStringFlow
-import org.ccci.gto.android.common.util.toLocale
 
 private const val PREFS_SETTINGS = "GodTools"
 private const val PREF_ADDED_TO_CAMPAIGN = "added_to_campaign."
@@ -45,8 +40,6 @@ class Settings internal constructor(private val context: Context, coroutineScope
     private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_SETTINGS, Context.MODE_PRIVATE)
 
     companion object {
-        const val PREF_PRIMARY_LANGUAGE = "languagePrimary"
-        const val PREF_PARALLEL_LANGUAGE = "languageParallel"
         const val PREF_FEATURE_DISCOVERED = "feature_discovered."
         const val PREF_FEATURE_DISCOVERED_COUNT = "feature_discovered_count."
 
@@ -83,39 +76,6 @@ class Settings internal constructor(private val context: Context, coroutineScope
     }.shareIn(coroutineScope, SharingStarted.WhileSubscribed())
         .onStart { emit(appLanguage) }
         .distinctUntilChanged()
-
-    var primaryLanguage: Locale
-        get() = prefs.getString(PREF_PRIMARY_LANGUAGE, null)?.toLocale() ?: defaultLanguage
-        set(value) {
-            prefs.edit {
-                putString(PREF_PRIMARY_LANGUAGE, value.toLanguageTag())
-                if (value == parallelLanguage) remove(PREF_PARALLEL_LANGUAGE)
-            }
-        }
-    val primaryLanguageLiveData by lazy {
-        prefs.getStringLiveData(PREF_PRIMARY_LANGUAGE, null)
-            .map { it?.toLocale() ?: defaultLanguage }
-            .distinctUntilChanged()
-    }
-    val primaryLanguageFlow
-        get() = prefs.getStringFlow(PREF_PRIMARY_LANGUAGE, null)
-            .map { it?.toLocale() ?: defaultLanguage }
-            .distinctUntilChanged()
-    val isPrimaryLanguageSet: Boolean get() = prefs.getString(PREF_PRIMARY_LANGUAGE, null) != null
-
-    var parallelLanguage
-        get() = prefs.getString(PREF_PARALLEL_LANGUAGE, null)?.toLocale()
-        set(locale) {
-            if (primaryLanguage == locale) return
-            prefs.edit { putString(PREF_PARALLEL_LANGUAGE, locale?.toLanguageTag()) }
-        }
-    val parallelLanguageLiveData by lazy {
-        prefs.getStringLiveData(PREF_PARALLEL_LANGUAGE, null).distinctUntilChanged()
-            .map { it?.toLocale() }
-    }
-    val parallelLanguageFlow
-        get() = prefs.getStringFlow(PREF_PARALLEL_LANGUAGE, null).distinctUntilChanged()
-            .map { it?.toLocale() }
     // endregion Language Settings
 
     // region Feature Discovery Tracking

--- a/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
@@ -2,13 +2,9 @@ package org.cru.godtools.base
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import app.cash.turbine.test
-import java.util.Locale
-import kotlinx.coroutines.test.runTest
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -24,49 +20,6 @@ class SettingsTest {
     fun setup() {
         settings = Settings(ApplicationProvider.getApplicationContext())
     }
-
-    // region primaryLanguage
-    @Test
-    fun `Property primaryLanguage`() {
-        assertFalse(settings.isPrimaryLanguageSet)
-
-        settings.primaryLanguage = Locale.FRENCH
-        assertEquals(Locale.FRENCH, settings.primaryLanguage)
-        assertTrue(settings.isPrimaryLanguageSet)
-
-        settings.primaryLanguage = Locale.GERMAN
-        assertEquals(Locale.GERMAN, settings.primaryLanguage)
-        assertTrue(settings.isPrimaryLanguageSet)
-    }
-
-    @Test
-    fun `Property primaryLanguage - Defaults to defaultLanguage`() {
-        assertEquals(Settings.defaultLanguage, settings.primaryLanguage)
-        assertFalse(settings.isPrimaryLanguageSet)
-    }
-
-    @Test
-    fun `Property primaryLanguage - Clears parallelLanguage if its the same`() {
-        settings.parallelLanguage = Locale.FRENCH
-        assertEquals(Locale.FRENCH, settings.parallelLanguage)
-        settings.primaryLanguage = Locale.FRENCH
-        assertEquals(Locale.FRENCH, settings.primaryLanguage)
-        assertNull(settings.parallelLanguage)
-    }
-
-    @Test
-    fun `Property primaryLanguageFlow`() = runTest {
-        settings.primaryLanguageFlow.test {
-            assertEquals(Settings.defaultLanguage, awaitItem())
-
-            settings.primaryLanguage = Locale.FRENCH
-            assertEquals(Locale.FRENCH, awaitItem())
-
-            settings.primaryLanguage = Locale.GERMAN
-            assertEquals(Locale.GERMAN, awaitItem())
-        }
-    }
-    // endregion primaryLanguage
 
     @Test
     fun verifyFeatureDiscovery() {

--- a/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/InitialContentImporter.kt
+++ b/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/InitialContentImporter.kt
@@ -13,10 +13,7 @@ class InitialContentImporter @Inject internal constructor(tasks: Tasks) {
 
     init {
         coroutineScope.launch {
-            launch {
-                tasks.loadBundledLanguages()
-                tasks.initPrimaryLanguage()
-            }
+            launch { tasks.loadBundledLanguages() }
 
             tasks.loadBundledResources()
             launch { tasks.initFavoriteTools() }

--- a/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
+++ b/library/initial-content/src/main/kotlin/org/cru/godtools/init/content/task/Tasks.kt
@@ -13,9 +13,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.jsonapi.JsonApiConverter
-import org.ccci.gto.android.common.util.includeFallbacks
 import org.cru.godtools.base.Settings
-import org.cru.godtools.base.util.deviceLocale
 import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.LastSyncTimeRepository
@@ -61,14 +59,6 @@ internal class Tasks @Inject constructor(
             Timber.tag(TAG).e(e, "Error loading bundled languages")
         }
     }
-
-    suspend fun initPrimaryLanguage() {
-        if (settings.isPrimaryLanguageSet) return
-
-        sequenceOf(context.deviceLocale).filterNotNull().includeFallbacks().distinct()
-            // set the first available language as the primary language
-            .firstOrNull { languagesRepository.findLanguage(it) != null }?.let { settings.primaryLanguage = it }
-    }
     // endregion Language Initial Content Tasks
 
     // region Tool Initial Content Tasks
@@ -92,7 +82,7 @@ internal class Tasks @Inject constructor(
             val preferred = async {
                 bundledTools.sortedBy { it.initialFavoritesPriority ?: Int.MAX_VALUE }.mapNotNull { it.code }
             }
-            val available = translationsRepository.getTranslationsForLanguages(listOf(settings.primaryLanguage))
+            val available = translationsRepository.getTranslationsForLanguages(listOf(settings.appLanguage))
                 .mapNotNullTo(mutableSetOf()) { it.toolCode }
 
             (preferred.await().asSequence().filter { available.contains(it) } + preferred.await().asSequence())

--- a/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
+++ b/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
@@ -37,7 +37,7 @@ class TasksTest {
         coEvery { updateLastSyncTime(*anyVararg()) } just Runs
     }
     private val settings = mockk<Settings> {
-        every { primaryLanguage } returns Locale("x")
+        every { appLanguage } returns Locale("x")
     }
     private val toolsRepository: ToolsRepository = mockk(relaxUnitFun = true) {
         coEvery { getTools() } returns emptyList()
@@ -58,7 +58,7 @@ class TasksTest {
 
     // region initFavoriteTools()
     @Test
-    fun `initFavoriteTools - Already Ran - Last sync recorded`() = runTest {
+    fun `initFavoriteTools() - Already Ran - Last sync recorded`() = runTest {
         coEvery { lastSyncTimeRepository.getLastSyncTime(*anyVararg()) } returns 5
         tasks.initFavoriteTools()
         coVerify {
@@ -70,7 +70,7 @@ class TasksTest {
     }
 
     @Test
-    fun `initFavoriteTools - Already Ran - Has favorite tools`() = runTest {
+    fun `initFavoriteTools() - Already Ran - Has favorite tools`() = runTest {
         coEvery { toolsRepository.getTools() } returns listOf(Tool().apply { isAdded = true })
         tasks.initFavoriteTools()
         coVerify {
@@ -82,7 +82,7 @@ class TasksTest {
     }
 
     @Test
-    fun testInitFavoriteTools() = runTest {
+    fun `initFavoriteTools()`() = runTest {
         val tools = Array(5) { Tool("${it + 1}") }
         val translations = listOf("1", "5").map { Translation(it) }
         coEvery { toolsRepository.getTools() } returns tools.toList()


### PR DESCRIPTION
- remove usage of the primaryLanguage from the initial content module
- update ToolViewModels to no longer use Settings.primaryLanguage
- remove ToolViewModels usage of Settings.parallelLanguage
- remove unused primary & parallel language settings
