### PR TITLE
configure the mockposable plugin in the app module instead of in build-logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.grgit)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.mockposable)
     alias(libs.plugins.paparazzi)
 }
 
@@ -259,6 +260,11 @@ if (project.hasProperty("firebaseAppDistributionBuild")) {
             }
         }
     }
+}
+
+// configure mockposable
+mockposable {
+    plugins = listOf("mockk")
 }
 
 fun generateFirebaseAppDistributionReleaseNotes(size: Int = 10) = buildString {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(libs.kotlin.kover.gradlePlugin)
     implementation(libs.ksp.gradlePlugin)
     implementation(libs.ktlint.gradle)
-    implementation(libs.mockposable)
     implementation(libs.onesky.gradlePlugin)
 }
 

--- a/build-logic/src/main/kotlin/AndroidConfiguration.kt
+++ b/build-logic/src/main/kotlin/AndroidConfiguration.kt
@@ -128,12 +128,6 @@ fun CommonExtension<*, *, *, *, *, *>.configureCompose(project: Project, enableC
 
         project.ksp.arg("circuit.codegen.mode", "hilt")
     }
-
-    // configure mockposable
-    project.pluginManager.apply("com.jeppeman.mockposable")
-    project.mockposable {
-        plugins = listOf("mockk")
-    }
 }
 
 // TODO: provide Project using the new multiple context receivers functionality.

--- a/build-logic/src/main/kotlin/Project.kt
+++ b/build-logic/src/main/kotlin/Project.kt
@@ -1,6 +1,5 @@
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.google.devtools.ksp.gradle.KspExtension
-import com.jeppeman.mockposable.gradle.MockposableSubPluginExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -13,7 +12,6 @@ internal fun Project.androidComponents(configure: Action<AndroidComponentsExtens
     extensions.configure("androidComponents", configure)
 internal fun Project.kapt(configure: KaptExtension.() -> Unit) = extensions.configure(configure)
 internal fun Project.ktlint(action: KtlintExtension.() -> Unit) = extensions.configure(action)
-internal fun Project.mockposable(configure: MockposableSubPluginExtension.() -> Unit) = extensions.configure(configure)
 
 internal val Project.libs get() = project.extensions.getByType<VersionCatalogsExtension>().named("libs")
 internal val Project.androidComponents

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -189,7 +189,6 @@ lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
 materialComponents = "com.google.android.material:material:1.12.0"
 mockk = "io.mockk:mockk:1.14.4"
-mockposable = 'com.jeppeman.mockposable:mockposable-gradle:0.13'
 okhttp3 = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 #onesky-gradlePlugin = "co.brainly:plugin:1.6.0"
@@ -244,4 +243,5 @@ grgit = { id = "org.ajoberstar.grgit", version = "5.3.2" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
+mockposable = { id = "com.jeppeman.mockposable", version = "0.13" }
 paparazzi = { id = "app.cash.paparazzi", version = "2.0.0-alpha02" }


### PR DESCRIPTION
When upgrading mockposable to support Kotlin 2.2.0 it causes a kotlin meta-data conflict. We can avoid this conflict by just configuring mockposable in the app module for now.
