### PR TITLE
Centralize some Dashboard filter logic

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenu.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenu.kt
@@ -1,0 +1,24 @@
+package org.cru.godtools.ui.dashboard.filters
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+class FilterMenu {
+    data class UiState<T>(
+        val menuExpanded: MutableState<Boolean> = mutableStateOf(false),
+        val query: MutableState<String> = mutableStateOf(""),
+        val items: ImmutableList<Item<T>> = persistentListOf(),
+        val selectedItem: T? = null,
+        val eventSink: (Event<T>) -> Unit = {},
+    ) : CircuitUiState {
+        data class Item<T>(val item: T, val count: Int)
+    }
+
+    sealed interface Event<T> : CircuitUiEvent {
+        data class SelectItem<T>(val item: T?) : Event<T>
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenuItem.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenuItem.kt
@@ -1,0 +1,35 @@
+package org.cru.godtools.ui.dashboard.filters
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+internal fun FilterMenuItem(
+    label: String,
+    supportingText: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = FilterMenuItem(
+    label = { Text(label) },
+    supportingText = supportingText,
+    onClick = onClick,
+    modifier = modifier,
+)
+
+@Composable
+internal fun FilterMenuItem(
+    label: @Composable () -> Unit,
+    supportingText: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) = ListItem(
+    headlineContent = label,
+    supportingContent = supportingText?.let { { Text(it) } },
+    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+    modifier = modifier.clickable(onClick = onClick)
+)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.ui.dashboard.lessons
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,8 +11,6 @@ import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.Surface
@@ -25,7 +22,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -42,6 +38,7 @@ import org.cru.godtools.R
 import org.cru.godtools.base.LocalAppLanguage
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.model.Language
+import org.cru.godtools.ui.dashboard.filters.FilterMenuItem
 import org.cru.godtools.ui.languages.LanguageName
 
 private val DROPDOWN_LESSON_MAX_HEIGHT = 700.dp
@@ -136,16 +133,3 @@ internal fun LessonLanguageFilter(modifier: Modifier = Modifier, viewModel: Less
         }
     }
 }
-
-@Composable
-private fun FilterMenuItem(
-    label: @Composable () -> Unit,
-    supportingText: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) = ListItem(
-    headlineContent = label,
-    supportingContent = supportingText?.let { { Text(it) } },
-    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-    modifier = modifier.clickable(onClick = onClick)
-)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
@@ -1,7 +1,6 @@
 package org.cru.godtools.ui.dashboard.tools
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,8 +18,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.SearchBar
@@ -33,7 +30,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
@@ -50,6 +46,7 @@ import org.cru.godtools.R
 import org.cru.godtools.base.LocalAppLanguage
 import org.cru.godtools.base.ui.theme.GodToolsTheme
 import org.cru.godtools.base.ui.util.getToolCategoryName
+import org.cru.godtools.ui.dashboard.filters.FilterMenuItem
 import org.cru.godtools.ui.languages.LanguageName
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -210,29 +207,3 @@ internal fun LanguageFilter(filters: ToolsScreen.Filters, modifier: Modifier = M
         }
     }
 }
