### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageLayouts.kt
@@ -19,11 +19,20 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 import java.util.Locale
 import org.cru.godtools.base.LocalAppLanguage
+import org.cru.godtools.base.util.getDisplayName
 import org.cru.godtools.model.Language
 
 @Composable
-internal fun LanguageName(locale: Locale) =
-    LanguageName(locale.getDisplayName(LocalAppLanguage.current), locale.getDisplayName(locale))
+internal fun LanguageName(locale: Locale, modifier: Modifier = Modifier) {
+    val appLanguage = LocalAppLanguage.current
+    val context = LocalContext.current
+
+    LanguageName(
+        displayName = remember(context, locale, appLanguage) { locale.getDisplayName(context, inLocale = appLanguage) },
+        nativeName = remember(context, locale) { locale.getDisplayName(context, inLocale = locale) },
+        modifier = modifier,
+    )
+}
 
 @Composable
 internal fun LanguageName(language: Language, modifier: Modifier = Modifier) {

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayoutTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayoutTest.kt
@@ -58,7 +58,10 @@ class DownloadableLanguagesLayoutTest {
     }
 
     @Test
-    @Ignore("performClick() on an IconButton in a SearchBar doesn't appear to work currently in Robolectric.")
+    @Ignore(
+        "performClick() on an IconButton in a SearchBar doesn't appear to work currently in Robolectric. " +
+            "See: https://github.com/robolectric/robolectric/issues/8420"
+    )
     fun `DownloadableLanguagesLayout() - Up navigation`() {
         composeTestRule.setContent {
             DownloadableLanguagesLayout(
@@ -96,7 +99,10 @@ class DownloadableLanguagesLayoutTest {
     }
 
     @Test
-    @Ignore("performClick() on an IconButton in a SearchBar doesn't appear to work currently in Robolectric.")
+    @Ignore(
+        "performClick() on an IconButton in a SearchBar doesn't appear to work currently in Robolectric. " +
+            "See: https://github.com/robolectric/robolectric/issues/8420"
+    )
     fun `DownloadableLanguagesLayout() - Search - Cancel Button`() {
         composeTestRule.setContent {
             DownloadableLanguagesLayout(


### PR DESCRIPTION
- use a Turbine for DeleteAccountPresenterTest
- Properly resolve locale names for the LanguageName composable
- add a reference to the ticket for the broken IconButton test functionality
