### PR TITLE
GT-2131 workaround a bug after upgrading google-services plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,8 @@ dependencies {
 // region Firebase App Distribution
 if (project.hasProperty("firebaseAppDistributionBuild")) {
     firebaseAppDistribution {
+        // HACK: workaround https://github.com/google/play-services-plugins/issues/276
+        appId = "1:71275134527:android:e6af54d704ba9adac5028a"
         artifactPath = layout.buildDirectory
             .file("outputs/apk_from_bundle/productionQa/app-production-qa-universal.apk")
             .get().asFile.path


### PR DESCRIPTION
google-services 4.4.0 changed the location of an internal generated xml file that contained the firebase appId, the firebase app distribution plugin directly reads this file to auto-discover the appId, but currently doesn't know about the new location.

This PR works around the issue by directly setting the appId for the QA build that we distribute via app distribution.

relevant upstream bug report: https://github.com/google/play-services-plugins/issues/276