-
-@Composable
-private fun FilterMenuItem(
-    label: String,
-    supportingText: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) = FilterMenuItem(
-    label = { Text(label) },
-    supportingText = supportingText,
-    onClick = onClick,
-    modifier = modifier,
-)
-
-@Composable
-private fun FilterMenuItem(
-    label: @Composable () -> Unit,
-    supportingText: String?,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) = ListItem(
-    headlineContent = label,
-    supportingContent = supportingText?.let { { Text(it) } },
-    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-    modifier = modifier.clickable(onClick = onClick)
-)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -41,7 +41,7 @@ internal fun ToolsLayout(state: ToolsScreen.State, modifier: Modifier = Modifier
     val spotlightTools by rememberUpdatedState(state.spotlightTools)
     val filters by rememberUpdatedState(state.filters)
     val tools by rememberUpdatedState(state.tools)
-    val selectedLanguage by rememberUpdatedState(state.filters.selectedLanguage)
+    val selectedLanguage by rememberUpdatedState(state.filters.languageFilter.selectedItem)
     val eventSink by rememberUpdatedState(state.eventSink)
 
     val columnState = rememberLazyListState()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsScreen.kt
@@ -3,11 +3,11 @@ package org.cru.godtools.ui.dashboard.tools
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
-import java.util.Locale
 import kotlinx.parcelize.Parcelize
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.banner.BannerType
+import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.tools.ToolCard
 
 @Parcelize
@@ -21,25 +21,13 @@ data object ToolsScreen : Screen {
     ) : CircuitUiState
 
     data class Filters(
-        val categories: List<Filter<String>> = emptyList(),
-        val selectedCategory: String? = null,
-        val showLanguagesMenu: Boolean = false,
-        val languages: List<Filter<Language>> = emptyList(),
-        val languageQuery: String = "",
-        val selectedLanguage: Language? = null,
-        val eventSink: (FiltersEvent) -> Unit = {},
+        val categoryFilter: FilterMenu.UiState<String> = FilterMenu.UiState(),
+        val languageFilter: FilterMenu.UiState<Language> = FilterMenu.UiState(),
     ) : CircuitUiState {
         data class Filter<T>(val item: T, val count: Int)
     }
 
     sealed interface Event : CircuitUiEvent {
         data class OpenToolDetails(val tool: String, val source: String? = null) : Event
-    }
-
-    sealed interface FiltersEvent : CircuitUiEvent {
-        data object ToggleLanguagesMenu : FiltersEvent
-        data class UpdateLanguageQuery(val query: String) : FiltersEvent
-        data class SelectCategory(val category: String?) : FiltersEvent
-        data class SelectLanguage(val locale: Locale?) : FiltersEvent
     }
 }

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersPaparazziTest.kt
@@ -1,6 +1,7 @@
 package org.cru.godtools.ui.dashboard.tools
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import com.android.resources.NightMode
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -8,8 +9,10 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import java.util.Locale
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlinx.collections.immutable.persistentListOf
 import org.cru.godtools.model.Language
 import org.cru.godtools.ui.BasePaparazziTest
