### PR TITLE
GT-2198 Add a download progress indicator for the downloadable languages UI

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayout.kt
@@ -2,6 +2,7 @@ package org.cru.godtools.ui.languages.downloadable
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -18,7 +19,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -129,11 +129,18 @@ private fun LanguageListItem(viewModel: LanguageViewModels.LanguageViewModel, mo
             Text(pluralStringResource(R.plurals.language_settings_downloadable_languages_available_tools, tools, tools))
         },
         trailingContent = {
-            Switch(language.isAdded, onCheckedChange = {
-                scope.launch(NonCancellable) {
-                    if (it) viewModel.pin() else viewModel.unpin()
+            val toolsDownloaded by viewModel.toolsDownloaded.collectAsState()
+
+            LanguageDownloadProgressIndicator(
+                language.isAdded,
+                downloaded = toolsDownloaded,
+                total = toolsAvailable,
+                modifier = Modifier.clickable {
+                    scope.launch(NonCancellable) {
+                        if (language.isAdded) viewModel.unpin() else viewModel.pin()
+                    }
                 }
-            })
+            )
         },
         modifier = modifier
     )

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageDownloadProgressIndicator+Preview.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageDownloadProgressIndicator+Preview.kt
@@ -1,0 +1,23 @@
+package org.cru.godtools.ui.languages.downloadable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import org.cru.godtools.base.ui.theme.GodToolsTheme
+
+@Preview
+@Composable
+private fun LanguageDownloadProgressIndicatorNotPinned() {
+    GodToolsTheme { LanguageDownloadProgressIndicator(isPinned = false, downloaded = 0, total = 5) }
+}
+
+@Preview
+@Composable
+private fun LanguageDownloadProgressIndicatorInProgress() {
+    GodToolsTheme { LanguageDownloadProgressIndicator(isPinned = true, downloaded = 2, total = 5) }
+}
+
+@Preview
+@Composable
+private fun LanguageDownloadProgressIndicatorDownloaded() {
+    GodToolsTheme { LanguageDownloadProgressIndicator(isPinned = true, downloaded = 5, total = 5) }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageDownloadProgressIndicator.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageDownloadProgressIndicator.kt
@@ -1,0 +1,65 @@
+package org.cru.godtools.ui.languages.downloadable
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.DownloadForOffline
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun LanguageDownloadProgressIndicator(
+    isPinned: Boolean,
+    downloaded: Int,
+    total: Int,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 24.dp,
+) {
+    val total = total.coerceAtLeast(0)
+    val downloaded = downloaded.coerceIn(0, total)
+    val contentModifier = modifier.size(iconSize)
+
+    when {
+        !isPinned -> Icon(
+            Icons.Outlined.DownloadForOffline,
+            null,
+            modifier = contentModifier,
+            tint = MaterialTheme.colorScheme.outline,
+        )
+        downloaded == total -> Icon(
+            Icons.Outlined.CheckCircle,
+            null,
+            modifier = contentModifier,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        else -> {
+            val progress by animateFloatAsState(
+                label = "Download Progress",
+                targetValue = when (total) {
+                    0 -> 1f
+                    else -> downloaded.toFloat() / total
+                },
+            )
+
+            val iconPadding = iconSize / 12
+            CircularProgressIndicator(
+                progress = progress,
+                color = MaterialTheme.colorScheme.primary,
+                strokeWidth = (iconSize / 2) - iconPadding,
+                modifier = contentModifier
+                    .padding(iconPadding)
+                    .border(iconSize / 12, MaterialTheme.colorScheme.primary, CircleShape)
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageViewModels.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/LanguageViewModels.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.stateIn
 import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.model.Language
+import org.cru.godtools.model.Tool
 
 @HiltViewModel
 class LanguageViewModels @Inject constructor(
@@ -29,6 +30,10 @@ class LanguageViewModels @Inject constructor(
         val language = MutableStateFlow(language)
 
         val numberOfTools = toolsRepository.getToolsFlowForLanguage(code)
+            .map { it.size }
+            .flowOn(Dispatchers.Default)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+        val toolsDownloaded = toolsRepository.getDownloadedToolsFlowByTypesAndLanguage(Tool.Type.NORMAL_TYPES, code)
             .map { it.size }
             .flowOn(Dispatchers.Default)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
@@ -17,6 +17,7 @@ interface ToolsRepository {
     fun getToolsFlowByType(vararg types: Tool.Type) = getToolsFlowByType(types.toSet())
     fun getToolsFlowByType(types: Collection<Tool.Type>): Flow<List<Tool>>
     fun getToolsFlowForLanguage(locale: Locale): Flow<List<Tool>>
+    fun getDownloadedToolsFlowByTypesAndLanguage(types: Collection<Tool.Type>, locale: Locale): Flow<List<Tool>>
     fun getMetaToolsFlow() = getToolsFlowByType(Tool.Type.META)
     fun getLessonsFlow() = getToolsFlowByType(Tool.Type.LESSON)
     fun getNormalToolsFlow() = getToolsFlowByType(Tool.Type.NORMAL_TYPES)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/ToolsDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/ToolsDao.kt
@@ -37,6 +37,15 @@ internal interface ToolsDao {
         "SELECT * FROM tools WHERE type in (:types) AND code IN (SELECT tool FROM translations WHERE locale = :locale)"
     )
     fun getToolsFlowByTypeAndLanguage(types: Collection<Tool.Type>, locale: Locale): Flow<List<ToolEntity>>
+    @Query(
+        """
+            SELECT * FROM tools
+            WHERE
+                type in (:types) AND
+                code IN (SELECT tool FROM translations WHERE locale = :locale AND isDownloaded = 1)
+        """
+    )
+    fun getDownloadedToolsFlowByTypeAndLanguage(types: Collection<Tool.Type>, locale: Locale): Flow<List<ToolEntity>>
     @Query("SELECT * FROM tools")
     suspend fun getToolFavorites(): List<ToolFavorite>
 

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepository.kt
@@ -27,6 +27,8 @@ internal abstract class ToolsRoomRepository(private val db: GodToolsRoomDatabase
         dao.getToolsByTypeFlow(types).map { it.map { it.toModel() } }
     override fun getToolsFlowForLanguage(locale: Locale) =
         dao.getToolsFlowByTypeAndLanguage(Tool.Type.NORMAL_TYPES, locale).map { it.map { it.toModel() } }
+    override fun getDownloadedToolsFlowByTypesAndLanguage(types: Collection<Tool.Type>, locale: Locale) =
+        dao.getDownloadedToolsFlowByTypeAndLanguage(types, locale).map { it.map { it.toModel() } }
 
     override fun toolsChangeFlow(): Flow<Any?> = db.changeFlow("tools")
 

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
@@ -180,6 +180,29 @@ abstract class ToolsRepositoryIT {
     }
     // endregion getToolsFlowForLanguage()
 
+    // region getDownloadedToolsFlowByTypesAndLanguage()
+    @Test
+    fun `getDownloadedToolsFlowByTypesAndLanguage()`() = testScope.runTest {
+        val tool1 = Tool("tool1")
+        val tool2 = Tool("tool2")
+        repository.storeInitialTools(listOf(tool1, tool2))
+        languagesRepository.storeInitialLanguages(listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH)))
+
+        repository.getDownloadedToolsFlowByTypesAndLanguage(Tool.Type.NORMAL_TYPES, Locale.ENGLISH).test {
+            assertTrue(awaitItem().isEmpty())
+
+            translationsRepository.storeInitialTranslations(
+                listOf(
+                    Translation("tool1", Locale.ENGLISH, isDownloaded = true),
+                    Translation("tool2", Locale.ENGLISH, isDownloaded = false),
+                    Translation("tool2", Locale.FRENCH, isDownloaded = true),
+                )
+            )
+            assertThat(awaitItem(), contains(tool(tool1)))
+        }
+    }
+    // endregion getDownloadedToolsFlowByTypesAndLanguage()
+
     // region getFavoriteToolsFlow()
     @Test
     fun `getFavoriteToolsFlow()`() = testScope.runTest {


### PR DESCRIPTION
- add a repository method to get a flow of downloaded tools for types and a language
- create a LanguageDownloadProgressIndicator for the downloadable languages UI
- replace the Switch on the downloaded languages UI with a custom progres indicator
