### PR TITLE
GT-2379 Disable density splits

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,7 @@ android {
         }
     }
     bundle {
+        density.enableSplit = false
         language.enableSplit = false
     }
     dynamicFeatures += ":feature:bundledcontent"


### PR DESCRIPTION
sideloading an incorrect version leads to crashes if the sideloaded version doesn't contain the proper density resources
