### PR TITLE
Misc cleanup

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -12,11 +12,17 @@ Review pull request $ARGUMENTS against the GodTools Android project conventions.
 1. Check for dismissed issues by reading `.claude/skills/pr-review/dismissed-issues.md` if it exists.
    Load all dismissed entries — each has a **Pattern** and **Reason**. You will use these to suppress matching findings later.
 
-2. Fetch the PR diff and metadata:
+2. Fetch the PR diff and metadata. If `$ARGUMENTS` is provided, use it as the PR number:
 ```
 gh pr diff $ARGUMENTS
 gh pr view $ARGUMENTS
 ```
+If no PR number is given (or the above fails because no upstream PR exists), fall back to reviewing the current branch against `develop`:
+```
+git diff develop...HEAD
+git log develop...HEAD --oneline
+```
+Use the branch name and commit log as the "title" in the review header.
 
 3. Identify all changed files and categorize them (Kotlin, build scripts, resources, manifests, tests).
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,9 @@
 files: [
   {
     "source": "/app/src/main/res/values/strings*.xml",
+    "ignore": [
+      "/app/src/main/res/values/strings_country_native_names.xml"
+    ],
     "translation": "/app/src/main/res/values-%android_code%/%original_file_name%",
     "update_option": "update_as_unapproved"
   },

--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/LessonActivity.kt
@@ -341,7 +341,7 @@ class LessonActivity :
     // region Resume Progress
     private fun LessonScreen.UiState.Loaded.indexOfResumePage(pageId: String?) = manifest.findPage(pageId)
         ?.let { generateSequence(it) { it.previousPage }.firstOrNull { !it.isHidden } }
-        ?.let { return lessonPager.pages.indexOf(it) } ?: -1
+        ?.let { lessonPager.pages.indexOf(it) } ?: -1
     // endregion Resume Progress
 
     // region Share Menu Logic


### PR DESCRIPTION
## Summary
- Fall back to current branch diff when no PR number given in `/pr-review`
- Remove unnecessary return from `indexOfResumePage` lambda
- Exclude `strings_country_native_names.xml` from Crowdin sync

## Test plan
- [ ] Verify `/pr-review` works without a PR number
- [ ] Verify Crowdin sync ignores country native names strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)