### PR TITLE
GT-2798-Edit-Menu-Tutorial-Lang-Specifications

### DIFF
--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/Page.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/Page.kt
@@ -51,7 +51,11 @@ internal enum class Page(
         supportedLocales = setOf(
             Locale.ENGLISH,
             Locale.forLanguageTag("lv"),
-            Locale.forLanguageTag("id")
+            Locale.forLanguageTag("id"),
+            Locale.forLanguageTag("es"),
+            Locale.forLanguageTag("af"),
+            Locale.forLanguageTag("af"),
+            Locale.forLanguageTag("vi"),
         )
     ),
     FEATURES_LIVE_SHARE(


### PR DESCRIPTION
This PR updates the tutorial to show the tool tips feature page for the languages that support tool tips. 
