### PR TITLE
cleanup

### DIFF
--- a/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
@@ -19,6 +19,18 @@ import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.dagger.EventBusModule
 import org.cru.godtools.dagger.FlipperModule
 import org.cru.godtools.dagger.ServicesModule
+import org.cru.godtools.db.DatabaseModule
+import org.cru.godtools.db.repository.AttachmentsRepository
+import org.cru.godtools.db.repository.DownloadedFilesRepository
+import org.cru.godtools.db.repository.FollowupsRepository
+import org.cru.godtools.db.repository.GlobalActivityRepository
+import org.cru.godtools.db.repository.LanguagesRepository
+import org.cru.godtools.db.repository.LastSyncTimeRepository
+import org.cru.godtools.db.repository.ToolsRepository
+import org.cru.godtools.db.repository.TrainingTipsRepository
+import org.cru.godtools.db.repository.TranslationsRepository
+import org.cru.godtools.db.repository.UserCountersRepository
+import org.cru.godtools.db.repository.UserRepository
 import org.cru.godtools.sync.GodToolsSyncService
 import org.greenrobot.eventbus.EventBus
 
@@ -27,6 +39,7 @@ import org.greenrobot.eventbus.EventBus
     components = [SingletonComponent::class],
     replaces = [
         AnalyticsModule::class,
+        DatabaseModule::class,
         EventBusModule::class,
         FlipperModule::class,
         ServicesModule::class,
@@ -56,4 +69,36 @@ class ExternalSingletonsModule {
     }
     @get:Provides
     val workManager by lazy { mockk<WorkManager>() }
+
+    // region DatabaseModule
+    @get:Provides
+    val attachmentsRepository: AttachmentsRepository by lazy { mockk() }
+    @get:Provides
+    val downloadedFilesRepository: DownloadedFilesRepository by lazy { mockk() }
+    @get:Provides
+    val followupsRepository: FollowupsRepository by lazy { mockk() }
+    @get:Provides
+    val globalActivityRepository: GlobalActivityRepository by lazy { mockk() }
+    @get:Provides
+    val languagesRepository: LanguagesRepository by lazy { mockk() }
+    @get:Provides
+    val lastSyncTimeRepository: LastSyncTimeRepository by lazy { mockk() }
+    @get:Provides
+    val toolsRepository: ToolsRepository by lazy {
+        mockk {
+            every { getFavoriteToolsFlow() } returns flowOf(emptyList())
+            every { getLessonsFlow() } returns flowOf(emptyList())
+            every { getToolsFlow() } returns flowOf(emptyList())
+            every { getMetaToolsFlow() } returns flowOf(emptyList())
+        }
+    }
+    @get:Provides
+    val trainingTipsRepository: TrainingTipsRepository by lazy { mockk() }
+    @get:Provides
+    val translationsRepository: TranslationsRepository by lazy { mockk() }
+    @get:Provides
+    val userRepository: UserRepository by lazy { mockk() }
+    @get:Provides
+    val userCountersRepository: UserCountersRepository by lazy { mockk() }
+    // endregion DatabaseModule
 }

--- a/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
@@ -16,6 +16,7 @@ import org.ccci.gto.android.common.dagger.eager.EagerModule
 import org.cru.godtools.account.GodToolsAccountManager
 import org.cru.godtools.analytics.AnalyticsModule
 import org.cru.godtools.dagger.EventBusModule
+import org.cru.godtools.dagger.FlipperModule
 import org.cru.godtools.dagger.ServicesModule
 import org.cru.godtools.sync.GodToolsSyncService
 import org.greenrobot.eventbus.EventBus
@@ -26,6 +27,7 @@ import org.greenrobot.eventbus.EventBus
     replaces = [
         AnalyticsModule::class,
         EventBusModule::class,
+        FlipperModule::class,
         ServicesModule::class,
     ]
 )

--- a/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ExternalSingletonsModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.testing.TestInstallIn
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
@@ -49,6 +50,8 @@ class ExternalSingletonsModule {
     val syncService: GodToolsSyncService by lazy {
         mockk {
             coEvery { syncTools(any()) } returns true
+            every { syncFollowupsAsync() } returns CompletableDeferred(true)
+            every { syncToolSharesAsync() } returns CompletableDeferred(true)
         }
     }
     @get:Provides

--- a/build-logic/src/main/kotlin/AndroidConfiguration.kt
+++ b/build-logic/src/main/kotlin/AndroidConfiguration.kt
@@ -39,7 +39,7 @@ private fun Project.configureCommonDependencies() {
             candidates.firstOrNull { it.id.let { it is ModuleComponentIdentifier && it.module == "guava" } }
                 ?.let { select(it) }
 
-            because("Google Guava provides listenablefuture, so we should prefer that over the standalong artifact")
+            because("Google Guava provides listenablefuture, so we should prefer that over the standalone artifact")
         }
 
         // exclude guava transitive compileOnly dependencies


### PR DESCRIPTION
- fix a comment
- we don't need to include the FlipperModule in the test dagger graph
- provide default mocks for several sync methods
- provide mocks for the DatabaseModule
