### PR TITLE
cleanup

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -111,7 +111,7 @@ private fun AccountLayoutHeader(
                 title = {},
                 navigationIcon = {
                     IconButton(onClick = { onEvent(AccountLayoutEvent.ACTION_UP) }) {
-                        Icon(Icons.Filled.ArrowBack, null)
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -41,7 +41,6 @@ import java.util.Locale
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.compose.material3.ui.navigationdrawer.toggle
 import org.ccci.gto.android.common.androidx.compose.material3.ui.pullrefresh.PullRefreshIndicator
-import org.ccci.gto.android.common.androidx.compose.ui.draw.autoMirror
 import org.ccci.gto.android.common.androidx.lifecycle.compose.OnResume
 import org.cru.godtools.R
 import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
@@ -102,7 +101,7 @@ internal fun DashboardLayout(onEvent: (DashboardEvent) -> Unit, viewModel: Dashb
                     navigationIcon = {
                         when {
                             hasBackStack -> IconButton(onClick = { viewModel.popPageStack() }) {
-                                Icon(Icons.Default.ArrowBack, null, Modifier.autoMirror())
+                                Icon(Icons.AutoMirrored.Default.ArrowBack, null)
                             }
                             else -> IconButton(onClick = { scope.launch { drawerState.toggle() } }) {
                                 Icon(Icons.Default.Menu, null)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
@@ -48,25 +48,23 @@ private val DROPDOWN_MAX_WIDTH = 400.dp
 internal const val TEST_TAG_FILTER_DROPDOWN = "filter_dropdown"
 
 @Composable
-internal fun ToolFilters(
-    filters: ToolsScreen.Filters,
-    modifier: Modifier = Modifier,
-    eventSink: (ToolsScreen.Event) -> Unit = {},
-) = Column(modifier.fillMaxWidth()) {
-    Text(
-        stringResource(R.string.dashboard_tools_section_filter_label),
-        style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-    )
+internal fun ToolFilters(filters: ToolsScreen.Filters, modifier: Modifier = Modifier) {
+    Column(modifier.fillMaxWidth()) {
+        Text(
+            stringResource(R.string.dashboard_tools_section_filter_label),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        )
 
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.padding(horizontal = 16.dp)
-    ) {
-        CategoryFilter(filters, modifier = Modifier.weight(1f))
-        LanguageFilter(filters, modifier = Modifier.weight(1f))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(horizontal = 16.dp)
+        ) {
+            CategoryFilter(filters, modifier = Modifier.weight(1f))
+            LanguageFilter(filters, modifier = Modifier.weight(1f))
+        }
     }
 }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -79,7 +79,6 @@ internal fun ToolsLayout(state: ToolsScreen.State, modifier: Modifier = Modifier
         item("tool-filters", "tool-filters") {
             ToolFilters(
                 filters = filters,
-                eventSink = eventSink,
                 modifier = Modifier
                     .animateItemPlacement()
                     .padding(vertical = 16.dp)

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/LanguageSettingsLayout.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.Button
@@ -34,7 +34,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import org.ccci.gto.android.common.androidx.compose.ui.draw.autoMirror
 import org.cru.godtools.R
 import org.cru.godtools.analytics.compose.RecordAnalyticsScreen
 import org.cru.godtools.analytics.model.AnalyticsScreenEvent
@@ -66,7 +65,7 @@ internal fun LanguageSettingsLayout(
                 colors = GodToolsTheme.topAppBarColors,
                 navigationIcon = {
                     IconButton(onClick = { onEvent(LanguageSettingsEvent.NavigateUp) }) {
-                        Icon(Icons.Filled.ArrowBack, null, Modifier.autoMirror())
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
                     }
                 },
             )

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/app/AppLanguageLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/app/AppLanguageLayout.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.AlertDialog
@@ -42,7 +42,6 @@ import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.components.SingletonComponent
 import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
-import org.ccci.gto.android.common.androidx.compose.ui.draw.autoMirror
 import org.ccci.gto.android.common.androidx.compose.ui.text.res.annotatedStringResource
 import org.ccci.gto.android.common.util.content.localize
 import org.cru.godtools.R
@@ -74,7 +73,7 @@ internal fun AppLanguageLayout(state: AppLanguageScreen.State, modifier: Modifie
                         onClick = { eventSink(Event.NavigateBack) },
                         modifier = Modifier.testTag(TEST_TAG_ACTION_BACK),
                     ) {
-                        Icon(Icons.Filled.ArrowBack, null, Modifier.autoMirror())
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
                     }
                 },
                 trailingIcon = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayout.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,7 +80,7 @@ fun DownloadableLanguagesLayout(
                         onClick = { onEvent(DownloadableLanguagesEvent.NavigateUp) },
                         modifier = Modifier.testTag(TEST_TAG_NAVIGATE_UP),
                     ) {
-                        Icon(Icons.Filled.ArrowBack, null)
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
                     }
                 },
                 trailingIcon = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -16,7 +16,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -98,7 +98,7 @@ fun ToolDetailsLayout(viewModel: ToolDetailsViewModel, onEvent: (ToolDetailsEven
                 title = {},
                 navigationIcon = {
                     IconButton(onClick = { onEvent(ToolDetailsEvent.NavigateUp) }) {
-                        Icon(Icons.Filled.ArrowBack, null)
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -107,7 +106,6 @@ fun PreloadTool(tool: Tool) {
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 fun LessonToolCard(
     toolCode: String,
     modifier: Modifier = Modifier,
@@ -198,7 +196,6 @@ fun ToolCard(
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 fun ToolCard(
     state: ToolCard.State,
     modifier: Modifier = Modifier,
@@ -331,7 +328,6 @@ fun SquareToolCard(
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 fun SquareToolCard(
     state: ToolCard.State,
     modifier: Modifier = Modifier,
@@ -411,7 +407,6 @@ fun SquareToolCard(
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 internal fun VariantToolCard(
     viewModel: ToolViewModels.ToolViewModel,
     isSelected: Boolean,

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/tools/ToolCardActionsTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/tools/ToolCardActionsTest.kt
@@ -1,13 +1,16 @@
 package org.cru.godtools.ui.tools
 
 import android.app.Application
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.slack.circuit.test.TestEventSink
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
@@ -20,7 +23,7 @@ class ToolCardActionsTest {
     private val events = TestEventSink<ToolCard.Event>()
 
     @Test
-    fun `ToolCardActions() - Open Tool`() {
+    fun `Button - Open Tool`() {
         val state = ToolCard.State(eventSink = events)
         composeTestRule.setContent { ToolCardActions(state) }
 
@@ -29,11 +32,29 @@ class ToolCardActionsTest {
     }
 
     @Test
-    fun `ToolCardActions() - Tool Details`() {
+    fun `Button - Tool Details`() {
         val state = ToolCard.State(eventSink = events)
         composeTestRule.setContent { ToolCardActions(state) }
 
         composeTestRule.onNodeWithText("Details", substring = true, ignoreCase = true).performClick()
         events.assertEvent(ToolCard.Event.OpenToolDetails)
+    }
+
+    @Test
+    fun `Recompose - eventSink updates`() = runTest {
+        val stateFlow = MutableStateFlow(ToolCard.State())
+        composeTestRule.setContent { ToolCardActions(stateFlow.collectAsState().value) }
+
+        composeTestRule.onNodeWithText("Open", substring = true, ignoreCase = true).performClick()
+        composeTestRule.onNodeWithText("Details", substring = true, ignoreCase = true).performClick()
+        events.assertNoEvents()
+
+        stateFlow.value = ToolCard.State(eventSink = events)
+        composeTestRule.onNodeWithText("Open", substring = true, ignoreCase = true).performClick()
+        composeTestRule.onNodeWithText("Details", substring = true, ignoreCase = true).performClick()
+        events.assertEvents(
+            ToolCard.Event.OpenTool,
+            ToolCard.Event.OpenToolDetails
+        )
     }
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Language.kt
@@ -39,11 +39,15 @@ data class Language(
         private fun Collection<Language>.toDisplayNameSortedMap(context: Context, displayLocale: Locale) =
             associateBy { it.getDisplayName(context, displayLocale) }.toSortedMap(displayLocale.getPrimaryCollator())
 
-        fun Collection<Language>.sortedByDisplayName(context: Context, displayLocale: Locale = context.appLanguage) =
-            toDisplayNameSortedMap(context, displayLocale).values.toList()
+        fun Collection<Language>.sortedByDisplayName(
+            context: Context,
+            displayLocale: Locale = context.appLanguage,
+        ): List<Language> = toDisplayNameSortedMap(context, displayLocale).values.toList()
 
-        fun Collection<Language>.getSortedDisplayNames(context: Context, displayLocale: Locale = context.appLanguage) =
-            toDisplayNameSortedMap(context, displayLocale).keys.toList()
+        fun Collection<Language>.getSortedDisplayNames(
+            context: Context,
+            displayLocale: Locale = context.appLanguage,
+        ): List<String> = toDisplayNameSortedMap(context, displayLocale).keys.toList()
 
         fun Collection<Language>.filterByDisplayAndNativeName(
             query: String,

--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -98,7 +98,7 @@ private inline fun TutorialAppBar(
     navigationIcon = {
         if (pageSet.showUpNavigation) {
             IconButton(onClick = { onTutorialAction(Action.BACK) }) {
-                Icon(Icons.Filled.ArrowBack, null)
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
             }
         }
     },


### PR DESCRIPTION
- add explicit types to avoid java type pollution
- add a unit test for recomposing ToolCardActions() with a new eventSink
- remove some unnecessary OptIn annotations
- remove unused eventSink parameter
