### PR TITLE
Add personalized tool order Room data model

### DIFF
--- a/library/db/room-schemas/org.cru.godtools.db.room.GodToolsRoomDatabase/26.json
+++ b/library/db/room-schemas/org.cru.godtools.db.room.GodToolsRoomDatabase/26.json
@@ -1,0 +1,786 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "3914f0b838e0b46bf7185c5978335863",
+    "entities": [
+      {
+        "tableName": "attachments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tool` TEXT, `filename` TEXT, `sha256` TEXT, `isDownloaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`), FOREIGN KEY(`tool`) REFERENCES `tools`(`code`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tool",
+            "columnName": "tool",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sha256",
+            "columnName": "sha256",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_attachments_tool",
+            "unique": false,
+            "columnNames": [
+              "tool"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_attachments_tool` ON `${TABLE_NAME}` (`tool`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tools",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tool"
+            ],
+            "referencedColumns": [
+              "code"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "languages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`code` TEXT NOT NULL, `name` TEXT, `isForcedName` INTEGER NOT NULL DEFAULT false, `isAdded` INTEGER NOT NULL DEFAULT false, `apiId` INTEGER, PRIMARY KEY(`code`))",
+        "fields": [
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isForcedName",
+            "columnName": "isForcedName",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isAdded",
+            "columnName": "isAdded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "apiId",
+            "columnName": "apiId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "code"
+          ]
+        }
+      },
+      {
+        "tableName": "downloadedFiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`filename` TEXT NOT NULL, PRIMARY KEY(`filename`))",
+        "fields": [
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "filename"
+          ]
+        }
+      },
+      {
+        "tableName": "downloadedTranslationFiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`translationId` INTEGER NOT NULL, `filename` TEXT NOT NULL, PRIMARY KEY(`translationId`, `filename`))",
+        "fields": [
+          {
+            "fieldPath": "key.translationId",
+            "columnName": "translationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key.filename",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "translationId",
+            "filename"
+          ]
+        }
+      },
+      {
+        "tableName": "followups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT, `email` TEXT NOT NULL, `destination` INTEGER NOT NULL, `language` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destination",
+            "columnName": "destination",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "global_activity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`users` INTEGER NOT NULL, `countries` INTEGER NOT NULL, `launches` INTEGER NOT NULL, `gospelPresentations` INTEGER NOT NULL, `id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "users",
+            "columnName": "users",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "countries",
+            "columnName": "countries",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launches",
+            "columnName": "launches",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gospelPresentations",
+            "columnName": "gospelPresentations",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tools",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`code` TEXT NOT NULL, `type` TEXT NOT NULL DEFAULT 'UNKNOWN', `name` TEXT, `category` TEXT, `description` TEXT, `shares` INTEGER NOT NULL DEFAULT 0, `pendingShares` INTEGER NOT NULL DEFAULT 0, `bannerId` INTEGER, `detailsBannerId` INTEGER, `detailsBannerAnimationId` INTEGER, `detailsBannerYoutubeVideoId` TEXT, `isScreenShareDisabled` INTEGER NOT NULL DEFAULT false, `defaultLocale` TEXT NOT NULL DEFAULT 'en', `defaultOrder` INTEGER NOT NULL DEFAULT 0, `order` INTEGER NOT NULL DEFAULT 2147483647, `metatoolCode` TEXT, `defaultVariantCode` TEXT, `isFavorite` INTEGER NOT NULL DEFAULT false, `isHidden` INTEGER NOT NULL DEFAULT false, `isSpotlight` INTEGER NOT NULL DEFAULT false, `primaryLocale` TEXT, `parallelLocale` TEXT, `changedFields` TEXT NOT NULL DEFAULT '', `progress` REAL, `progressLastPageId` TEXT, `apiId` INTEGER, PRIMARY KEY(`code`))",
+        "fields": [
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'UNKNOWN'"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shares",
+            "columnName": "shares",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pendingShares",
+            "columnName": "pendingShares",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bannerId",
+            "columnName": "bannerId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "detailsBannerId",
+            "columnName": "detailsBannerId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "detailsBannerAnimationId",
+            "columnName": "detailsBannerAnimationId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "detailsBannerYoutubeVideoId",
+            "columnName": "detailsBannerYoutubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isScreenShareDisabled",
+            "columnName": "isScreenShareDisabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "defaultLocale",
+            "columnName": "defaultLocale",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "defaultOrder",
+            "columnName": "defaultOrder",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2147483647"
+          },
+          {
+            "fieldPath": "metatoolCode",
+            "columnName": "metatoolCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "defaultVariantCode",
+            "columnName": "defaultVariantCode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isHidden",
+            "columnName": "isHidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isSpotlight",
+            "columnName": "isSpotlight",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "primaryLocale",
+            "columnName": "primaryLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parallelLocale",
+            "columnName": "parallelLocale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "changedFields",
+            "columnName": "changedFields",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "progressLastPageId",
+            "columnName": "progressLastPageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "apiId",
+            "columnName": "apiId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "code"
+          ]
+        }
+      },
+      {
+        "tableName": "personalized_tool_order",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`locale` TEXT NOT NULL, `country` TEXT NOT NULL, `tool` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`locale`, `country`, `tool`), FOREIGN KEY(`tool`) REFERENCES `tools`(`code`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tool",
+            "columnName": "tool",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "locale",
+            "country",
+            "tool"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_personalized_tool_order_tool",
+            "unique": false,
+            "columnNames": [
+              "tool"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personalized_tool_order_tool` ON `${TABLE_NAME}` (`tool`)"
+          },
+          {
+            "name": "index_personalized_tool_order_locale_country_order",
+            "unique": false,
+            "columnNames": [
+              "locale",
+              "country",
+              "order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_personalized_tool_order_locale_country_order` ON `${TABLE_NAME}` (`locale`, `country`, `order`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tools",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tool"
+            ],
+            "referencedColumns": [
+              "code"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "training_tips",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`isCompleted` INTEGER NOT NULL, `isNew` INTEGER NOT NULL, `tool` TEXT NOT NULL, `locale` TEXT NOT NULL, `tipId` TEXT NOT NULL, PRIMARY KEY(`tool`, `locale`, `tipId`))",
+        "fields": [
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNew",
+            "columnName": "isNew",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key.tool",
+            "columnName": "tool",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key.locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key.tipId",
+            "columnName": "tipId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tool",
+            "locale",
+            "tipId"
+          ]
+        }
+      },
+      {
+        "tableName": "translations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `tool` TEXT NOT NULL, `locale` TEXT NOT NULL, `version` INTEGER NOT NULL, `name` TEXT, `description` TEXT, `tagline` TEXT, `toolDetailsConversationStarters` TEXT, `toolDetailsOutline` TEXT, `toolDetailsBibleReferences` TEXT, `manifestFileName` TEXT, `isDownloaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`), FOREIGN KEY(`tool`) REFERENCES `tools`(`code`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`locale`) REFERENCES `languages`(`code`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tool",
+            "columnName": "tool",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolDetailsConversationStarters",
+            "columnName": "toolDetailsConversationStarters",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolDetailsOutline",
+            "columnName": "toolDetailsOutline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolDetailsBibleReferences",
+            "columnName": "toolDetailsBibleReferences",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "manifestFileName",
+            "columnName": "manifestFileName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_translations_tool_locale",
+            "unique": false,
+            "columnNames": [
+              "tool",
+              "locale"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_translations_tool_locale` ON `${TABLE_NAME}` (`tool`, `locale`)"
+          },
+          {
+            "name": "index_translations_tool_locale_version",
+            "unique": false,
+            "columnNames": [
+              "tool",
+              "locale",
+              "version"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_translations_tool_locale_version` ON `${TABLE_NAME}` (`tool` ASC, `locale` ASC, `version` DESC)"
+          },
+          {
+            "name": "index_translations_locale",
+            "unique": false,
+            "columnNames": [
+              "locale"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_translations_locale` ON `${TABLE_NAME}` (`locale`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tools",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tool"
+            ],
+            "referencedColumns": [
+              "code"
+            ]
+          },
+          {
+            "table": "languages",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "locale"
+            ],
+            "referencedColumns": [
+              "code"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `ssoGuid` TEXT, `name` TEXT, `givenName` TEXT, `familyName` TEXT, `email` TEXT, `createdAt` INTEGER, `isInitialFavoriteToolsSynced` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ssoGuid",
+            "columnName": "ssoGuid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "givenName",
+            "columnName": "givenName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "familyName",
+            "columnName": "familyName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isInitialFavoriteToolsSynced",
+            "columnName": "isInitialFavoriteToolsSynced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "user_counters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `count` INTEGER NOT NULL, `decayedCount` REAL NOT NULL, `delta` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "decayedCount",
+            "columnName": "decayedCount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "delta",
+            "columnName": "delta",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "last_sync_times",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "time",
+            "columnName": "time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3914f0b838e0b46bf7185c5978335863')"
+    ]
+  }
+}

--- a/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/repository/ToolsRepository.kt
@@ -29,6 +29,9 @@ interface ToolsRepository {
     fun getFavoriteToolsFlow() = getNormalToolsFlow()
         .map { it.filter { it.isFavorite }.sortedWith(Tool.COMPARATOR_FAVORITE_ORDER) }
 
+    fun getPersonalizedLessonsFlow(locale: Locale, country: String?): Flow<List<Tool>>
+    fun getPersonalizedToolsFlow(locale: Locale, country: String?): Flow<List<Tool>>
+
     fun toolsChangeFlow(): Flow<Any?>
 
     suspend fun pinTool(code: String, trackChanges: Boolean = true)
@@ -46,6 +49,7 @@ interface ToolsRepository {
     // region Sync Methods
     suspend fun storeToolsFromSync(tools: Collection<Tool>)
     suspend fun storeFavoriteToolsFromSync(tools: Collection<Tool>)
+    suspend fun storePersonalizedToolOrderFromSync(locale: Locale, country: String?, tools: List<Tool>)
     suspend fun deleteIfNotFavorite(code: String)
     // endregion Sync Methods
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabase.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabase.kt
@@ -27,6 +27,7 @@ import org.cru.godtools.db.room.entity.FollowupEntity
 import org.cru.godtools.db.room.entity.GlobalActivityEntity
 import org.cru.godtools.db.room.entity.LanguageEntity
 import org.cru.godtools.db.room.entity.LastSyncTimeEntity
+import org.cru.godtools.db.room.entity.PersonalizedToolOrderEntity
 import org.cru.godtools.db.room.entity.ToolEntity
 import org.cru.godtools.db.room.entity.TrainingTipEntity
 import org.cru.godtools.db.room.entity.TranslationEntity
@@ -45,7 +46,7 @@ import org.cru.godtools.db.room.repository.UserCountersRoomRepository
 import org.cru.godtools.db.room.repository.UserRoomRepository
 
 @Database(
-    version = 25,
+    version = 26,
     entities = [
         AttachmentEntity::class,
         LanguageEntity::class,
@@ -54,6 +55,7 @@ import org.cru.godtools.db.room.repository.UserRoomRepository
         FollowupEntity::class,
         GlobalActivityEntity::class,
         ToolEntity::class,
+        PersonalizedToolOrderEntity::class,
         TrainingTipEntity::class,
         TranslationEntity::class,
         UserEntity::class,
@@ -80,6 +82,7 @@ import org.cru.godtools.db.room.repository.UserRoomRepository
         AutoMigration(from = 22, to = 23),
         AutoMigration(from = 23, to = 24),
         AutoMigration(from = 24, to = 25),
+        AutoMigration(from = 25, to = 26),
     ],
 )
 @TypeConverters(Java8TimeConverters::class, LocaleConverter::class)
@@ -147,6 +150,8 @@ internal abstract class GodToolsRoomDatabase : RoomDatabase() {
  * 24: 2024-04-22
  * v6.3.2
  * 25: 2025-01-27
+ * v6.3.7
+ * 26: 2026-04-07
  */
 
 internal fun RoomDatabase.Builder<GodToolsRoomDatabase>.enableMigrations() =

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/ToolsDao.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/dao/ToolsDao.kt
@@ -10,7 +10,9 @@ import androidx.room.Update
 import androidx.room.Upsert
 import java.util.Locale
 import kotlinx.coroutines.flow.Flow
+import org.cru.godtools.db.room.entity.PersonalizedToolOrderEntity
 import org.cru.godtools.db.room.entity.ToolEntity
+import org.cru.godtools.db.room.entity.partial.SyncPersonalizedTool
 import org.cru.godtools.db.room.entity.partial.SyncTool
 import org.cru.godtools.db.room.entity.partial.ToolFavorite
 import org.cru.godtools.model.Tool
@@ -72,4 +74,24 @@ internal interface ToolsDao {
     suspend fun updateToolViews(code: String, views: Int)
     @Delete
     suspend fun delete(tool: ToolEntity)
+
+    // region Personalized Tools
+    @Query(
+        """
+            SELECT t.*
+            FROM personalized_tool_order AS o JOIN tools AS t ON t.code = o.tool
+            WHERE o.locale = :locale AND o.country = :country AND t.type IN (:type)
+            ORDER BY o.`order` ASC
+        """
+    )
+    fun getPersonalizedToolsFlow(locale: Locale, country: String, vararg type: Tool.Type): Flow<List<ToolEntity>>
+
+    @Upsert(entity = ToolEntity::class)
+    suspend fun upsertToolsPersonalized(tools: Collection<SyncPersonalizedTool>)
+    @Upsert
+    suspend fun upsertPersonalizedToolOrder(order: Collection<PersonalizedToolOrderEntity>)
+
+    @Query("DELETE FROM personalized_tool_order WHERE locale = :locale AND country = :country")
+    suspend fun resetPersonalizedToolOrder(locale: Locale, country: String)
+    // endregion Personalized Tools
 }

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/PersonalizedToolOrderEntity.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/PersonalizedToolOrderEntity.kt
@@ -1,0 +1,30 @@
+package org.cru.godtools.db.room.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import java.util.Locale
+
+@Entity(
+    tableName = "personalized_tool_order",
+    primaryKeys = ["locale", "country", "tool"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ToolEntity::class,
+            parentColumns = ["code"],
+            childColumns = ["tool"],
+            onUpdate = ForeignKey.CASCADE,
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("tool"),
+        Index("locale", "country", "order"),
+    ]
+)
+internal data class PersonalizedToolOrderEntity(
+    val locale: Locale,
+    val country: String,
+    val tool: String,
+    val order: Int,
+)

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/ToolEntity.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/ToolEntity.kt
@@ -10,6 +10,7 @@ import org.cru.godtools.model.Tool
 internal class ToolEntity(
     @PrimaryKey
     val code: String,
+    @ColumnInfo(defaultValue = "UNKNOWN")
     val type: Tool.Type,
     val name: String? = null,
     val category: String? = null,

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/partial/SyncPersonalizedTool.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/entity/partial/SyncPersonalizedTool.kt
@@ -1,0 +1,8 @@
+package org.cru.godtools.db.room.entity.partial
+
+import org.cru.godtools.model.Tool
+
+internal class SyncPersonalizedTool(tool: Tool) {
+    val apiId = tool.apiId
+    val code = tool.code.orEmpty()
+}

--- a/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepository.kt
+++ b/library/db/src/main/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepository.kt
@@ -8,9 +8,12 @@ import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.androidx.room.changeFlow
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.db.room.GodToolsRoomDatabase
+import org.cru.godtools.db.room.entity.PersonalizedToolOrderEntity
 import org.cru.godtools.db.room.entity.ToolEntity
+import org.cru.godtools.db.room.entity.partial.SyncPersonalizedTool
 import org.cru.godtools.db.room.entity.partial.SyncTool
 import org.cru.godtools.model.Tool
+import org.cru.godtools.model.Tool.Type.Companion.NORMAL_TYPES
 import org.cru.godtools.model.trackChanges
 
 @Dao
@@ -31,6 +34,12 @@ internal abstract class ToolsRoomRepository(private val db: GodToolsRoomDatabase
         dao.getDownloadedToolsFlowByTypeAndLanguage(types, locale).map { it.map { it.toModel() } }
     override fun getLessonsFlowByLanguage(locale: Locale) =
         dao.getToolsFlowByTypeAndLanguage(listOf(Tool.Type.LESSON), locale).map { it.map { it.toModel() } }
+
+    override fun getPersonalizedLessonsFlow(locale: Locale, country: String?) =
+        dao.getPersonalizedToolsFlow(locale, country.orEmpty(), Tool.Type.LESSON).map { it.map { it.toModel() } }
+    override fun getPersonalizedToolsFlow(locale: Locale, country: String?) =
+        dao.getPersonalizedToolsFlow(locale, country.orEmpty(), *NORMAL_TYPES.toTypedArray())
+            .map { it.map { it.toModel() } }
 
     override fun toolsChangeFlow(): Flow<Any?> = db.changeFlow("tools")
 
@@ -85,6 +94,22 @@ internal abstract class ToolsRoomRepository(private val db: GodToolsRoomDatabase
             if (!it.isFieldChanged(Tool.ATTR_IS_FAVORITE)) it.isFavorite = isFavorite
         }
         dao.updateToolFavorites(toolFavorites)
+    }
+
+    @Transaction
+    override suspend fun storePersonalizedToolOrderFromSync(locale: Locale, country: String?, tools: List<Tool>) {
+        dao.upsertToolsPersonalized(tools.map { SyncPersonalizedTool(it) })
+        dao.resetPersonalizedToolOrder(locale, country.orEmpty())
+        dao.upsertPersonalizedToolOrder(
+            tools.mapIndexed { i, tool ->
+                PersonalizedToolOrderEntity(
+                    locale = locale,
+                    country = country.orEmpty(),
+                    tool = tool.code.orEmpty(),
+                    order = i
+                )
+            }
+        )
     }
 
     @Transaction

--- a/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/repository/ToolsRepositoryIT.kt
@@ -251,6 +251,108 @@ abstract class ToolsRepositoryIT {
     }
     // endregion getLessonsFlowByLanguage()
 
+    // region getPersonalizedToolsFlow()
+    @Test
+    fun `getPersonalizedToolsFlow() - empty when no order stored`() = testScope.runTest {
+        repository.storeInitialTools(listOf(randomTool("tool", Tool.Type.TRACT)))
+        assertTrue(repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).first().isEmpty())
+    }
+
+    @Test
+    fun `getPersonalizedToolsFlow() - returns tools in personalized order`() = testScope.runTest {
+        val tool1 = randomTool("tool1", Tool.Type.TRACT)
+        val tool2 = randomTool("tool2", Tool.Type.CYOA)
+        val tool3 = randomTool("tool3", Tool.Type.ARTICLE)
+        repository.storeInitialTools(listOf(tool1, tool2, tool3))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, "US", listOf(tool2, tool3, tool1))
+        assertEquals(
+            listOf("tool2", "tool3", "tool1"),
+            repository.getPersonalizedToolsFlow(Locale.ENGLISH, "US").first().map { it.code }
+        )
+    }
+
+    @Test
+    fun `getPersonalizedToolsFlow() - filters to NORMAL_TYPES only`() = testScope.runTest {
+        val tract = randomTool("tract", Tool.Type.TRACT)
+        val lesson = randomTool("lesson", Tool.Type.LESSON)
+        val meta = randomTool("meta", Tool.Type.META)
+        repository.storeInitialTools(listOf(tract, lesson, meta))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(lesson, meta, tract))
+        assertEquals(
+            listOf("tract"),
+            repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).first().map { it.code }
+        )
+    }
+
+    @Test
+    fun `getPersonalizedToolsFlow() - scoped to locale and country`() = testScope.runTest {
+        val tool = randomTool("tool", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(tool))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, "US", listOf(tool))
+        assertTrue(repository.getPersonalizedToolsFlow(Locale.FRENCH, "US").first().isEmpty())
+        assertTrue(repository.getPersonalizedToolsFlow(Locale.ENGLISH, "CA").first().isEmpty())
+    }
+
+    @Test
+    fun `getPersonalizedToolsFlow() - null country`() = testScope.runTest {
+        val tool = randomTool("tool", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(tool))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool))
+        assertEquals(listOf("tool"), repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).first().map { it.code })
+    }
+
+    @Test
+    fun `getPersonalizedToolsFlow() - updates when order changes`() = testScope.runTest {
+        val tool1 = randomTool("tool1", Tool.Type.TRACT)
+        val tool2 = randomTool("tool2", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(tool1, tool2))
+
+        repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).test {
+            assertTrue(awaitItem().isEmpty())
+
+            repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool1, tool2))
+            runCurrent()
+            assertEquals(listOf("tool1", "tool2"), expectMostRecentItem().map { it.code })
+
+            repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool2, tool1))
+            runCurrent()
+            assertEquals(listOf("tool2", "tool1"), expectMostRecentItem().map { it.code })
+        }
+    }
+    // endregion getPersonalizedToolsFlow()
+
+    // region getPersonalizedLessonsFlow()
+    @Test
+    fun `getPersonalizedLessonsFlow() - returns lessons in personalized order`() = testScope.runTest {
+        val lesson1 = randomTool("lesson1", Tool.Type.LESSON)
+        val lesson2 = randomTool("lesson2", Tool.Type.LESSON)
+        repository.storeInitialTools(listOf(lesson1, lesson2))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(lesson2, lesson1))
+        assertEquals(
+            listOf("lesson2", "lesson1"),
+            repository.getPersonalizedLessonsFlow(Locale.ENGLISH, null).first().map { it.code }
+        )
+    }
+
+    @Test
+    fun `getPersonalizedLessonsFlow() - filters to LESSON type only`() = testScope.runTest {
+        val lesson = randomTool("lesson", Tool.Type.LESSON)
+        val tract = randomTool("tract", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(lesson, tract))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tract, lesson))
+        assertEquals(
+            listOf("lesson"),
+            repository.getPersonalizedLessonsFlow(Locale.ENGLISH, null).first().map { it.code }
+        )
+    }
+    // endregion getPersonalizedLessonsFlow()
+
     // region toolsChangeFlow()
     @Test
     fun `toolsChangeFlow()`() = testScope.runTest {
@@ -609,6 +711,49 @@ abstract class ToolsRepositoryIT {
         }
     }
     // endregion storeFavoriteToolsFromSync()
+
+    // region storePersonalizedToolOrderFromSync()
+    @Test
+    fun `storePersonalizedToolOrderFromSync() - doesn't pave over existing tool data`() = testScope.runTest {
+        val tool = randomTool("tool", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(tool))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool))
+        assertEquals(tool, repository.findTool("tool"))
+    }
+
+    @Test
+    fun `storePersonalizedToolOrderFromSync() - order is preserved when tools are stored after`() = testScope.runTest {
+        val tool1 = randomTool("tool1", Tool.Type.TRACT)
+        val tool2 = randomTool("tool2", Tool.Type.TRACT)
+        val tool3 = randomTool("tool3", Tool.Type.TRACT)
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool2, tool3, tool1))
+        repository.storeToolsFromSync(listOf(tool1, tool2, tool3))
+        assertEquals(
+            listOf("tool2", "tool3", "tool1"),
+            repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).first().map { it.code }
+        )
+    }
+
+    @Test
+    fun `storePersonalizedToolOrderFromSync() - different locales are independent`() = testScope.runTest {
+        val tool1 = randomTool("tool1", Tool.Type.TRACT)
+        val tool2 = randomTool("tool2", Tool.Type.TRACT)
+        repository.storeInitialTools(listOf(tool1, tool2))
+
+        repository.storePersonalizedToolOrderFromSync(Locale.ENGLISH, null, listOf(tool1, tool2))
+        repository.storePersonalizedToolOrderFromSync(Locale.FRENCH, null, listOf(tool2, tool1))
+        assertEquals(
+            listOf("tool1", "tool2"),
+            repository.getPersonalizedToolsFlow(Locale.ENGLISH, null).first().map { it.code }
+        )
+        assertEquals(
+            listOf("tool2", "tool1"),
+            repository.getPersonalizedToolsFlow(Locale.FRENCH, null).first().map { it.code }
+        )
+    }
+    // endregion storePersonalizedToolOrderFromSync()
 
     // region deleteIfNotFavorite()
     @Test

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseMigrationIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/GodToolsRoomDatabaseMigrationIT.kt
@@ -420,6 +420,40 @@ class GodToolsRoomDatabaseMigrationIT {
         }
     }
 
