### PR TITLE
cleanup

### DIFF
--- a/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
+++ b/library/initial-content/src/test/kotlin/org/cru/godtools/init/content/task/TasksTest.kt
@@ -84,7 +84,7 @@ class TasksTest {
     @Test
     fun `initFavoriteTools()`() = runTest {
         val tools = Array(5) { Tool("${it + 1}") }
-        val translations = listOf("1", "5").map { Translation(it) }
+        val translations = listOf("1", "5").map { Translation(toolCode = it) }
         coEvery { toolsRepository.getTools() } returns tools.toList()
         coEvery { translationsRepository.getTranslationsForLanguages(any()) } returns translations
         every { jsonApiConverter.fromJson(any(), Tool::class.java) } returns JsonApiObject.of(*tools)
@@ -100,9 +100,4 @@ class TasksTest {
         confirmVerified(toolsRepository)
     }
     // endregion initFavoriteTools()
-
-    private fun Tool(tool: String) = Tool().apply { code = tool }
-    private fun Translation(tool: String) = Translation().apply {
-        toolCode = tool
-    }
 }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -36,7 +36,7 @@ private const val SYNC_PARALLELISM = 8
 @Singleton
 class GodToolsSyncService @VisibleForTesting internal constructor(
     workManager: Lazy<WorkManager>,
-    private val syncTasks: Map<Class<out BaseSyncTasks>, @JvmSuppressWildcards Provider<BaseSyncTasks>>,
+    private val syncTasks: Map<Class<out BaseSyncTasks>, Provider<BaseSyncTasks>>,
     private val coroutineDispatcher: CoroutineDispatcher,
     private val coroutineScope: CoroutineScope = CoroutineScope(coroutineDispatcher + SupervisorJob()),
 ) {

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -49,7 +49,6 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
 
     private val workManager by workManager
 
-    private inline fun <reified T : BaseSyncTasks> with(block: T.() -> Unit) = with<T, Unit>(block)
     private inline fun <reified T : BaseSyncTasks, R : Any?> with(block: T.() -> R) =
         requireNotNull(syncTasks[T::class.java]?.get() as? T) { "${T::class.simpleName} not injected" }.block()
 

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/BaseSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/BaseSyncTasks.kt
@@ -1,20 +1,8 @@
 package org.cru.godtools.sync.task
 
-import android.content.ContentResolver
-import android.os.Bundle
 import androidx.annotation.RestrictTo
 import androidx.annotation.WorkerThread
-import androidx.collection.LongSparseArray
-import org.cru.godtools.model.Base
 
 @WorkerThread
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-abstract class BaseSyncTasks internal constructor() {
-    companion object {
-        fun isForced(extras: Bundle) = extras.getBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, false)
-
-        fun <E : Base> index(items: Collection<E>) = LongSparseArray<E>().apply {
-            for (item in items) put(item.id, item)
-        }
-    }
-}
+abstract class BaseSyncTasks internal constructor()


### PR DESCRIPTION
- use the model test constructor functions instead
- remove several unused functions from BaseSyncTasks
- remove unneeded with method from GodToolsSyncService
- remove unnecessary @JvmSuppressWildcards annotation
