### PR TITLE
GT-1991 Make some adjustments to how we access the ToolViewModel

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/AllFavoritesLayout.kt
@@ -27,15 +27,16 @@ import org.cru.godtools.R
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_FAVORITE
-import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent
+import org.cru.godtools.ui.tools.ToolViewModels
 
 @Composable
 @OptIn(ExperimentalFoundationApi::class)
 internal fun AllFavoritesList(
     onEvent: (ToolCardEvent) -> Unit,
     viewModel: HomeViewModel = viewModel(),
+    toolViewModels: ToolViewModels = viewModel(),
 ) {
     val favoriteTools by viewModel.reorderableFavoriteTools.collectAsState()
 
@@ -72,9 +73,8 @@ internal fun AllFavoritesList(
                 val interactionSource = remember { MutableInteractionSource() }
                 interactionSource.reorderableDragInteractions(isDragging)
 
-                PreloadTool(tool)
                 ToolCard(
-                    toolCode = tool.code.orEmpty(),
+                    toolViewModels[tool.code.orEmpty(), tool],
                     confirmRemovalFromFavorites = true,
                     interactionSource = interactionSource,
                     onEvent = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -30,6 +30,7 @@ import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.SquareToolCard
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardEvent
+import org.cru.godtools.ui.tools.ToolViewModels
 
 internal val MARGIN_TOOLS_LAYOUT_HORIZONTAL = 16.dp
 
@@ -38,6 +39,7 @@ internal val MARGIN_TOOLS_LAYOUT_HORIZONTAL = 16.dp
 internal fun ToolsLayout(
     onEvent: (ToolCardEvent) -> Unit,
     viewModel: ToolsViewModel = viewModel(),
+    toolViewModels: ToolViewModels = viewModel(),
 ) {
     val banner by viewModel.banner.collectAsState()
     val spotlightTools by viewModel.spotlightTools.collectAsState()
@@ -85,9 +87,8 @@ internal fun ToolsLayout(
         }
 
         items(tools, { "tool:${it.id}" }, { "tool" }) { tool ->
-            PreloadTool(tool)
             ToolCard(
-                tool.code.orEmpty(),
+                toolViewModels[tool.code.orEmpty(), tool],
                 additionalLanguage = selectedLanguage,
                 showActions = false,
                 onEvent = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -73,7 +73,6 @@ import org.cru.godtools.ui.drawer.DrawerMenuLayout
 import org.cru.godtools.ui.tooldetails.analytics.model.ToolDetailsScreenEvent
 import org.cru.godtools.ui.tools.AvailableInLanguage
 import org.cru.godtools.ui.tools.DownloadProgressIndicator
-import org.cru.godtools.ui.tools.PreloadTool
 import org.cru.godtools.ui.tools.ToolCardEvent
 import org.cru.godtools.ui.tools.ToolViewModels
 import org.cru.godtools.ui.tools.VariantToolCard
@@ -133,11 +132,12 @@ fun ToolDetailsLayout(
 private fun ToolDetailsContent(
     viewModel: ToolDetailsViewModel,
     modifier: Modifier = Modifier,
+    toolViewModels: ToolViewModels = viewModel(key = "ToolDetailsContent"),
     onEvent: (ToolDetailsEvent) -> Unit = {},
 ) {
     val coroutineScope = rememberCoroutineScope()
     val toolCode by viewModel.toolCode.collectAsState()
-    val toolViewModel = viewModel<ToolViewModels>()[toolCode.orEmpty()]
+    val toolViewModel = toolViewModels[toolCode.orEmpty()]
     val tool by toolViewModel.tool.collectAsState()
     val translation by toolViewModel.firstTranslation.collectAsState()
 
@@ -232,6 +232,7 @@ private fun ToolDetailsContent(
                 ToolDetailsPage.DESCRIPTION -> ToolDetailsAbout(toolViewModel, modifier = Modifier.padding(32.dp))
                 ToolDetailsPage.VARIANTS -> ToolDetailsVariants(
                     viewModel,
+                    toolViewModels,
                     onVariantSelected = {
                         if (toolCode != it) coroutineScope.launch { scrollState.animateScrollTo(0) }
                         viewModel.setToolCode(it)
@@ -334,6 +335,7 @@ internal fun ToolDetailsActions(
 @Composable
 private fun ToolDetailsVariants(
     viewModel: ToolDetailsViewModel,
+    toolViewModels: ToolViewModels,
     onVariantSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -350,9 +352,8 @@ private fun ToolDetailsVariants(
         variants.forEach { tool ->
             val code = tool.code ?: return@forEach
 
-            PreloadTool(tool)
             VariantToolCard(
-                code,
+                viewModel = toolViewModels[code, tool],
                 isSelected = currentTool == code,
                 onEvent = {
                     when (it) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -332,11 +332,10 @@ fun SquareToolCard(
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun VariantToolCard(
-    toolCode: String,
+internal fun VariantToolCard(
+    viewModel: ToolViewModels.ToolViewModel,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
-    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     onEvent: (ToolCardEvent) -> Unit = {},
 ) {
     val tool by viewModel.tool.collectAsState()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -99,7 +99,7 @@ sealed class ToolCardEvent(val tool: Tool?, val lang1: Locale?, val lang2: Local
 @Composable
 fun PreloadTool(tool: Tool) {
     val code = tool.code ?: return
-    toolViewModels.initializeToolViewModel(code, tool)
+    toolViewModels[code, tool]
 }
 
 @Composable

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -147,9 +147,8 @@ fun LessonToolCard(
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun ToolCard(
-    toolCode: String,
+    viewModel: ToolViewModels.ToolViewModel,
     modifier: Modifier = Modifier,
-    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     additionalLanguage: Language? = null,
     confirmRemovalFromFavorites: Boolean = false,
     showActions: Boolean = true,

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -57,8 +57,6 @@ import org.cru.godtools.model.getName
 import org.cru.godtools.model.getTagline
 
 private val toolViewModels: ToolViewModels @Composable get() = viewModel()
-@Composable
-private fun toolViewModel(tool: String) = toolViewModels[tool]
 
 private val toolCardElevation @Composable get() = elevatedCardElevation(defaultElevation = 4.dp)
 
@@ -107,9 +105,9 @@ fun PreloadTool(tool: Tool) {
 fun LessonToolCard(
     toolCode: String,
     modifier: Modifier = Modifier,
+    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     onEvent: (ToolCardEvent) -> Unit = {},
 ) {
-    val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
     val translation by viewModel.firstTranslation.collectAsState()
 
@@ -151,13 +149,13 @@ fun LessonToolCard(
 fun ToolCard(
     toolCode: String,
     modifier: Modifier = Modifier,
+    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     additionalLanguage: Language? = null,
     confirmRemovalFromFavorites: Boolean = false,
     showActions: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onEvent: (ToolCardEvent) -> Unit = {},
 ) {
-    val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
     val firstTranslation by viewModel.firstTranslation.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
@@ -245,13 +243,13 @@ fun ToolCard(
 fun SquareToolCard(
     toolCode: String,
     modifier: Modifier = Modifier,
+    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     showCategory: Boolean = true,
     showActions: Boolean = true,
     floatParallelLanguageUp: Boolean = true,
     confirmRemovalFromFavorites: Boolean = false,
     onEvent: (ToolCardEvent) -> Unit = {},
 ) {
-    val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
     val firstTranslation by viewModel.firstTranslation.collectAsState()
     val secondTranslation by viewModel.secondTranslation.collectAsState()
@@ -338,9 +336,9 @@ fun VariantToolCard(
     toolCode: String,
     isSelected: Boolean,
     modifier: Modifier = Modifier,
+    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
     onEvent: (ToolCardEvent) -> Unit = {},
 ) {
-    val viewModel = toolViewModel(toolCode)
     val tool by viewModel.tool.collectAsState()
     val firstTranslation by viewModel.firstTranslation.collectAsState()
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
@@ -43,9 +43,7 @@ class ToolViewModels @Inject constructor(
 ) : ViewModel() {
     private val toolViewModels = mutableMapOf<String, ToolViewModel>()
     operator fun get(tool: String) = toolViewModels.getOrPut(tool) { ToolViewModel(tool) }
-    fun initializeToolViewModel(code: String, tool: Tool) {
-        toolViewModels.getOrPut(code) { ToolViewModel(code, tool) }
-    }
+    operator fun get(code: String, tool: Tool?) = toolViewModels.getOrPut(code) { ToolViewModel(code, tool) }
 
     private val appLanguage = settings.appLanguageFlow
         .flatMapLatest { languagesRepository.findLanguageFlow(it) }


### PR DESCRIPTION
- use an overloaded get operator instead of separate initialize method
- make it possible to provide a viewModel to the ToolCard layouts
- update VariantToolCard to take a ToolViewModel instead of the code of the tool to render
- provide a ToolViewModel to the ToolCard when rendering
