### PR TITLE
Create a DrawerMenuPresenter for use in Circuit layouts

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuPresenter.kt
@@ -1,0 +1,42 @@
+package org.cru.godtools.ui.drawer
+
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.slack.circuit.runtime.presenter.Presenter
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+import org.cru.godtools.account.GodToolsAccountManager
+import org.cru.godtools.ui.drawer.DrawerMenuScreen.Event
+import org.cru.godtools.ui.drawer.DrawerMenuScreen.State
+
+@Singleton
+class DrawerMenuPresenter @Inject constructor(
+    private val accountManager: GodToolsAccountManager,
+) : Presenter<State> {
+    @Composable
+    override fun present(): State {
+        val scope = rememberCoroutineScope()
+        val drawerState = rememberDrawerState(DrawerValue.Closed)
+
+        return State(
+            drawerState = drawerState,
+            isLoggedIn = remember { accountManager.isAuthenticatedFlow }.collectAsState(false).value,
+            eventSink = {
+                when (it) {
+                    Event.Logout -> scope.launch {
+                        launch(NonCancellable) { accountManager.logout() }
+                        drawerState.close()
+                    }
+
+                    Event.DismissDrawer -> scope.launch { drawerState.close() }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/drawer/DrawerMenuScreen.kt
@@ -1,0 +1,24 @@
+package org.cru.godtools.ui.drawer
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data object DrawerMenuScreen : Screen {
+    data class State(
+        val drawerState: DrawerState = DrawerState(DrawerValue.Closed),
+        val isLoggedIn: Boolean = false,
+        val eventSink: (Event) -> Unit = {},
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data object Logout : Event
+
+        // TODO: this is a temporary event to aid in migrating the logic to Circuit
+        data object DismissDrawer : Event
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayout.kt
@@ -88,7 +88,7 @@ internal const val TEST_TAG_ACTION_TOOL_TRAINING = "action_tool_training"
 @Composable
 @CircuitInject(ToolDetailsScreen::class, SingletonComponent::class)
 @OptIn(ExperimentalMaterial3Api::class)
-fun ToolDetailsLayout(state: State, modifier: Modifier = Modifier) = DrawerMenuLayout(modifier) {
+fun ToolDetailsLayout(state: State, modifier: Modifier = Modifier) = DrawerMenuLayout(state.drawerState, modifier) {
     val hasShortcut by rememberUpdatedState(state.hasShortcut)
     val eventSink by rememberUpdatedState(state.eventSink)
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenter.kt
@@ -59,6 +59,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.cru.godtools.sync.GodToolsSyncService
+import org.cru.godtools.ui.drawer.DrawerMenuPresenter
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.Event
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.Page
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.State
@@ -81,6 +82,7 @@ class ToolDetailsPresenter @AssistedInject constructor(
     private val settings: Settings,
     private val shortcutManager: GodToolsShortcutManager,
     private val syncService: GodToolsSyncService,
+    private val drawerMenuPresenter: DrawerMenuPresenter,
     private val toolCardPresenter: ToolCardPresenter,
     @Named(IS_CONNECTED_STATE_FLOW)
     private val isConnected: StateFlow<Boolean>,
@@ -163,6 +165,7 @@ class ToolDetailsPresenter @AssistedInject constructor(
             pages = rememberPages(hasVariants = variants.isNotEmpty()),
             availableLanguages = rememberAvailableLanguages(toolCode),
             variants = variants,
+            drawerState = drawerMenuPresenter.present(),
             eventSink = eventSink
         )
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsScreen.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.Translation
 import org.cru.godtools.shared.tool.parser.model.Manifest
+import org.cru.godtools.ui.drawer.DrawerMenuScreen
 import org.cru.godtools.ui.tools.ToolCard
 
 @Parcelize
@@ -33,6 +34,7 @@ class ToolDetailsScreen(val initialTool: String, val secondLanguage: Locale? = n
         val pages: ImmutableList<Page> = persistentListOf(Page.DESCRIPTION),
         val availableLanguages: ImmutableList<String> = persistentListOf(),
         val variants: ImmutableList<ToolCard.State> = persistentListOf(),
+        val drawerState: DrawerMenuScreen.State = DrawerMenuScreen.State(),
         val eventSink: (Event) -> Unit = {},
     ) : CircuitUiState
 

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/drawer/DrawerMenuPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/drawer/DrawerMenuPresenterTest.kt
@@ -1,0 +1,59 @@
+package org.cru.godtools.ui.drawer
+
+import android.app.Application
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.slack.circuit.test.test
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.cru.godtools.TestUtils.clearAndroidUiDispatcher
+import org.cru.godtools.account.GodToolsAccountManager
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = Application::class)
+class DrawerMenuPresenterTest {
+    private val isAuthenticatedFlow = MutableStateFlow(false)
+
+    private val accountManager: GodToolsAccountManager = mockk {
+        every { isAuthenticatedFlow } returns this@DrawerMenuPresenterTest.isAuthenticatedFlow
+    }
+
+    private val presenter = DrawerMenuPresenter(
+        accountManager = accountManager
+    )
+
+    @AfterTest
+    fun cleanup() = clearAndroidUiDispatcher()
+
+    @Test
+    fun `State - isLoggedIn`() = runTest {
+        presenter.test {
+            assertFalse(expectMostRecentItem().isLoggedIn)
+
+            isAuthenticatedFlow.value = true
+            assertTrue(expectMostRecentItem().isLoggedIn)
+        }
+    }
+
+    @Test
+    fun `Event - Logout`() = runTest {
+        isAuthenticatedFlow.value = true
+        coEvery { accountManager.logout() } just Runs
+
+        presenter.test {
+            expectMostRecentItem().eventSink(DrawerMenuScreen.Event.Logout)
+            coVerify { accountManager.logout() }
+        }
+    }
+}

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayoutTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsLayoutTest.kt
@@ -14,12 +14,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.slack.circuit.test.TestEventSink
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.flow.flowOf
 import org.cru.godtools.base.ui.compose.LocalEventBus
-import org.cru.godtools.ui.drawer.DrawerViewModel
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.Event
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.State
 import org.greenrobot.eventbus.EventBus
@@ -34,19 +31,6 @@ class ToolDetailsLayoutTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val events = TestEventSink<Event>()
-
-    @BeforeTest
-    fun setup() {
-        // TODO: remove this once we migrate DrawerLayout to Circuit
-        composeTestRule.activity.viewModelStore.put(
-            "androidx.lifecycle.ViewModelProvider.DefaultKey:${DrawerViewModel::class.java.canonicalName}",
-            DrawerViewModel(
-                accountManager = mockk {
-                    every { isAuthenticatedFlow } returns flowOf(false)
-                }
-            ),
-        )
-    }
 
     private fun renderToolDetailsLayout(state: State = State(eventSink = events)) = composeTestRule.setContent {
         CompositionLocalProvider(

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenterTest.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.ui.tooldetails
 
 import android.app.Application
 import android.content.Context
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jeppeman.mockposable.mockk.everyComposable
@@ -57,6 +59,8 @@ import org.cru.godtools.model.randomTranslation
 import org.cru.godtools.shortcuts.GodToolsShortcutManager
 import org.cru.godtools.shortcuts.PendingShortcut
 import org.cru.godtools.sync.GodToolsSyncService
+import org.cru.godtools.ui.drawer.DrawerMenuPresenter
+import org.cru.godtools.ui.drawer.DrawerMenuScreen
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen.Event
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardPresenter
@@ -98,6 +102,9 @@ class ToolDetailsPresenterTest {
 
         excludeRecords { this@mockk.equals(any()) }
     }
+    private val drawerMenuPresenter: DrawerMenuPresenter = mockk {
+        everyComposable { present() } returns DrawerMenuScreen.State()
+    }
     private val eventBus: EventBus = mockk(relaxUnitFun = true)
     private val fileSystem: ToolFileSystem = mockk()
     private val manifestManager: ManifestManager = mockk {
@@ -138,6 +145,7 @@ class ToolDetailsPresenterTest {
         shortcutManager = shortcutManager,
         syncService = syncService,
         isConnected = isConnected,
+        drawerMenuPresenter = drawerMenuPresenter,
         toolCardPresenter = toolCardPresenter,
         screen = screen,
         navigator = navigator,
@@ -291,6 +299,21 @@ class ToolDetailsPresenterTest {
         }
     }
     // endregion State.variants
+
+    // region State.drawerState
+    @Test
+    fun `State - drawerState`() = runTest {
+        val drawerState = DrawerMenuScreen.State(
+            drawerState = DrawerState(DrawerValue.Open),
+            isLoggedIn = Random.nextBoolean()
+        )
+        everyComposable { drawerMenuPresenter.present() } returns drawerState
+
+        createPresenter().test {
+            assertEquals(drawerState, expectMostRecentItem().drawerState)
+        }
+    }
+    // endregion State.drawerState
 
     // region Event.OpenTool
     @Test


### PR DESCRIPTION
- **Start refactoring DrawerMenuLayout to use a State object instead of the ViewModel**
- **create a DrawerMenuPresenter**
- **update ToolDetailsLayout to utilize DrawerMenuScreen.State**
