### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -201,7 +201,6 @@ private fun ToolDetailsContent(
                 }
 
                 ToolDetailsActions(
-                    viewModel,
                     toolViewModel,
                     onEvent = onEvent,
                     modifier = Modifier.padding(top = 16.dp, horizontal = TOOL_DETAILS_HORIZONTAL_MARGIN)
@@ -286,7 +285,6 @@ private fun ToolDetailsBanner(toolViewModel: ToolViewModels.ToolViewModel, modif
 @Composable
 @VisibleForTesting
 internal fun ToolDetailsActions(
-    viewModel: ToolDetailsViewModel,
     toolViewModel: ToolViewModels.ToolViewModel,
     modifier: Modifier = Modifier,
     onEvent: (ToolDetailsEvent) -> Unit = {},

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayoutTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayoutTest.kt
@@ -34,7 +34,6 @@ class ToolDetailsLayoutTest {
     private val manifestFlow = MutableStateFlow<Manifest?>(null)
     private val availableLanguagesFlow = MutableStateFlow(emptyList<Language>())
 
-    private val viewModel: ToolDetailsViewModel = mockk()
     private val toolViewModel: ToolViewModels.ToolViewModel = mockk {
         every { tool } returns toolFlow
         every { firstTranslation } returns firstTranslationFlow
@@ -54,7 +53,7 @@ class ToolDetailsLayoutTest {
     // region ToolDetailsActions()
     @Test
     fun `ToolDetailsActions() - Tool Training Button - visible when manifest has tips`() {
-        composeTestRule.setContent { ToolDetailsActions(viewModel, toolViewModel) }
+        composeTestRule.setContent { ToolDetailsActions(toolViewModel) }
         manifestFlow.value = mockk { every { hasTips } returns true }
 
         composeTestRule.onNodeWithTag(TEST_TAG_ACTION_TOOL_TRAINING).assertExists()
@@ -62,7 +61,7 @@ class ToolDetailsLayoutTest {
 
     @Test
     fun `ToolDetailsActions() - Tool Training Button - gone when manifest does not have tips`() {
-        composeTestRule.setContent { ToolDetailsActions(viewModel, toolViewModel) }
+        composeTestRule.setContent { ToolDetailsActions(toolViewModel) }
         manifestFlow.value = mockk { every { hasTips } returns false }
 
         composeTestRule.onNodeWithTag(TEST_TAG_ACTION_TOOL_TRAINING).assertDoesNotExist()
@@ -70,7 +69,7 @@ class ToolDetailsLayoutTest {
 
     @Test
     fun `ToolDetailsActions() - Tool Training Button - gone when manifest does not exist`() {
-        composeTestRule.setContent { ToolDetailsActions(viewModel, toolViewModel) }
+        composeTestRule.setContent { ToolDetailsActions(toolViewModel) }
         manifestFlow.value = null
 
         composeTestRule.onNodeWithTag(TEST_TAG_ACTION_TOOL_TRAINING).assertDoesNotExist()

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseMigrationIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseMigrationIT.kt
@@ -8,13 +8,13 @@ import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.util.UUID
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import org.ccci.gto.android.common.util.database.getString
 import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -72,7 +72,7 @@ class GodToolsRoomDatabaseMigrationIT {
                 assertEquals("sync_time", it.getStringOrNull(0))
                 assertEquals(1234, it.getIntOrNull(1))
             }
-            db.query(filesQuery)
+            db.query(filesQuery).close()
         }
     }
 
@@ -94,7 +94,7 @@ class GodToolsRoomDatabaseMigrationIT {
                 assertEquals("sync_time", it.getStringOrNull(0))
                 assertEquals(1234, it.getIntOrNull(1))
             }
-            db.query(toolsQuery)
+            db.query(toolsQuery).close()
         }
     }
 
@@ -116,7 +116,7 @@ class GodToolsRoomDatabaseMigrationIT {
                 assertEquals("sync_time", it.getStringOrNull(0))
                 assertEquals(1234, it.getIntOrNull(1))
             }
-            db.query(attachmentsQuery)
+            db.query(attachmentsQuery).close()
         }
     }
 
@@ -138,7 +138,7 @@ class GodToolsRoomDatabaseMigrationIT {
                 assertEquals("sync_time", it.getStringOrNull(0))
                 assertEquals(1234, it.getIntOrNull(1))
             }
-            db.query(translationsQuery)
+            db.query(translationsQuery).close()
         }
     }
 
@@ -313,7 +313,7 @@ class GodToolsRoomDatabaseMigrationIT {
                 assertEquals("sync_time", it.getStringOrNull(0))
                 assertEquals(1234, it.getIntOrNull(1))
             }
-            db.query(filesQuery)
+            db.query(filesQuery).close()
         }
     }
 }

