### PR TITLE
GT-1991 Display additional language label only if translation is available

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
@@ -32,6 +32,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.cru.godtools.tutorial.PageSet
 import org.cru.godtools.tutorial.TutorialActivityResultContract
+import org.cru.godtools.ui.tools.EXTRA_ADDITIONAL_LANGUAGE
 import org.cru.godtools.util.openToolActivity
 
 fun Activity.startToolDetailsActivity(toolCode: String, additionalLanguage: Locale? = null) = startActivity(

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
@@ -5,29 +5,16 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.lifecycle.flowWithLifecycle
-import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.combineTransform
-import kotlinx.coroutines.flow.conflate
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_TOOL_DETAILS
-import org.cru.godtools.base.BaseModule
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_TIPS
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.base.ui.theme.GodToolsTheme
-import org.cru.godtools.downloadmanager.GodToolsDownloadManager
 import org.cru.godtools.model.Tool
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.cru.godtools.tutorial.PageSet
@@ -76,8 +63,6 @@ class ToolDetailsActivity : BaseActivity() {
                 )
             }
         }
-
-        downloadLatestTranslationsAutomatically()
     }
     // endregion Lifecycle
 
@@ -92,29 +77,9 @@ class ToolDetailsActivity : BaseActivity() {
     }
 
     // region Training Tips
