### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/account/delete/DeleteAccountScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/delete/DeleteAccountScreen.kt
@@ -15,9 +15,9 @@ data object DeleteAccountScreen : Screen {
         abstract val eventSink: (Event) -> Unit
     }
 
-    sealed class Event : CircuitUiEvent {
-        data object DeleteAccount : Event()
-        data object ClearError : Event()
-        data object Close : Event()
+    sealed interface Event : CircuitUiEvent {
+        data object DeleteAccount : Event
+        data object ClearError : Event
+        data object Close : Event
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/app/AppLanguageLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/app/AppLanguageLayout.kt
@@ -47,7 +47,7 @@ import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.ui.languages.LanguageName
 
 internal sealed interface AppLanguageEvent {
-    object NavigateBack : AppLanguageEvent
+    data object NavigateBack : AppLanguageEvent
     class LanguageSelected(val language: Locale) : AppLanguageEvent
 }
 

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/activity/BaseActivity.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/activity/BaseActivity.kt
@@ -71,7 +71,7 @@ abstract class BaseActivity protected constructor() : AppCompatActivity() {
 
     protected open fun showNextFeatureDiscovery() = Unit
 
-    protected fun showFeatureDiscovery(feature: String, force: Boolean = false) {
+    private fun showFeatureDiscovery(feature: String, force: Boolean = false) {
         // short-circuit if this activity is not started
         if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return
 


### PR DESCRIPTION
- make the AppLanguageEvent.NavigateBack object a data object
- make DeleteAccountScreen a sealed interface instead of a sealed class
- reduce visibility of showFeatureDiscovery()