--- a/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/DownloadProgressTest.kt
+++ b/library/download-manager/src/test/kotlin/org/cru/godtools/downloadmanager/DownloadProgressTest.kt
@@ -1,9 +1,10 @@
 package org.cru.godtools.downloadmanager
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class DownloadProgressTest {
     @Test
@@ -35,9 +36,14 @@ class DownloadProgressTest {
 
     @Test
     fun testEquals() {
-        assertTrue(DownloadProgress.INITIAL == DownloadProgress(0, 0))
-        assertTrue(DownloadProgress(10, 20) == DownloadProgress(10, 20))
-        assertFalse(DownloadProgress(9, 20) == DownloadProgress(10, 20))
-        assertFalse(DownloadProgress(9, 19) == DownloadProgress(9, 20))
+        assertEquals(DownloadProgress.INITIAL, DownloadProgress(0, 0))
+        assertEquals(DownloadProgress(10, 20), DownloadProgress(10, 20))
+        assertNotEquals(DownloadProgress(9, 20), DownloadProgress(10, 20))
+        assertNotEquals(DownloadProgress(9, 19), DownloadProgress(9, 20))
+    }
+
+    @Test
+    fun testEqualsIndeterminate() {
+        assertEquals(DownloadProgress(20, 0), DownloadProgress(10, 0))
     }
 }

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/ExternalSingletonsModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/ExternalSingletonsModule.kt
@@ -10,6 +10,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flowOf
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.tool.service.FollowupService
 import org.cru.godtools.base.tool.service.ManifestManager
@@ -40,6 +41,7 @@ class ExternalSingletonsModule {
     @get:Provides
     val manifestManager by lazy {
         mockk<ManifestManager> {
+            every { getLatestPublishedManifestFlow(any(), any()) } returns flowOf(null)
             every { getLatestPublishedManifestLiveData(any(), any()) } answers { MutableLiveData() }
         }
     }
@@ -55,6 +57,7 @@ class ExternalSingletonsModule {
     val syncService by lazy {
         mockk<GodToolsSyncService> {
             coEvery { syncTool(any(), any()) } returns true
+            coEvery { syncToolSharesAsync() } returns CompletableDeferred(true)
         }
     }
     @get:Provides

--- a/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/MockDatabaseModule.kt
+++ b/ui/article-renderer/src/test/kotlin/org/cru/godtools/tool/article/MockDatabaseModule.kt
@@ -4,6 +4,9 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.just
 import io.mockk.mockk
 import org.cru.godtools.db.DatabaseModule
 import org.cru.godtools.db.repository.LanguagesRepository
@@ -19,7 +22,11 @@ class MockDatabaseModule {
     @get:Provides
     val languagesRepository: LanguagesRepository by lazy { mockk() }
     @get:Provides
-    val toolsRepository: ToolsRepository by lazy { mockk() }
+    val toolsRepository: ToolsRepository by lazy {
+        mockk {
+            coEvery { updateToolViews(any(), any()) } just Runs
+        }
+    }
     @get:Provides
     val translationsRepository: TranslationsRepository by lazy { mockk() }
 }


### PR DESCRIPTION
- ToolDetailsActions() doesn't actually use the ToolDetailsViewModel
- add an DownloadProgress equality test for indeterminate state
- mock some methods that get called in the background
- make sure to close all our test queries
