### PR TITLE
GT-2660 Prevent Zombie Accordion Sections

### DIFF
--- a/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionController.kt
+++ b/ui/base-tool/src/main/kotlin/org/cru/godtools/base/tool/ui/controller/AccordionController.kt
@@ -92,7 +92,7 @@ class AccordionController @VisibleForTesting internal constructor(
             binding.controller = this
             binding.activeSection = accordionController.activeSection
 
-            accordionController.activeSection.observe(accordionController.lifecycleOwner) { updateLifecycleMaxState() }
+            accordionController.activeSection.observe(lifecycleOwner) { updateLifecycleMaxState() }
 
             with(lifecycleOwner.lifecycle) {
                 onResume {


### PR DESCRIPTION
Previously observing on the accordion lifecycle would cause the observer to continue after a section had been destoryed.
This would lead to the destroyed section trying to become a zombie the next time the active section was updated.
