### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
@@ -41,9 +41,9 @@ import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.shared.analytics.AnalyticsScreenNames
 
 internal sealed interface LanguageSettingsEvent {
-    object NavigateUp : LanguageSettingsEvent
-    object AppLanguage : LanguageSettingsEvent
-    object DownloadableLanguages : LanguageSettingsEvent
+    data object NavigateUp : LanguageSettingsEvent
+    data object AppLanguage : LanguageSettingsEvent
+    data object DownloadableLanguages : LanguageSettingsEvent
 }
 
 private const val SECTION_APP_LANGUAGE = "app_language"

--- a/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
@@ -10,6 +10,10 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -20,14 +24,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.model.Language
-import org.cru.godtools.model.LanguageMatchers.languageMatcher
 import org.cru.godtools.sync.GodToolsSyncService
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
@@ -49,7 +46,7 @@ class DownloadableLanguagesViewModelTest {
 
     private lateinit var viewModel: DownloadableLanguagesViewModel
 
-    @Before
+    @BeforeTest
     fun setup() {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScope.testScheduler))
         viewModel = DownloadableLanguagesViewModel(
@@ -60,7 +57,7 @@ class DownloadableLanguagesViewModelTest {
         )
     }
 
-    @After
+    @AfterTest
     fun cleanup() {
         Dispatchers.resetMain()
     }
@@ -89,7 +86,7 @@ class DownloadableLanguagesViewModelTest {
             awaitItem()
 
             languages.emit(listOf(french, english))
-            assertThat(awaitItem(), contains(languageMatcher(english), languageMatcher(french)))
+            assertEquals(listOf(english, french), awaitItem())
         }
     }
 
@@ -103,13 +100,10 @@ class DownloadableLanguagesViewModelTest {
             awaitItem()
 
             languages.emit(listOf(english, french))
-            assertThat(awaitItem(), contains(languageMatcher(french), languageMatcher(english)))
+            assertEquals(listOf(french, english), awaitItem())
 
             languages.emit(listOf(english, french, german))
-            assertThat(
-                awaitItem(),
-                contains(languageMatcher(french), languageMatcher(english), languageMatcher(german))
-            )
+            assertEquals(listOf(french, english, german), awaitItem())
         }
     }
 
@@ -122,16 +116,16 @@ class DownloadableLanguagesViewModelTest {
             awaitItem()
 
             languages.emit(listOf(french, english))
-            assertThat(awaitItem(), contains(languageMatcher(english), languageMatcher(french)))
+            assertEquals(listOf(english, french), awaitItem())
 
             viewModel.updateSearchQuery("eng")
-            assertThat(awaitItem(), contains(languageMatcher(english)))
+            assertEquals(listOf(english), awaitItem())
 
             viewModel.updateSearchQuery("fra")
-            assertThat(awaitItem(), contains(languageMatcher(french)))
+            assertEquals(listOf(french), awaitItem())
 
             viewModel.updateSearchQuery("eng ish")
-            assertThat(awaitItem(), contains(languageMatcher(english)))
+            assertEquals(listOf(english), awaitItem())
         }
     }
     // endregion Property: languages

--- a/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
@@ -17,6 +17,8 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -83,6 +85,7 @@ class DownloadableLanguagesViewModelTest {
         val french = Language(Locale.FRENCH)
 
         viewModel.languages.test {
+            languages.subscriptionCount.takeWhile { it < 1 }.collect()
             awaitItem()
 
             languages.emit(listOf(french, english))
@@ -97,6 +100,7 @@ class DownloadableLanguagesViewModelTest {
         val german = Language(Locale.GERMAN, isAdded = true)
 
         viewModel.languages.test {
+            languages.subscriptionCount.takeWhile { it < 1 }.collect()
             awaitItem()
 
             languages.emit(listOf(english, french))
@@ -113,6 +117,7 @@ class DownloadableLanguagesViewModelTest {
         val french = Language(Locale.FRENCH)
 
         viewModel.languages.test {
+            languages.subscriptionCount.takeWhile { it < 1 }.collect()
             awaitItem()
 
             languages.emit(listOf(french, english))


### PR DESCRIPTION
- make LanguageSettingEvents data objects
- use kotlin-test for DownloadableLanguagesViewModelTest
- make sure the languages MutableSharedFlow is subscribed to before starting tests
