### PR TITLE
GT-2460 Switch to an internal fork of the onesky plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "imported/onesky-gradle-plugin"]
-	path = imported/onesky-gradle-plugin
-	url = https://github.com/frett/onesky-gradle-plugin.git

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -21,8 +21,3 @@ dependencyResolutionManagement {
         }
     }
 }
-
-// TODO: temporarily import our forked version of the onesky-gradle-plugin until
-//       https://github.com/brainly/onesky-gradle-plugin/pull/12 is merged
-//       see: https://jira.cru.org/browse/GT-2344
-includeBuild("../imported/onesky-gradle-plugin")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -4,6 +4,12 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
+        maven {
+            url = uri("https://cruglobal.jfrog.io/artifactory/maven-mobile/")
+            content {
+                includeGroup("org.cru.mobile.fork.co.brainly")
+            }
+        }
         google()
         gradlePluginPortal()
         mavenCentral()

--- a/build-logic/src/main/kotlin/OneSkyConfiguration.kt
+++ b/build-logic/src/main/kotlin/OneSkyConfiguration.kt
@@ -18,7 +18,7 @@ private val ONESKY_LANGUAGE_CODE_OVERRIDES = mapOf(
 
 fun Project.onesky(configuration: OneSkyPluginExtension.() -> Unit) {
     extra.set(DEPRECATE_STRINGS_FLAG, true)
-    apply(plugin = "co.brainly.onesky")
+    apply(plugin = "org.cru.mobile.fork.co.brainly.onesky")
 
     configure<OneSkyPluginExtension> {
         apiKey = findProperty(PROP_API_KEY)?.toString().orEmpty()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -189,7 +189,8 @@ mockk = "io.mockk:mockk:1.13.14"
 mockposable = 'com.jeppeman.mockposable:mockposable-gradle:0.12'
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
-onesky-gradlePlugin = "co.brainly:plugin:1.6.0"
+#onesky-gradlePlugin = "co.brainly:plugin:1.6.0"
+onesky-gradlePlugin = "org.cru.mobile.fork.co.brainly:plugin:1.6.0_71"
 picasso = "com.squareup.picasso:picasso:2.8"
 picasso-transformations = "jp.wasabeef:picasso-transformations:2.4.0"
 play-app-update-ktx = "com.google.android.play:app-update-ktx:2.1.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,11 @@
 pluginManagement {
     repositories {
+        maven {
+            url = uri("https://cruglobal.jfrog.io/artifactory/maven-mobile/")
+            content {
+                includeGroup("org.cru.mobile.fork.co.brainly")
+            }
+        }
         google()
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
- **use our forked version of the onesky plugin**
- **remove the onesky-gradle-plugin submodule**