+import org.cru.godtools.ui.dashboard.filters.FilterMenu.UiState
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
@@ -19,17 +22,17 @@ class ToolFiltersPaparazziTest(
 ) : BasePaparazziTest(nightMode = nightMode, accessibilityMode = accessibilityMode) {
     @Test
     fun `LanguageFilter - Button - No Language Selected`() = renderLanguageFilter(
-        ToolsScreen.Filters(
-            selectedLanguage = null,
-            showLanguagesMenu = false,
+        UiState(
+            selectedItem = null,
+            menuExpanded = mutableStateOf(false),
         )
     )
 
     @Test
     fun `LanguageFilter - Button - English Selected`() = renderLanguageFilter(
-        ToolsScreen.Filters(
-            selectedLanguage = Language(Locale.ENGLISH),
-            showLanguagesMenu = false,
+        UiState(
+            selectedItem = Language(Locale.ENGLISH),
+            menuExpanded = mutableStateOf(false),
         )
     )
 
@@ -40,18 +43,18 @@ class ToolFiltersPaparazziTest(
     @Test
     @Ignore("Ignored for now due to LayoutLib rendering issues")
     fun `LanguageFilter - Dropdown Menu`() = renderLanguageFilter(
-        ToolsScreen.Filters(
-            selectedLanguage = Language(Locale.ENGLISH),
-            showLanguagesMenu = true,
-            languages = listOf(
-                ToolsScreen.Filters.Filter(Language(Locale.ENGLISH), 12345),
-                ToolsScreen.Filters.Filter(Language(Locale.FRENCH), 1),
-                ToolsScreen.Filters.Filter(Language(Locale("es")), 3),
+        UiState(
+            selectedItem = Language(Locale.ENGLISH),
+            menuExpanded = mutableStateOf(true),
+            items = persistentListOf(
+                UiState.Item(Language(Locale.ENGLISH), 12345),
+                UiState.Item(Language(Locale.FRENCH), 1),
+                UiState.Item(Language(Locale("es")), 3),
             ),
         )
     )
 
-    private fun renderLanguageFilter(filters: ToolsScreen.Filters) = centerInSnapshot {
-        LanguageFilter(filters, modifier = Modifier.fillMaxWidth(0.5f))
+    private fun renderLanguageFilter(state: UiState<Language>) = centerInSnapshot {
+        LanguageFilter(state, modifier = Modifier.fillMaxWidth(0.5f))
     }
 }

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
@@ -17,9 +17,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -34,8 +32,7 @@ import org.cru.godtools.model.Translation
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.model.randomTranslation
 import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.tools.ToolsScreen.Filters.Filter
-import org.cru.godtools.ui.dashboard.tools.ToolsScreen.FiltersEvent
+import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardPresenter
 import org.junit.runner.RunWith
@@ -157,9 +154,9 @@ class ToolsPresenterTest {
     }
     // endregion State.spotlightTools
 
-    // region State.filters.categories
+    // region State.filters.categoryFilter.items
     @Test
-    fun `State - filters - categories - no language`() = runTest {
+    fun `State - filters - categoryFilter - items - no language`() = runTest {
         toolsFlow.value = listOf(
             randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false, defaultOrder = 0),
             randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = false, defaultOrder = 1),
@@ -167,26 +164,32 @@ class ToolsPresenterTest {
 
         presenter.test {
             assertEquals(
-                listOf(Filter(Tool.CATEGORY_GOSPEL, 1), Filter(Tool.CATEGORY_ARTICLES, 1)),
-                expectMostRecentItem().filters.categories
+                listOf(
+                    FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 1),
+                    FilterMenu.UiState.Item(Tool.CATEGORY_ARTICLES, 1)
+                ),
+                expectMostRecentItem().filters.categoryFilter.items
             )
         }
     }
 
     @Test
-    fun `State - filters - categories - distinct categories`() = runTest {
+    fun `State - filters - categoryFilter - items - distinct categories`() = runTest {
         toolsFlow.value = listOf(
             randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
             randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
         )
 
         presenter.test {
-            assertEquals(listOf(Filter(Tool.CATEGORY_GOSPEL, 2)), expectMostRecentItem().filters.categories)
+            assertEquals(
+                listOf(FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 2)),
+                expectMostRecentItem().filters.categoryFilter.items
+            )
         }
     }
 
     @Test
-    fun `State - filters - categories - ordered by tool default order`() = runTest {
+    fun `State - filters - categoryFilter - items - ordered by tool default order`() = runTest {
         toolsFlow.value = listOf(
             randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false, defaultOrder = 1),
             randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = false, defaultOrder = 0),
@@ -194,14 +197,17 @@ class ToolsPresenterTest {
 
         presenter.test {
             assertEquals(
-                listOf(Filter(Tool.CATEGORY_ARTICLES, 1), Filter(Tool.CATEGORY_GOSPEL, 1)),
-                expectMostRecentItem().filters.categories
+                listOf(
+                    FilterMenu.UiState.Item(Tool.CATEGORY_ARTICLES, 1),
+                    FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 1)
+                ),
+                expectMostRecentItem().filters.categoryFilter.items
             )
         }
     }
 
     @Test
-    fun `State - filters - categories - exclude non-default variants`() = runTest {
+    fun `State - filters - categoryFilter - items - exclude non-default variants`() = runTest {
         val meta = randomTool("meta", defaultVariantCode = "tool")
         toolsFlow.value = listOf(
             randomTool("tool", category = Tool.CATEGORY_GOSPEL, metatoolCode = "meta", isHidden = false),
@@ -210,50 +216,40 @@ class ToolsPresenterTest {
 
         presenter.test {
             metatoolsFlow.value = listOf(meta)
-            assertEquals(listOf(Filter(Tool.CATEGORY_GOSPEL, 1)), expectMostRecentItem().filters.categories)
+            assertEquals(
+                listOf(FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 1)),
+                expectMostRecentItem().filters.categoryFilter.items
+            )
         }
     }
 
     @Test
-    fun `State - filters - categories - exclude hidden tools`() = runTest {
+    fun `State - filters - categoryFilter - items - exclude hidden tools`() = runTest {
         toolsFlow.value = listOf(
             randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
             randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = true),
         )
 
         presenter.test {
-            assertEquals(listOf(Filter(Tool.CATEGORY_GOSPEL, 1)), expectMostRecentItem().filters.categories)
+            assertEquals(
+                listOf(FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 1)),
+                expectMostRecentItem().filters.categoryFilter.items
+            )
         }
     }
-    // endregion State.filters.categories
+    // endregion State.filters.categoryFilter.items
 
-    // region State.filters.showLanguagesMenu
+    // region State.filters.languageFilter.items
     @Test
-    fun `State - filters - showLanguagesMenu`() = runTest {
-        presenter.test {
-            with(expectMostRecentItem()) {
-                assertFalse(filters.showLanguagesMenu)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
-
-            with(expectMostRecentItem()) {
-                assertTrue(filters.showLanguagesMenu)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
-
-            assertFalse(expectMostRecentItem().filters.showLanguagesMenu)
-        }
-    }
-    // endregion State.filters.showLanguagesMenu
-
-    // region State.filters.languages
-    @Test
-    fun `State - filters - languages - no category`() = runTest {
+    fun `State - filters - languageFilter - items - no category`() = runTest {
         val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
 
         presenter.test {
             languagesFlow.value = languages
-            assertEquals(languages.map { Filter(it, 0) }, expectMostRecentItem().filters.languages)
+            assertEquals(
+                languages.map { FilterMenu.UiState.Item(it, 0) },
+                expectMostRecentItem().filters.languageFilter.items
+            )
         }
 
         verifyAll {
@@ -262,19 +258,22 @@ class ToolsPresenterTest {
     }
 
     @Test
-    fun `State - filters - languages - for category`() = runTest {
+    fun `State - filters - languageFilter - items - for category`() = runTest {
         val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
 
         presenter.test {
-            awaitItem().filters.eventSink(FiltersEvent.SelectCategory(Tool.CATEGORY_GOSPEL))
+            awaitItem().filters.categoryFilter.eventSink(FilterMenu.Event.SelectItem(Tool.CATEGORY_GOSPEL))
 
             gospelLanguagesFlow.value = languages
-            assertEquals(languages.map { Filter(it, 0) }, expectMostRecentItem().filters.languages)
+            assertEquals(
+                languages.map { FilterMenu.UiState.Item(it, 0) },
+                expectMostRecentItem().filters.languageFilter.items
+            )
         }
     }
 
     @Test
-    fun `State - filters - languages - include tool count`() = runTest {
+    fun `State - filters - languageFilter - items - include tool count`() = runTest {
         val translationsFlow = MutableStateFlow(emptyList<Translation>())
         every { translationsRepository.getTranslationsFlowForTools(setOf("tool1", "tool2")) } returns translationsFlow
 
@@ -292,114 +291,89 @@ class ToolsPresenterTest {
             languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
 
             assertEquals(
-                listOf(Filter(Language(Locale.ENGLISH), 2), Filter(Language(Locale.FRENCH), 1)),
-                expectMostRecentItem().filters.languages
+                listOf(
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 2),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 1)
+                ),
+                expectMostRecentItem().filters.languageFilter.items
             )
         }
     }
 
     @Test
-    fun `State - filters - languages - filtered by languageQuery`() = runTest {
+    fun `State - filters - languageFilter - items - filtered by query`() = runTest {
         val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
         languagesFlow.value = languages
 
         presenter.test {
-            expectMostRecentItem().filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            with(expectMostRecentItem()) {
-                assertEquals(languages.map { Filter(it, 0) }, filters.languages)
-                filters.eventSink(FiltersEvent.UpdateLanguageQuery("french"))
+            expectMostRecentItem().filters.languageFilter.let {
+                it.menuExpanded.value = true
+                assertEquals(languages.map { FilterMenu.UiState.Item(it, 0) }, it.items)
+                it.query.value = "french"
             }
 
-            assertEquals(listOf(Filter(Language(Locale.FRENCH), 0)), expectMostRecentItem().filters.languages)
+            assertEquals(
+                listOf(FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)),
+                expectMostRecentItem().filters.languageFilter.items
+            )
         }
 
         verifyAll {
             languagesRepository.getLanguagesFlow()
         }
     }
-    // endregion State.filters.languages
+    // endregion State.filters.languageFilter.items
 
-    // region State.filters.selectedLanguage
+    // region State.filters.languageFilter.selectedItem
     @Test
-    fun `State - filters - selectedLanguage - no language selected`() = runTest {
+    fun `State - filters - languageFilter - selectedItem - no language selected`() = runTest {
         presenter.test {
-            assertNull(expectMostRecentItem().filters.selectedLanguage)
+            assertNull(expectMostRecentItem().filters.languageFilter.selectedItem)
         }
 
         verify(inverse = true) { languagesRepository.findLanguageFlow(any()) }
     }
 
     @Test
-    fun `State - filters - selectedLanguage - language not found`() = runTest {
+    fun `State - filters - languageFilter - selectedItem - language not found`() = runTest {
         presenter.test {
-            awaitItem().filters.eventSink(FiltersEvent.SelectLanguage(Locale.ENGLISH))
+            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.ENGLISH)))
 
-            assertNull(expectMostRecentItem().filters.selectedLanguage)
+            assertNull(expectMostRecentItem().filters.languageFilter.selectedItem)
         }
 
         verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
     }
 
     @Test
-    fun `State - filters - selectedLanguage - language selected`() = runTest {
+    fun `State - filters - languageFilter - selectedItem - language selected`() = runTest {
         val language = Language(Locale.ENGLISH)
         every { languagesRepository.findLanguageFlow(Locale.ENGLISH) } returns flowOf(language)
 
         presenter.test {
-            awaitItem().filters.eventSink(FiltersEvent.SelectLanguage(Locale.ENGLISH))
+            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(language))
 
-            assertEquals(language, expectMostRecentItem().filters.selectedLanguage)
+            assertEquals(language, expectMostRecentItem().filters.languageFilter.selectedItem)
         }
 
         verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
     }
-    // endregion State.filters.selectedLanguage
+    // endregion State.filters.languageFilter.selectedItem
 
-    // region FiltersEvent.ToggleLanguagesMenu
+    // region State.filters.languageFilter.menuExpanded
     @Test
-    fun `FiltersEvent - ToggleLanguagesMenu`() = runTest {
+    fun `State - filters - languageFilter - menuExpanded - resets query when set to false`() = runTest {
         presenter.test {
-            with(expectMostRecentItem()) {
-                assertFalse(filters.showLanguagesMenu)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
+            val state = expectMostRecentItem().filters.languageFilter
 
-            with(expectMostRecentItem()) {
-                assertTrue(filters.showLanguagesMenu)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
+            state.menuExpanded.value = true
+            state.query.value = "test"
+            assertEquals("test", state.query.value)
 
-            assertFalse(expectMostRecentItem().filters.showLanguagesMenu)
-        }
-    }
+            state.menuExpanded.value = false
+            assertEquals("", state.query.value)
 
-    @Test
-    fun `FiltersEvent - ToggleLanguagesMenu - resets languageQuery`() = runTest {
-        presenter.test {
-            expectMostRecentItem().filters.eventSink(FiltersEvent.UpdateLanguageQuery("test"))
-
-            with(expectMostRecentItem()) {
-                assertFalse(filters.showLanguagesMenu)
-                assertEquals("test", filters.languageQuery)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
-
-            with(expectMostRecentItem()) {
-                assertTrue(filters.showLanguagesMenu)
-                assertEquals("", filters.languageQuery)
-                filters.eventSink(FiltersEvent.UpdateLanguageQuery("test"))
-            }
-
-            with(expectMostRecentItem()) {
-                assertTrue(filters.showLanguagesMenu)
-                assertEquals("test", filters.languageQuery)
-                filters.eventSink(FiltersEvent.ToggleLanguagesMenu)
-            }
-
-            with(expectMostRecentItem()) {
-                assertFalse(filters.showLanguagesMenu)
-                assertEquals("", filters.languageQuery)
-            }
+            cancelAndIgnoreRemainingEvents()
         }
     }
     // endregion FiltersEvent.ToggleLanguagesMenu


### PR DESCRIPTION
- **centralize the FilterMenuItem composable**
- **create a shared FilterMenu.UiState to standardize filter menu state**
- **update the ToolsScreen to use FilterMenu.UiState for the language and category filter menus**
