### PR TITLE
Fix/renovate facebook string resources #1675

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
     "dependencies"
   ],
   "dependencyDashboard": true,
+  "ignoreDeps": [
+    "string:facebook_app_id",
+    "string:fb_login_protocol_scheme",
+    "string:facebook_client_token"
+  ],
   "packageRules": [
     {
       "groupName": "Kotlin",
@@ -63,6 +68,17 @@
         "com.google.firebase:firebase-perf{/,}**",
         "com.google.firebase:perf-plugin{/,}**"
       ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "string:facebook_app_id",
+        "string:fb_login_protocol_scheme",
+        "string:facebook_client_token"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description
Fixes Renovate false positive warnings for Facebook string resources that are incorrectly detected as Maven dependencies.

## Problem
Renovate is attempting to look up the following as Maven packages, but they are actually Android string resources defined via `resValue()` in `build.gradle.kts`:
- `string:facebook_app_id`
- `string:fb_login_protocol_scheme`
- `string:facebook_client_token`

This causes warnings in the Dependency Dashboard (#1675) because Renovate cannot find these as Maven packages.

## Solution
- Added `ignoreDeps` array at the top level to explicitly ignore these false positives
- Added `packageRules` entry with `enabled: false` as a backup measure
- Both approaches ensure Renovate will not attempt to look up these string resources

## Changes
- Updated `.github/renovate.json` to ignore Facebook string resource false positives

## Verification
- ✅ JSON syntax validated
- ✅ Configuration follows Renovate best practices
- ✅ Matches existing packageRules patterns in the file