### PR TITLE
cleanup

### DIFF
--- a/app/config/ktlint/baseline.xml
+++ b/app/config/ktlint/baseline.xml
@@ -3,9 +3,6 @@
     <file name="src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt">
         <error line="63" column="9" source="compose:vm-injection-check" />
     </file>
-    <file name="src/main/kotlin/org/cru/godtools/ui/account/globalactivity/GlobalActivityLayout.kt">
-        <error line="33" column="5" source="compose:modifier-missing-check" />
-    </file>
     <file name="src/main/kotlin/org/cru/godtools/ui/banner/FavoriteToolsBanner.kt">
         <error line="17" column="9" source="compose:vm-injection-check" />
     </file>
@@ -17,8 +14,5 @@
     </file>
     <file name="src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt">
         <error line="38" column="9" source="compose:vm-injection-check" />
-    </file>
-    <file name="src/main/kotlin/org/cru/godtools/ui/languages/downloadable/DownloadableLanguagesLayout.kt">
-        <error line="58" column="5" source="compose:modifier-missing-check" />
     </file>
 </baseline>

--- a/app/config/ktlint/baseline.xml
+++ b/app/config/ktlint/baseline.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
-    <file name="src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt">
-        <error line="63" column="9" source="compose:vm-injection-check" />
-    </file>
-    <file name="src/main/kotlin/org/cru/godtools/ui/banner/FavoriteToolsBanner.kt">
-        <error line="17" column="9" source="compose:vm-injection-check" />
-    </file>
-    <file name="src/main/kotlin/org/cru/godtools/ui/banner/TutorialFeaturesBanner.kt">
-        <error line="22" column="9" source="compose:vm-injection-check" />
-    </file>
     <file name="src/main/kotlin/org/cru/godtools/ui/dashboard/AppUpdateSnackbar.kt">
         <error line="24" column="14" source="compose:compositionlocal-allowlist" />
     </file>

--- a/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/account/AccountLayout.kt
@@ -59,8 +59,7 @@ internal val ACCOUNT_PAGE_MARGIN_HORIZONTAL = 16.dp
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-internal fun AccountLayout(onEvent: (AccountLayoutEvent) -> Unit = {}) {
-    val viewModel = viewModel<AccountViewModel>()
+internal fun AccountLayout(viewModel: AccountViewModel = viewModel(), onEvent: (AccountLayoutEvent) -> Unit = {}) {
     val user by viewModel.user.collectAsState()
     val pages by viewModel.pages.collectAsState(emptyList())
     val refreshing by viewModel.isSyncRunning.collectAsState()

--- a/app/src/main/kotlin/org/cru/godtools/ui/banner/FavoriteToolsBanner.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/banner/FavoriteToolsBanner.kt
@@ -13,9 +13,7 @@ import org.cru.godtools.R
 import org.cru.godtools.base.Settings
 
 @Composable
-internal fun FavoriteToolsBanner(modifier: Modifier = Modifier) {
-    val viewModel = viewModel<FavoriteToolsBannerViewModel>()
-
+internal fun FavoriteToolsBanner(modifier: Modifier = Modifier, viewModel: FavoriteToolsBannerViewModel = viewModel()) {
     Banner(
         text = stringResource(R.string.tools_list_favorites_banner_text),
         primaryButton = stringResource(R.string.tools_list_favorites_banner_action_dismiss),

--- a/app/src/main/kotlin/org/cru/godtools/ui/banner/TutorialFeaturesBanner.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/banner/TutorialFeaturesBanner.kt
@@ -17,9 +17,11 @@ import org.cru.godtools.tutorial.startTutorialActivity
 import org.greenrobot.eventbus.EventBus
 
 @Composable
-internal fun TutorialFeaturesBanner(modifier: Modifier = Modifier) {
+internal fun TutorialFeaturesBanner(
+    modifier: Modifier = Modifier,
+    viewModel: TutorialFeaturesBannerViewModel = viewModel()
+) {
     val context = LocalContext.current
-    val viewModel = viewModel<TutorialFeaturesBannerViewModel>()
 
     Banner(
         text = stringResource(R.string.tutorial_features_banner_text),

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/languages/app/AppLanguagePresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/languages/app/AppLanguagePresenterTest.kt
@@ -143,7 +143,7 @@ class AppLanguagePresenterTest {
 
             with(expectMostRecentItem()) {
                 val selectedLanguage = assertNotNull(selectedLanguage)
-                navigator.assertIsEmpty()
+                navigator.assertPopIsEmpty()
                 eventSink(AppLanguageScreen.Event.ConfirmLanguage(selectedLanguage))
             }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,6 +23,6 @@ ktlint {
     version.set(libs.versions.ktlint)
 
     filter {
-        exclude { it.file.path.startsWith("${buildDir.path}/") }
+        exclude { it.file in layout.buildDirectory.asFileTree }
     }
 }


### PR DESCRIPTION
- **replace deprecated assertIsEmpty() usage**
- **remove some unnecessary ktlint baseline entries**
- **fix a few Composable lint issues that we were ignoring in the baseline**
- **switch to layout.buildDirectory for the ktlint exclude rule**
