### PR TITLE
cleanup

### DIFF
--- a/app/config/ktlint/baseline.xml
+++ b/app/config/ktlint/baseline.xml
@@ -34,7 +34,6 @@
         <error line="118" column="13" source="compose:vm-forwarding-check" />
     </file>
     <file name="src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt">
-        <error line="94" column="5" source="compose:modifier-missing-check" />
-        <error line="235" column="45" source="compose:vm-forwarding-check" />
+        <error line="239" column="45" source="compose:vm-forwarding-check" />
     </file>
 </baseline>

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/DashboardLayout.kt
@@ -93,7 +93,7 @@ internal fun DashboardLayout(onEvent: (DashboardEvent) -> Unit, viewModel: Dashb
     val snackbarHostState = remember { SnackbarHostState() }
     AppUpdateSnackbar(snackbarHostState)
 
-    DrawerMenuLayout(drawerState) {
+    DrawerMenuLayout(drawerState = drawerState) {
         Scaffold(
             topBar = {
                 TopAppBar(

--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
@@ -71,6 +71,7 @@ import org.cru.godtools.ui.login.startLoginActivity
 
 @Composable
 fun DrawerMenuLayout(
+    modifier: Modifier = Modifier,
     drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
     content: @Composable () -> Unit,
 ) {
@@ -86,7 +87,8 @@ fun DrawerMenuLayout(
                 dismissDrawer = { scope.launch { drawerState.close() } }
             )
         },
-        content = content
+        modifier = modifier,
+        content = content,
     )
 }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
@@ -8,20 +8,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
+import androidx.compose.material.icons.automirrored.outlined.LiveHelp
+import androidx.compose.material.icons.automirrored.outlined.Login
+import androidx.compose.material.icons.automirrored.outlined.Logout
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.Description
-import androidx.compose.material.icons.outlined.FormatListBulleted
-import androidx.compose.material.icons.outlined.LiveHelp
-import androidx.compose.material.icons.outlined.Login
-import androidx.compose.material.icons.outlined.Logout
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.PersonRemove
 import androidx.compose.material.icons.outlined.Policy
 import androidx.compose.material.icons.outlined.RateReview
 import androidx.compose.material.icons.outlined.School
-import androidx.compose.material.icons.outlined.Send
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.DrawerState
@@ -141,7 +141,7 @@ private fun DrawerContentLayout(
                 val isAuthenticated by viewModel.isAuthenticatedFlow.collectAsState()
                 if (!isAuthenticated) {
                     NavigationDrawerItem(
-                        icon = { Icon(Icons.Outlined.Login, null) },
+                        icon = { Icon(Icons.AutoMirrored.Outlined.Login, null) },
                         label = { Text(stringResource(R.string.menu_login)) },
                         selected = false,
                         onClick = {
@@ -169,7 +169,7 @@ private fun DrawerContentLayout(
                         }
                     )
                     NavigationDrawerItem(
-                        icon = { Icon(Icons.Outlined.Logout, null) },
+                        icon = { Icon(Icons.AutoMirrored.Outlined.Logout, null) },
                         label = { Text(stringResource(R.string.menu_logout)) },
                         selected = false,
                         onClick = {
@@ -194,7 +194,7 @@ private fun DrawerContentLayout(
             // region Support
             NavigationDrawerHeadline(label = { Text(stringResource(R.string.menu_heading_support)) })
             NavigationDrawerItem(
-                icon = { Icon(Icons.Outlined.Send, null) },
+                icon = { Icon(Icons.AutoMirrored.Outlined.Send, null) },
                 label = { Text(stringResource(R.string.menu_feedback)) },
                 selected = false,
                 onClick = {
@@ -212,7 +212,7 @@ private fun DrawerContentLayout(
                 }
             )
             NavigationDrawerItem(
-                icon = { Icon(Icons.Outlined.LiveHelp, null) },
+                icon = { Icon(Icons.AutoMirrored.Outlined.LiveHelp, null) },
                 label = { Text(stringResource(R.string.menu_question)) },
                 selected = false,
                 onClick = {
@@ -265,7 +265,7 @@ private fun DrawerContentLayout(
             // region About
             NavigationDrawerHeadline(label = { Text(stringResource(R.string.menu_heading_about)) })
             NavigationDrawerItem(
-                icon = { Icon(Icons.Outlined.FormatListBulleted, null) },
+                icon = { Icon(Icons.AutoMirrored.Outlined.FormatListBulleted, null) },
                 label = { Text(stringResource(R.string.menu_terms_of_use)) },
                 selected = false,
                 onClick = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuLayout.kt
@@ -24,9 +24,9 @@ import androidx.compose.material.icons.outlined.School
 import androidx.compose.material.icons.outlined.Send
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.Translate
-import androidx.compose.material3.Divider
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -132,7 +132,7 @@ private fun DrawerContentLayout(
                     dismissDrawer()
                 }
             )
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             // endregion Get Started
 
             // region Account
@@ -187,7 +187,7 @@ private fun DrawerContentLayout(
                         },
                     )
                 }
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             }
             // endregion Account
 
@@ -220,7 +220,7 @@ private fun DrawerContentLayout(
                     dismissDrawer()
                 }
             )
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             // endregion Support
 
             // region Share
@@ -259,7 +259,7 @@ private fun DrawerContentLayout(
                     dismissDrawer()
                 }
             )
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             // endregion Share
 
             // region About
@@ -300,7 +300,7 @@ private fun DrawerContentLayout(
                     dismissDrawer()
                 }
             )
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             // endregion About
 
             NavigationDrawerHeadline(label = {

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsAbout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsAbout.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.ripple.rememberRipple
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -75,7 +75,7 @@ internal fun ToolDetailsAbout(toolViewModel: ToolViewModels.ToolViewModel, modif
                 derivedStateOf { translation.value?.toolDetailsConversationStarters.orEmpty() }
             }
             if (conversationStarters.isNotBlank()) {
-                Divider()
+                HorizontalDivider()
                 ToolDetailsAboutAccordionSection(
                     header = stringResource(R.string.tool_details_section_description_conversation_starters),
                     expanded = expandedSection == ToolDetailsAboutAccordionSection.CONVERSATION_STARTERS,
@@ -88,7 +88,7 @@ internal fun ToolDetailsAbout(toolViewModel: ToolViewModels.ToolViewModel, modif
             // Outline section
             val outline by remember { derivedStateOf { translation.value?.toolDetailsOutline.orEmpty() } }
             if (outline.isNotBlank()) {
-                Divider()
+                HorizontalDivider()
                 ToolDetailsAboutAccordionSection(
                     header = stringResource(R.string.tool_details_section_description_outline),
                     expanded = expandedSection == ToolDetailsAboutAccordionSection.OUTLINE,
@@ -103,7 +103,7 @@ internal fun ToolDetailsAbout(toolViewModel: ToolViewModels.ToolViewModel, modif
                 derivedStateOf { translation.value?.toolDetailsBibleReferences.orEmpty() }
             }
             if (bibleReferences.isNotBlank()) {
-                Divider()
+                HorizontalDivider()
                 ToolDetailsAboutAccordionSection(
                     header = stringResource(R.string.tool_details_section_description_bible_references),
                     expanded = expandedSection == ToolDetailsAboutAccordionSection.BIBLE_REFERENCES,
@@ -114,13 +114,13 @@ internal fun ToolDetailsAbout(toolViewModel: ToolViewModels.ToolViewModel, modif
             }
 
             // Languages section
-            Divider()
+            HorizontalDivider()
             ToolDetailsLanguages(
                 toolViewModel,
                 expanded = expandedSection == ToolDetailsAboutAccordionSection.LANGUAGES,
                 onToggleLanguages = { toggleSection(ToolDetailsAboutAccordionSection.LANGUAGES) },
             )
-            Divider()
+            HorizontalDivider()
         }
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -91,7 +91,11 @@ sealed interface ToolDetailsEvent {
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun ToolDetailsLayout(viewModel: ToolDetailsViewModel, onEvent: (ToolDetailsEvent) -> Unit = {}) = DrawerMenuLayout {
+fun ToolDetailsLayout(
+    viewModel: ToolDetailsViewModel,
+    modifier: Modifier = Modifier,
+    onEvent: (ToolDetailsEvent) -> Unit = {},
+) = DrawerMenuLayout(modifier) {
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -213,7 +213,7 @@ private fun ToolDetailsContent(
                 TabRow(
                     selectedTabIndex = pagerState.currentPage,
                     indicator = { positions ->
-                        TabRowDefaults.Indicator(Modifier.pagerTabIndicatorOffset(pagerState, positions))
+                        TabRowDefaults.SecondaryIndicator(Modifier.pagerTabIndicatorOffset(pagerState, positions))
                     },
                     divider = {},
                     modifier = Modifier.padding(horizontal = TOOL_DETAILS_HORIZONTAL_MARGIN)

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/SquareToolCard.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/SquareToolCard.kt
@@ -1,0 +1,169 @@
+package org.cru.godtools.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.ccci.gto.android.common.androidx.compose.foundation.text.minLinesHeight
+import org.ccci.gto.android.common.androidx.compose.ui.draw.invisibleIf
+import org.cru.godtools.base.ui.util.ProvideLayoutDirectionFromLocale
+
+@Composable
+fun SquareToolCard(
+    toolCode: String,
+    modifier: Modifier = Modifier,
+    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
+    showCategory: Boolean = true,
+    showSecondLanguage: Boolean = false,
+    showActions: Boolean = true,
+    floatParallelLanguageUp: Boolean = true,
+    confirmRemovalFromFavorites: Boolean = false,
+    onEvent: (ToolCardEvent) -> Unit = {},
+) {
+    val tool by viewModel.tool.collectAsState()
+    val firstTranslation by viewModel.firstTranslation.collectAsState()
+    val secondTranslation by viewModel.secondTranslation.collectAsState()
+
+    val eventSink: (ToolCard.Event) -> Unit = remember(viewModel) {
+        {
+            when (it) {
+                ToolCard.Event.Click -> onEvent(
+                    ToolCardEvent.Click(
+                        tool = tool?.code,
+                        type = tool?.type,
+                        lang1 = firstTranslation.value?.languageCode,
+                        lang2 = secondTranslation?.languageCode
+                    )
+                )
+                ToolCard.Event.OpenTool -> onEvent(
+                    ToolCardEvent.OpenTool(
+                        tool = tool?.code,
+                        type = tool?.type,
+                        lang1 = firstTranslation.value?.languageCode,
+                        lang2 = secondTranslation?.languageCode
+                    )
+                )
+                ToolCard.Event.OpenToolDetails -> onEvent(ToolCardEvent.OpenToolDetails(toolCode))
+                ToolCard.Event.PinTool -> viewModel.pinTool()
+                ToolCard.Event.UnpinTool -> viewModel.unpinTool()
+            }
+        }
+    }
+
+    SquareToolCard(
+        state = viewModel.toState(eventSink = eventSink),
+        modifier = modifier,
+        showCategory = showCategory,
+        showSecondLanguage = showSecondLanguage,
+        showActions = showActions,
+        floatParallelLanguageUp = floatParallelLanguageUp,
+        confirmRemovalFromFavorites = confirmRemovalFromFavorites,
+    )
+}
+
+@Composable
+fun SquareToolCard(
+    state: ToolCard.State,
+    modifier: Modifier = Modifier,
+    showCategory: Boolean = true,
+    showSecondLanguage: Boolean = false,
+    showActions: Boolean = true,
+    floatParallelLanguageUp: Boolean = true,
+    confirmRemovalFromFavorites: Boolean = false,
+) {
+    val downloadProgress by rememberUpdatedState(state.downloadProgress)
+    val eventSink by rememberUpdatedState(state.eventSink)
+
+    ProvideLayoutDirectionFromLocale(locale = { state.translation?.languageCode }) {
+        ElevatedCard(
+            elevation = toolCardElevation,
+            onClick = { eventSink(ToolCard.Event.Click) },
+            modifier = modifier.width(189.dp)
+        ) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                ToolBanner(
+                    state = state,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(189f / 128f)
+                )
+                FavoriteAction(
+                    state = state,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    confirmRemoval = confirmRemovalFromFavorites
+                )
+                DownloadProgressIndicator(
+                    { downloadProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomCenter)
+                )
+            }
+            Column(modifier = Modifier.padding(16.dp)) {
+                Box {
+                    Column {
+                        ToolName(state, minLines = 1, maxLines = 2, modifier = Modifier.fillMaxWidth())
+                        if (showCategory) {
+                            ToolCategory(
+                                state,
+                                modifier = Modifier
+                                    .padding(top = 2.dp)
+                                    .fillMaxWidth()
+                            )
+                        }
+                        if (showSecondLanguage && floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
+                    }
+
+                    // Reserve the maximum height consistently across all cards
+                    Column(modifier = Modifier.invisibleIf(true)) {
+                        Spacer(modifier = Modifier.minLinesHeight(2, state.toolNameStyle))
+                        if (showCategory) {
+                            Spacer(
+                                modifier = Modifier
+                                    .padding(top = 2.dp)
+                                    .minLinesHeight(1, toolCategoryStyle)
+                            )
+                        }
+                        if (showSecondLanguage && floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
+                    }
+                }
+                if (showSecondLanguage && !floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
+
+                if (showActions) {
+                    ToolCardActions(
+                        state,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SquareToolCardSecondLanguage(state: ToolCard.State) = ToolCardInfoContent {
+    val secondTranslation by rememberUpdatedState(state.secondTranslation)
+    val available by remember { derivedStateOf { secondTranslation != null } }
+
+    AvailableInLanguage(
+        state.secondLanguage,
+        horizontalArrangement = Arrangement.Start,
+        modifier = Modifier
+            .padding(top = 2.dp)
+            .invisibleIf { !available }
+    )
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tools/ToolCardLayouts.kt
@@ -6,12 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CardDefaults.elevatedCardElevation
@@ -59,11 +57,11 @@ import org.cru.godtools.model.getTagline
 
 internal const val TEST_TAG_TOOL_CATEGORY = "tool_category"
 
-private val toolViewModels: ToolViewModels @Composable get() = viewModel()
+internal val toolViewModels: ToolViewModels @Composable get() = viewModel()
 
-private val toolCardElevation @Composable get() = elevatedCardElevation(defaultElevation = 4.dp)
+internal val toolCardElevation @Composable get() = elevatedCardElevation(defaultElevation = 4.dp)
 
-private val ToolCard.State.toolNameStyle: TextStyle
+internal val ToolCard.State.toolNameStyle: TextStyle
     @Composable
     get() {
         val baseStyle = MaterialTheme.typography.titleMedium
@@ -79,7 +77,7 @@ private val ToolCard.State.toolNameStyle: TextStyle
     }
 
 private val toolDescriptionStyle @Composable get() = MaterialTheme.typography.bodyMedium
-private val toolCategoryStyle @Composable get() = MaterialTheme.typography.bodySmall
+internal val toolCategoryStyle @Composable get() = MaterialTheme.typography.bodySmall
 private val toolCardInfoLabelColor: Color @Composable get() {
     val baseColor = LocalContentColor.current
     return remember(baseColor) { with(baseColor) { copy(alpha = alpha * 0.6f) } }
@@ -275,138 +273,6 @@ fun ToolCard(
 }
 
 @Composable
-fun SquareToolCard(
-    toolCode: String,
-    modifier: Modifier = Modifier,
-    viewModel: ToolViewModels.ToolViewModel = toolViewModels[toolCode],
-    showCategory: Boolean = true,
-    showSecondLanguage: Boolean = false,
-    showActions: Boolean = true,
-    floatParallelLanguageUp: Boolean = true,
-    confirmRemovalFromFavorites: Boolean = false,
-    onEvent: (ToolCardEvent) -> Unit = {},
-) {
-    val tool by viewModel.tool.collectAsState()
-    val firstTranslation by viewModel.firstTranslation.collectAsState()
-    val secondTranslation by viewModel.secondTranslation.collectAsState()
-
-    val eventSink: (ToolCard.Event) -> Unit = remember(viewModel) {
-        {
-            when (it) {
-                ToolCard.Event.Click -> onEvent(
-                    ToolCardEvent.Click(
-                        tool = tool?.code,
-                        type = tool?.type,
-                        lang1 = firstTranslation.value?.languageCode,
-                        lang2 = secondTranslation?.languageCode
-                    )
-                )
-                ToolCard.Event.OpenTool -> onEvent(
-                    ToolCardEvent.OpenTool(
-                        tool = tool?.code,
-                        type = tool?.type,
-                        lang1 = firstTranslation.value?.languageCode,
-                        lang2 = secondTranslation?.languageCode
-                    )
-                )
-                ToolCard.Event.OpenToolDetails -> onEvent(ToolCardEvent.OpenToolDetails(toolCode))
-                ToolCard.Event.PinTool -> viewModel.pinTool()
-                ToolCard.Event.UnpinTool -> viewModel.unpinTool()
-            }
-        }
-    }
-
-    SquareToolCard(
-        state = viewModel.toState(eventSink = eventSink),
-        modifier = modifier,
-        showCategory = showCategory,
-        showSecondLanguage = showSecondLanguage,
-        showActions = showActions,
-        floatParallelLanguageUp = floatParallelLanguageUp,
-        confirmRemovalFromFavorites = confirmRemovalFromFavorites,
-    )
-}
-
-@Composable
-fun SquareToolCard(
-    state: ToolCard.State,
-    modifier: Modifier = Modifier,
-    showCategory: Boolean = true,
-    showSecondLanguage: Boolean = false,
-    showActions: Boolean = true,
-    floatParallelLanguageUp: Boolean = true,
-    confirmRemovalFromFavorites: Boolean = false,
-) {
-    val downloadProgress by rememberUpdatedState(state.downloadProgress)
-    val eventSink by rememberUpdatedState(state.eventSink)
-
-    ProvideLayoutDirectionFromLocale(locale = { state.translation?.languageCode }) {
-        ElevatedCard(
-            elevation = toolCardElevation,
-            onClick = { eventSink(ToolCard.Event.Click) },
-            modifier = modifier.width(189.dp)
-        ) {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                ToolBanner(
-                    state = state,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(189f / 128f)
-                )
-                FavoriteAction(
-                    state = state,
-                    modifier = Modifier.align(Alignment.TopEnd),
-                    confirmRemoval = confirmRemovalFromFavorites
-                )
-                DownloadProgressIndicator(
-                    { downloadProgress },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                )
-            }
-            Column(modifier = Modifier.padding(16.dp)) {
-                Box {
-                    Column {
-                        ToolName(state, minLines = 1, maxLines = 2, modifier = Modifier.fillMaxWidth())
-                        if (showCategory) {
-                            ToolCategory(
-                                state,
-                                modifier = Modifier
-                                    .padding(top = 2.dp)
-                                    .fillMaxWidth()
-                            )
-                        }
-                        if (showSecondLanguage && floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
-                    }
-
-                    // Reserve the maximum height consistently across all cards
-                    Column(modifier = Modifier.invisibleIf(true)) {
-                        Spacer(modifier = Modifier.minLinesHeight(2, state.toolNameStyle))
-                        if (showCategory) {
-                            Spacer(
-                                modifier = Modifier
-                                    .padding(top = 2.dp)
-                                    .minLinesHeight(1, toolCategoryStyle)
-                            )
-                        }
-                        if (showSecondLanguage && floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
-                    }
-                }
-                if (showSecondLanguage && !floatParallelLanguageUp) SquareToolCardSecondLanguage(state)
-
-                if (showActions) {
-                    ToolCardActions(
-                        state,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
 internal fun VariantToolCard(
     viewModel: ToolViewModels.ToolViewModel,
     isSelected: Boolean,
@@ -475,7 +341,7 @@ internal fun VariantToolCard(
 }
 
 @Composable
-private fun ToolBanner(state: ToolCard.State, modifier: Modifier = Modifier) = AsyncImage(
+internal fun ToolBanner(state: ToolCard.State, modifier: Modifier = Modifier) = AsyncImage(
     model = state.banner,
     contentDescription = null,
     contentScale = ContentScale.Crop,
@@ -483,7 +349,7 @@ private fun ToolBanner(state: ToolCard.State, modifier: Modifier = Modifier) = A
 )
 
 @Composable
-private fun ToolName(
+internal fun ToolName(
     state: ToolCard.State,
     modifier: Modifier = Modifier,
     minLines: Int = 1,
@@ -501,7 +367,7 @@ private fun ToolName(
 }
 
 @Composable
-private fun ToolCategory(state: ToolCard.State, modifier: Modifier = Modifier) {
+internal fun ToolCategory(state: ToolCard.State, modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val tool by rememberUpdatedState(state.tool)
     val translation by rememberUpdatedState(state.translation)
@@ -517,22 +383,8 @@ private fun ToolCategory(state: ToolCard.State, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun ToolCardInfoContent(content: @Composable () -> Unit) = CompositionLocalProvider(
+internal fun ToolCardInfoContent(content: @Composable () -> Unit) = CompositionLocalProvider(
     LocalContentColor provides toolCardInfoLabelColor,
     LocalTextStyle provides toolCardInfoLabelStyle,
     content = content
 )
-
-@Composable
-private fun SquareToolCardSecondLanguage(state: ToolCard.State) = ToolCardInfoContent {
-    val secondTranslation by rememberUpdatedState(state.secondTranslation)
-    val available by remember { derivedStateOf { secondTranslation != null } }
-
-    AvailableInLanguage(
-        state.secondLanguage,
-        horizontalArrangement = Arrangement.Start,
-        modifier = Modifier
-            .padding(top = 2.dp)
-            .invisibleIf { !available }
-    )
-}


### PR DESCRIPTION
- move SquareToolCard layouts to their own source file
- provide a Modifier parameter for the ToolDetailsLayout
- use SecondaryIndicator instead of Indicator
- replace deprecated Divider with HorizontalDivider
- switch to auto-mirrored icons
