### PR TITLE
cleanup

### DIFF
--- a/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesViewModelTest.kt
@@ -17,8 +17,7 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -85,7 +84,7 @@ class DownloadableLanguagesViewModelTest {
         val french = Language(Locale.FRENCH)
 
         viewModel.languages.test {
-            languages.subscriptionCount.takeWhile { it < 1 }.collect()
+            languages.subscriptionCount.first { it >= 1 }
             awaitItem()
 
             languages.emit(listOf(french, english))
@@ -100,7 +99,7 @@ class DownloadableLanguagesViewModelTest {
         val german = Language(Locale.GERMAN, isAdded = true)
 
         viewModel.languages.test {
-            languages.subscriptionCount.takeWhile { it < 1 }.collect()
+            languages.subscriptionCount.first { it >= 1 }
             awaitItem()
 
             languages.emit(listOf(english, french))
@@ -117,7 +116,7 @@ class DownloadableLanguagesViewModelTest {
         val french = Language(Locale.FRENCH)
 
         viewModel.languages.test {
-            languages.subscriptionCount.takeWhile { it < 1 }.collect()
+            languages.subscriptionCount.first { it >= 1 }
             awaitItem()
 
             languages.emit(listOf(french, english))

--- a/library/base/src/main/kotlin/org/cru/godtools/base/util/LocaleUtils.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/util/LocaleUtils.kt
@@ -3,15 +3,12 @@
 package org.cru.godtools.base.util
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.core.os.ConfigurationCompat
 import java.util.Locale
 import org.ccci.gto.android.common.util.content.localizeIfPossible
 import org.ccci.gto.android.common.util.getOptionalDisplayName
+import org.cru.godtools.base.R
 import timber.log.Timber
-
-@VisibleForTesting
-internal const val STRING_RES_LANGUAGE_NAME_PREFIX = "language_name_"
 
 val Context.deviceLocale get() = ConfigurationCompat.getLocales(resources.configuration)[0]
 
@@ -30,11 +27,8 @@ fun Locale.getDisplayName(context: Context? = null, defaultName: String? = null,
         }
 }
 
-private fun Context.getLanguageNameStringRes(locale: Locale) =
-    when (val stringId = resources.getIdentifier(locale.languageNameStringRes, "string", packageName)) {
-        0 -> null
-        else -> resources.getString(stringId)
-    }
-
-private val Locale.languageNameStringRes
-    get() = "$STRING_RES_LANGUAGE_NAME_PREFIX${toString().lowercase(Locale.ROOT)}"
+private fun Context.getLanguageNameStringRes(locale: Locale) = when (locale.toLanguageTag()) {
+    "fa" -> getString(R.string.language_name_fa)
+    "fil" -> getString(R.string.language_name_fil)
+    else -> null
+}

--- a/library/base/src/test/kotlin/org/cru/godtools/base/util/LocaleUtilsGetDisplayNameTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/util/LocaleUtilsGetDisplayNameTest.kt
@@ -4,52 +4,45 @@ import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.MockKStubScope
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Locale
-import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import org.junit.Assert.assertEquals
+import kotlin.test.assertEquals
+import org.cru.godtools.base.R
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-
-private const val PACKAGE_NAME = "packageName"
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)
 class LocaleUtilsGetDisplayNameTest {
-    lateinit var context: Context
+    private lateinit var context: Context
 
     @BeforeTest
     fun setup() {
         context = mockk {
-            every { packageName } returns PACKAGE_NAME
             every { resources } returns mockk {
                 every { configuration } returns Configuration()
-                every { getIdentifier(any(), "string", PACKAGE_NAME) } returns 0
             }
             every { createConfigurationContext(any()) } returns this
+            every { getString(R.string.language_name_fa) } returns "Language Name fa"
+            every { getString(R.string.language_name_fil) } returns "Language Name fil"
         }
     }
 
     @Test
     fun preferLanguageNameString() {
-        everyGetLanguageNameStringRes(Locale.ENGLISH) returns "Language Name String"
-
-        assertEquals("Language Name String", Locale.ENGLISH.getDisplayName(context, defaultName = "invalid"))
-        verify(inverse = true) { context.createConfigurationContext(any()) }
+        assertEquals("Language Name fa", Locale.forLanguageTag("fa").getDisplayName(context, defaultName = "invalid"))
+        assertEquals("Language Name fil", Locale.forLanguageTag("fil").getDisplayName(context, defaultName = "invalid"))
     }
 
     @Test
     fun preferLanguageNameStringInDifferentLocale() {
-        everyGetLanguageNameStringRes(Locale.ENGLISH) returns "Language Name String"
-
         assertEquals(
-            "Language Name String",
-            Locale.ENGLISH.getDisplayName(context, defaultName = "invalid", inLocale = Locale.FRENCH)
+            "Language Name fa",
+            Locale.forLanguageTag("fa").getDisplayName(context, defaultName = "invalid", inLocale = Locale.FRENCH)
         )
         verify(exactly = 1) { context.createConfigurationContext(match { it.locale == Locale.FRENCH }) }
     }
@@ -67,18 +60,5 @@ class LocaleUtilsGetDisplayNameTest {
     @Test
     fun fallbackToLanguageCode() {
         assertEquals("x", Locale("x").getDisplayName(context = context))
-    }
-
-    private fun everyGetLanguageNameStringRes(locale: Locale): MockKStubScope<String, String> {
-        val id = Random.nextInt(1, Int.MAX_VALUE)
-        val resources = context.resources
-        every {
-            resources.getIdentifier(
-                "$STRING_RES_LANGUAGE_NAME_PREFIX${locale.toString().lowercase(Locale.ENGLISH)}",
-                "string",
-                PACKAGE_NAME
-            )
-        } returns id
-        return every { resources.getString(id) }
     }
 }


### PR DESCRIPTION
- use .first() instead of .takeWhile().collect()
- move away from resource reflection to resolve custom language names
