### PR TITLE
GT-2326 Pass the second language when opening tips from tool details

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/OpenToolTrainingScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/OpenToolTrainingScreen.kt
@@ -9,4 +9,9 @@ import org.cru.godtools.model.Tool
  * This is a temporary screen to help bridge functionality until Tutorials use Circuit.
  */
 @Parcelize
-internal class OpenToolTrainingScreen(val tool: String?, val type: Tool.Type, val locale: Locale?) : Screen
+internal class OpenToolTrainingScreen(
+    val tool: String?,
+    val type: Tool.Type,
+    val locale: Locale?,
+    val secondaryLocale: Locale? = null,
+) : Screen

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/SelectedToolSavedState.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/SelectedToolSavedState.kt
@@ -8,6 +8,7 @@ import org.cru.godtools.model.Tool
 private const val KEY_TOOL = "KEY_TIPS_TOOL"
 private const val KEY_TYPE = "KEY_TIPS_TYPE"
 private const val KEY_LANGUAGE = "KEY_TIPS_LANGUAGE"
+private const val KEY_SECONDARY_LANGUAGE = "KEY_TIPS_SECONDARY_LANGUAGE"
 
 class SelectedToolSavedState(private val savedState: SavedStateHandle) : ViewModel() {
     var tool
@@ -19,4 +20,7 @@ class SelectedToolSavedState(private val savedState: SavedStateHandle) : ViewMod
     var language
         get() = savedState.get<Locale>(KEY_LANGUAGE)
         set(value) = savedState.set(KEY_LANGUAGE, value)
+    var secondaryLanguage
+        get() = savedState.get<Locale>(KEY_SECONDARY_LANGUAGE)
+        set(value) = savedState.set(KEY_SECONDARY_LANGUAGE, value)
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsActivity.kt
@@ -67,7 +67,12 @@ class ToolDetailsActivity : BaseActivity() {
                                 when (screen) {
                                     // TODO: move this logic into the ToolDetailsPresenter once tutorials use Circuit
                                     is OpenToolTrainingScreen -> {
-                                        launchTrainingTips(screen.tool, screen.type, screen.locale)
+                                        launchTrainingTips(
+                                            screen.tool,
+                                            screen.type,
+                                            screen.locale,
+                                            screen.secondaryLocale
+                                        )
                                         true
                                     }
 
@@ -96,17 +101,21 @@ class ToolDetailsActivity : BaseActivity() {
         code: String? = selectedTool.tool,
         type: Tool.Type? = selectedTool.type,
         locale: Locale? = selectedTool.language,
+        secondaryLocale: Locale? = selectedTool.secondaryLanguage,
         skipTutorial: Boolean = false,
     ): Unit = when {
         code == null || type == null || locale == null -> Unit
         skipTutorial || settings.isFeatureDiscovered("$FEATURE_TUTORIAL_TIPS$code") -> {
             settings.setFeatureDiscovered("$FEATURE_TUTORIAL_TIPS$code")
-            openToolActivity(code, type, locale, showTips = true)
+            val locales = listOfNotNull(locale, secondaryLocale)
+            openToolActivity(code, type, *locales.toTypedArray(), showTips = true)
         }
+
         else -> {
             selectedTool.tool = code
             selectedTool.type = type
             selectedTool.language = locale
+            selectedTool.secondaryLanguage = secondaryLocale
             tipsTutorialLauncher.launch(PageSet.TIPS)
         }
     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/tooldetails/ToolDetailsPresenter.kt
@@ -125,6 +125,7 @@ class ToolDetailsPresenter @AssistedInject constructor(
                                 Tool.Type.ARTICLE -> listOfNotNull(
                                     secondTranslation?.languageCode ?: translation?.languageCode
                                 )
+
                                 else -> listOfNotNull(translation?.languageCode, secondTranslation?.languageCode)
                             },
                             activeLocale = secondTranslation?.languageCode
@@ -139,7 +140,14 @@ class ToolDetailsPresenter @AssistedInject constructor(
                     Event.OpenToolTraining -> tool?.let {
                         // TODO: handle opening training tips and optionally showing the tutorial locally once the
                         //       tutorial uses Circuit.
-                        navigator.goTo(OpenToolTrainingScreen(it.code, it.type, translation?.languageCode))
+                        navigator.goTo(
+                            OpenToolTrainingScreen(
+                                it.code,
+                                it.type,
+                                translation?.languageCode,
+                                secondTranslation?.languageCode
+                            )
+                        )
                     }
 
                     Event.PinTool -> coroutineScope.launch {


### PR DESCRIPTION
This PR aims to fix what caused the QA failure in the original GT-2326 ticket. The language selector in the top bar should now show for when two languages are selected in the app. 