+    @Test
+    fun testMigrate25To26() {
+        val personalizedOrderQuery = "SELECT * FROM personalized_tool_order"
+
+        // create v25 database
+        helper.createDatabase(GodToolsRoomDatabase.DATABASE_NAME, 25).use { db ->
+            db.execSQL("INSERT INTO tools (code, type) VALUES (?, ?)", arrayOf<Any>("kgp", Tool.Type.TRACT))
+            assertFailsWith<SQLException> { db.query(personalizedOrderQuery) }
+        }
+
+        // run migration
+        helper.runMigrationsAndValidate(GodToolsRoomDatabase.DATABASE_NAME, 26, true, *MIGRATIONS).use { db ->
+            db.query("SELECT code, type FROM tools WHERE code = 'kgp'").use {
+                assertEquals(1, it.count)
+                it.moveToFirst()
+                assertEquals("kgp", it.getStringOrNull(0))
+                assertEquals("TRACT", it.getStringOrNull(1))
+            }
+            db.query(personalizedOrderQuery).close()
+            db.execSQL(
+                "INSERT INTO personalized_tool_order (locale, country, tool, `order`) VALUES (?, ?, ?, ?)",
+                arrayOf<Any>("en", "US", "kgp", 0)
+            )
+            db.query("SELECT locale, country, tool, `order` FROM personalized_tool_order").use {
+                assertEquals(1, it.count)
+                it.moveToFirst()
+                assertEquals("en", it.getStringOrNull(0))
+                assertEquals("US", it.getStringOrNull(1))
+                assertEquals("kgp", it.getStringOrNull(2))
+                assertEquals(0, it.getIntOrNull(3))
+            }
+        }
+    }
+
     private fun SupportSQLiteDatabase.dumpIndices(table: String) = query("PRAGMA index_list($table)").use { it ->
         it.map { it.getString(1) }.associateWith { name ->
             query("PRAGMA index_info($name)").use { it.map { it.getString(2) }.toSet() }


### PR DESCRIPTION
## Summary
- Adds DB version 26 with a new `personalized_tool_order` table (auto-migration from 25), storing a per-locale/country ordered list of tool codes
- Exposes `getPersonalizedToolsFlow`, `getPersonalizedLessonsFlow`, and `storePersonalizedToolOrderFromSync` on `ToolsRepository`
- Type filtering (NORMAL_TYPES / LESSON) is pushed into SQL via a vararg parameter on the DAO query

## Test plan
- [ ] Migration test (`testMigrate25To26`) verifies table creation, existing tool preservation, and data round-trip
- [ ] `ToolsRepositoryIT` covers: ordering, type filtering, locale/country scoping, null country, reactive updates, store-before-sync, and no-clobber of existing tool data

🤖 Generated with [Claude Code](https://claude.com/claude-code)