-    @Inject
-    internal lateinit var downloadManager: GodToolsDownloadManager
-    @Inject
-    @Named(BaseModule.IS_CONNECTED_STATE_FLOW)
-    internal lateinit var isConnectedFlow: StateFlow<Boolean>
-
     private val selectedTool by viewModels<SelectedToolSavedState>()
     private val tipsTutorialLauncher = registerForActivityResult(TutorialActivityResultContract()) {
         if (it == RESULT_OK) launchTrainingTips(skipTutorial = true)
-    }
-
-    private fun downloadLatestTranslationsAutomatically() {
-        combine(
-            viewModel.toolCode,
-            settings.appLanguageFlow,
-            viewModel.additionalLocale
-        ) { t, l1, l2 -> t?.let { Pair(t, listOfNotNull(l1, l2)) } }
-            .combineTransform(isConnectedFlow) { it, isConnected -> if (isConnected) emit(it) }
-            .filterNotNull()
-            .flowWithLifecycle(lifecycle)
-            .conflate()
-            .onEach { (t, l) -> l.map { downloadManager.downloadLatestPublishedTranslationAsync(t, it) }.awaitAll() }
-            .launchIn(lifecycleScope)
     }
 
     private fun launchTrainingTips(

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
@@ -22,9 +22,9 @@ import kotlinx.coroutines.flow.onEach
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_TOOL_DETAILS
+import org.cru.godtools.base.BaseModule
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_TIPS
-import org.cru.godtools.base.ui.BaseUiModule
 import org.cru.godtools.base.ui.activity.BaseActivity
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.downloadmanager.GodToolsDownloadManager
@@ -95,7 +95,7 @@ class ToolDetailsActivity : BaseActivity() {
     @Inject
     internal lateinit var downloadManager: GodToolsDownloadManager
     @Inject
-    @Named(BaseUiModule.IS_CONNECTED_STATE_FLOW)
+    @Named(BaseModule.IS_CONNECTED_STATE_FLOW)
     internal lateinit var isConnectedFlow: StateFlow<Boolean>
 
     private val selectedTool by viewModels<SelectedToolSavedState>()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -185,8 +185,10 @@ private fun ToolDetailsContent(
                         style = MaterialTheme.typography.bodyMedium,
                     )
 
-                    val additionalLanguage by viewModel.additionalLanguage.collectAsState()
-                    if (additionalLanguage != null) {
+                    val additionalTranslation by toolViewModel.secondTranslation.collectAsState()
+                    if (additionalTranslation != null) {
+                        val additionalLanguage by toolViewModel.secondLanguage.collectAsState()
+
                         Spacer(modifier = Modifier.weight(1f))
                         AvailableInLanguage(
                             language = additionalLanguage,
@@ -292,11 +294,12 @@ internal fun ToolDetailsActions(
 ) = Column(modifier = modifier) {
     val tool by toolViewModel.tool.collectAsState()
     val translation by toolViewModel.firstTranslation.collectAsState()
+    val secondTranslation by toolViewModel.secondTranslation.collectAsState()
 
     Button(
         onClick = {
             onEvent(
-                ToolDetailsEvent.OpenTool(tool, translation.value?.languageCode, viewModel.additionalLocale.value)
+                ToolDetailsEvent.OpenTool(tool, translation.value?.languageCode, secondTranslation?.languageCode)
             )
         },
         modifier = Modifier.fillMaxWidth()

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -66,6 +66,7 @@ import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.base.ui.util.getFontFamilyOrNull
 import org.cru.godtools.base.ui.youtubeplayer.YouTubePlayer
+import org.cru.godtools.downloadmanager.compose.DownloadLatestTranslation
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.getName
 import org.cru.godtools.shortcuts.PendingShortcut
@@ -140,10 +141,14 @@ private fun ToolDetailsContent(
     val toolViewModel = toolViewModels[toolCode.orEmpty()]
     val tool by toolViewModel.tool.collectAsState()
     val translation by toolViewModel.firstTranslation.collectAsState()
+    val secondTranslation by toolViewModel.secondTranslation.collectAsState()
 
     val scrollState = rememberScrollState()
     val pages by viewModel.pages.collectAsState()
     val pagerState = rememberPagerState { pages.size }
+
+    DownloadLatestTranslation(toolCode, translation.value?.languageCode)
+    DownloadLatestTranslation(toolCode, secondTranslation?.languageCode)
 
     toolCode?.let { RecordAnalyticsScreen(ToolDetailsScreenEvent(it)) }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.stateIn
 import org.cru.godtools.base.EXTRA_TOOL
 import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.db.repository.AttachmentsRepository
-import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.cru.godtools.ui.tools.EXTRA_ADDITIONAL_LANGUAGE
@@ -28,7 +27,6 @@ class ToolDetailsViewModel @Inject constructor(
     private val shortcutManager: GodToolsShortcutManager,
     private val toolFileSystem: ToolFileSystem,
     toolsRepository: ToolsRepository,
-    languagesRepository: LanguagesRepository,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     val toolCode = savedStateHandle.getStateFlow<String?>(EXTRA_TOOL, null)
@@ -43,10 +41,6 @@ class ToolDetailsViewModel @Inject constructor(
         .flatMapLatest { it?.let { attachmentsRepository.findAttachmentFlow(it) } ?: flowOf(null) }
         .map { it?.takeIf { it.isDownloaded }?.getFile(toolFileSystem) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
-
-    val additionalLanguage = additionalLocale
-        .flatMapLatest { it?.let { languagesRepository.findLanguageFlow(it) } ?: flowOf(null) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val shortcut = tool.map {
         it?.takeIf { shortcutManager.canPinToolShortcut(it) }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
@@ -18,7 +17,6 @@ import org.cru.godtools.base.ToolFileSystem
 import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
-import org.cru.godtools.ui.tools.EXTRA_ADDITIONAL_LANGUAGE
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,7 +29,6 @@ class ToolDetailsViewModel @Inject constructor(
 ) : ViewModel() {
     val toolCode = savedStateHandle.getStateFlow<String?>(EXTRA_TOOL, null)
     fun setToolCode(code: String) = savedStateHandle.set(EXTRA_TOOL, code)
-    val additionalLocale = savedStateHandle.getStateFlow<Locale?>(EXTRA_ADDITIONAL_LANGUAGE, null)
 
     val tool = toolCode
         .flatMapLatest { it?.let { toolsRepository.findToolFlow(it) } ?: flowOf(null) }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModel.kt
@@ -19,8 +19,7 @@ import org.cru.godtools.db.repository.AttachmentsRepository
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
-
-internal const val EXTRA_ADDITIONAL_LANGUAGE = "additionalLanguage"
+import org.cru.godtools.ui.tools.EXTRA_ADDITIONAL_LANGUAGE
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolViewModels.kt
@@ -1,8 +1,10 @@
 package org.cru.godtools.ui.tools
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +31,8 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 
+internal const val EXTRA_ADDITIONAL_LANGUAGE = "additionalLanguage"
+
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
 class ToolViewModels @Inject constructor(
@@ -40,10 +44,13 @@ class ToolViewModels @Inject constructor(
     private val settings: Settings,
     private val toolsRepository: ToolsRepository,
     private val translationsRepository: TranslationsRepository,
+    savedState: SavedStateHandle,
 ) : ViewModel() {
     private val toolViewModels = mutableMapOf<String, ToolViewModel>()
     operator fun get(tool: String) = toolViewModels.getOrPut(tool) { ToolViewModel(tool) }
     operator fun get(code: String, tool: Tool?) = toolViewModels.getOrPut(code) { ToolViewModel(code, tool) }
+
+    private val additionalLocale = savedState.getStateFlow<Locale?>(EXTRA_ADDITIONAL_LANGUAGE, null)
 
     private val appLanguage = settings.appLanguageFlow
         .flatMapLatest { languagesRepository.findLanguageFlow(it) }

--- a/app/src/test/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsViewModelTest.kt
@@ -46,7 +46,6 @@ class ToolDetailsViewModelTest {
             shortcutManager = mockk(),
             toolFileSystem = mockk(),
             toolsRepository = toolsRepository,
-            languagesRepository = mockk(),
             savedStateHandle = SavedStateHandle()
         )
     }

--- a/library/base/src/main/AndroidManifest.xml
+++ b/library/base/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/library/base/src/main/kotlin/org/cru/godtools/base/BaseModule.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/BaseModule.kt
@@ -1,4 +1,4 @@
-package org.cru.godtools.base.ui
+package org.cru.godtools.base
 
 import android.content.Context
 import dagger.Module
@@ -15,7 +15,7 @@ import org.ccci.gto.android.common.kotlin.coroutines.flow.net.isConnectedFlow
 
 @Module
 @InstallIn(SingletonComponent::class)
-object BaseUiModule {
+object BaseModule {
     const val IS_CONNECTED_STATE_FLOW = "STATE_FLOW_IS_CONNECTED"
 
     @Provides

--- a/library/download-manager/build.gradle.kts
+++ b/library/download-manager/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace = "org.cru.godtools.downloadmanager"
 
+    configureCompose(project)
     buildFeatures.dataBinding = true
 
     testOptions.unitTests.all {
@@ -46,6 +47,5 @@ dependencies {
     testImplementation(libs.hilt.testing)
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.turbine)
-
     kaptTest(libs.hilt.compiler)
 }

--- a/library/download-manager/src/main/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslation.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslation.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.downloadmanager.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -10,6 +11,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.util.Locale
+import javax.inject.Named
+import kotlinx.coroutines.flow.StateFlow
+import org.cru.godtools.base.BaseModule
 import org.cru.godtools.downloadmanager.GodToolsDownloadManager
 import org.cru.godtools.model.TranslationKey
 
@@ -20,6 +24,7 @@ fun DownloadLatestTranslation(tool: String?, locale: Locale?) {
 
     val context = LocalContext.current
     val dagger = remember(context) { EntryPointAccessors.fromApplication<DownloadLatestTranslationEntryPoint>(context) }
+    if (!dagger.isConnected.collectAsState().value) return
 
     LaunchedEffect(tool, locale) {
         dagger.downloadManager.downloadLatestPublishedTranslation(TranslationKey(tool, locale))
@@ -30,4 +35,7 @@ fun DownloadLatestTranslation(tool: String?, locale: Locale?) {
 @InstallIn(SingletonComponent::class)
 internal interface DownloadLatestTranslationEntryPoint {
     val downloadManager: GodToolsDownloadManager
+
+    @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    val isConnected: StateFlow<Boolean>
 }

--- a/library/download-manager/src/main/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslation.kt
+++ b/library/download-manager/src/main/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslation.kt
@@ -1,0 +1,33 @@
+package org.cru.godtools.downloadmanager.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import java.util.Locale
+import org.cru.godtools.downloadmanager.GodToolsDownloadManager
+import org.cru.godtools.model.TranslationKey
+
+@Composable
+fun DownloadLatestTranslation(tool: String?, locale: Locale?) {
+    if (LocalInspectionMode.current) return
+    if (tool == null || locale == null) return
+
+    val context = LocalContext.current
+    val dagger = remember(context) { EntryPointAccessors.fromApplication<DownloadLatestTranslationEntryPoint>(context) }
+
+    LaunchedEffect(tool, locale) {
+        dagger.downloadManager.downloadLatestPublishedTranslation(TranslationKey(tool, locale))
+    }
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+internal interface DownloadLatestTranslationEntryPoint {
+    val downloadManager: GodToolsDownloadManager
+}

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/ExternalSingletonsModule.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/ExternalSingletonsModule.kt
@@ -1,0 +1,32 @@
+package org.cru.godtools.downloadmanager
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.cru.godtools.base.BaseModule
+
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [BaseModule::class]
+)
+abstract class ExternalSingletonsModule {
+    companion object {
+        @get:Provides
+        @get:Singleton
+        @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+        val isConnected = MutableStateFlow(true)
+    }
+
+    @Binds
+    @Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    abstract fun isConnected(
+        @Named(BaseModule.IS_CONNECTED_STATE_FLOW) flow: MutableStateFlow<Boolean>,
+    ): StateFlow<Boolean>
+}

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslationTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/compose/DownloadLatestTranslationTest.kt
@@ -1,0 +1,64 @@
+package org.cru.godtools.downloadmanager.compose
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.testing.BindValue
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerifyAll
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Locale
+import org.cru.godtools.downloadmanager.GodToolsDownloadManager
+import org.cru.godtools.model.TranslationKey
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@Config(application = HiltTestApplication::class)
+class DownloadLatestTranslationTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1)
+    val composeTestRule = createComposeRule()
+
+    @BindValue
+    val downloadManager: GodToolsDownloadManager = mockk {
+        coEvery { downloadLatestPublishedTranslation(any()) } returns true
+    }
+
+    @Test
+    fun `DownloadLatestTranslation()`() {
+        composeTestRule.setContent { DownloadLatestTranslation("kgp", Locale.ENGLISH) }
+
+        composeTestRule.runOnIdle {
+            coVerifyAll {
+                downloadManager.downloadLatestPublishedTranslation(TranslationKey("kgp", Locale.ENGLISH))
+            }
+        }
+    }
+
+    @Test
+    fun `DownloadLatestTranslation() - null tool`() {
+        composeTestRule.setContent { DownloadLatestTranslation(null, Locale.ENGLISH) }
+
+        composeTestRule.runOnIdle {
+            verify { downloadManager wasNot Called }
+        }
+    }
+
+    @Test
+    fun `DownloadLatestTranslation() - null locale`() {
+        composeTestRule.setContent { DownloadLatestTranslation("kgp", null) }
+
+        composeTestRule.runOnIdle {
+            verify { downloadManager wasNot Called }
+        }
+    }
+}

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/MockBaseModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/MockBaseModule.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.tool.article
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.cru.godtools.base.BaseModule
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [BaseModule::class])
+object MockBaseModule {
+    @get:Provides
+    @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    val isConnected = MutableStateFlow(true).asStateFlow()
+}

--- a/ui/base/build.gradle.kts
+++ b/ui/base/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(libs.gtoSupport.androidx.lifecycle)
     implementation(libs.gtoSupport.base)
     implementation(libs.gtoSupport.compat)
-    implementation(libs.gtoSupport.kotlin.coroutines)
     implementation(libs.gtoSupport.picasso)
     implementation(libs.gtoSupport.util)
 

--- a/ui/base/src/main/AndroidManifest.xml
+++ b/ui/base/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application>
         <activity android:name="org.cru.godtools.base.ui.firebase.DynamicLinksSpringboardActivity"
             android:exported="true">

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/MockBaseModule.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/MockBaseModule.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.tool.cyoa
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.cru.godtools.base.BaseModule
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [BaseModule::class])
+object MockBaseModule {
+    @get:Provides
+    @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    val isConnected = MutableStateFlow(true).asStateFlow()
+}

--- a/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/MockBaseModule.kt
+++ b/ui/lesson-renderer/src/test/kotlin/org/cru/godtools/tool/lesson/MockBaseModule.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.tool.lesson
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.cru.godtools.base.BaseModule
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [BaseModule::class])
+object MockBaseModule {
+    @get:Provides
+    @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    val isConnected = MutableStateFlow(true).asStateFlow()
+}

--- a/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/MockBaseModule.kt
+++ b/ui/tract-renderer/src/test/kotlin/org/cru/godtools/tool/tract/MockBaseModule.kt
@@ -1,0 +1,18 @@
+package org.cru.godtools.tool.tract
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import javax.inject.Named
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.cru.godtools.base.BaseModule
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [BaseModule::class])
+object MockBaseModule {
+    @get:Provides
+    @get:Named(BaseModule.IS_CONNECTED_STATE_FLOW)
+    val isConnected = MutableStateFlow(true).asStateFlow()
+}


### PR DESCRIPTION
- track the additional language in ToolViewModels
- load the additionalTranslation instead of the removed parallelTranslation
- use the secondTranslation & secondLanguage in the ToolDetailsLayout
- we no longer need to load the additionalLanguage model in ToolDetailsViewModel
- create a DownloadLatestTranslation composable that will trigger a download of the latest translation
- move isConnectedStateFlow to the base module
- update DownloadLatestTranslation to only trigger when online
- we no longer need to trigger the download manager from ToolDetailsActivity
