### PR TITLE
GT-3011: Sync personalized tool order from the API

### DIFF
--- a/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
+++ b/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
@@ -1,5 +1,6 @@
 package org.cru.godtools.api
 
+import java.util.Locale
 import org.ccci.gto.android.common.jsonapi.model.JsonApiObject
 import org.ccci.gto.android.common.jsonapi.retrofit2.JsonApiParams
 import org.cru.godtools.model.Tool
@@ -11,6 +12,8 @@ import retrofit2.http.QueryMap
 private const val PATH_RESOURCES = "resources"
 private const val PARAM_FILTER_SYSTEM = "filter[system]"
 private const val PARAM_FILTER_CODE = "filter[abbreviation]"
+private const val PARAM_FILTER_LANGUAGE = "filter[lang]"
+private const val PARAM_FILTER_COUNTRY = "filter[country]"
 
 interface ToolsApi {
     @GET("$PATH_RESOURCES?$PARAM_FILTER_SYSTEM=${BuildConfig.MOBILE_CONTENT_SYSTEM}")
@@ -19,6 +22,19 @@ interface ToolsApi {
     @GET(PATH_RESOURCES)
     suspend fun getTool(
         @Query(PARAM_FILTER_CODE) code: String,
-        @QueryMap params: JsonApiParams
+        @QueryMap params: JsonApiParams,
+    ): Response<JsonApiObject<Tool>>
+
+    @GET("$PATH_RESOURCES/featured")
+    suspend fun getToolOrder(
+        @Query(PARAM_FILTER_LANGUAGE) locale: Locale,
+        @Query(PARAM_FILTER_COUNTRY) country: String,
+        @QueryMap params: JsonApiParams,
+    ): Response<JsonApiObject<Tool>>
+
+    @GET("$PATH_RESOURCES/default_order")
+    suspend fun getDefaultToolOrder(
+        @Query(PARAM_FILTER_LANGUAGE) locale: Locale,
+        @QueryMap params: JsonApiParams,
     ): Response<JsonApiObject<Tool>>
 }

--- a/library/model/src/main/kotlin/org/cru/godtools/model/Tool.kt
+++ b/library/model/src/main/kotlin/org/cru/godtools/model/Tool.kt
@@ -24,7 +24,6 @@ private const val JSON_TYPE_ARTICLE = "article"
 private const val JSON_TYPE_CYOA = "cyoa"
 private const val JSON_TYPE_LESSON = "lesson"
 private const val JSON_TYPE_META = "metatool"
-private const val JSON_ABBREVIATION = "abbreviation"
 private const val JSON_NAME = "name"
 private const val JSON_CATEGORY = "attr-category"
 private const val JSON_HIDDEN = "attr-hidden"
@@ -42,7 +41,7 @@ private const val JSON_SCREEN_SHARE_DISABLED = "attr-screen-share-disabled"
 
 @JsonApiType(Tool.JSONAPI_TYPE)
 class Tool(
-    @JsonApiAttribute(JSON_ABBREVIATION)
+    @JsonApiAttribute(JSON_CODE)
     val code: String?,
     @JsonApiAttribute(JSON_TYPE)
     val type: Type = Type.UNKNOWN,
@@ -101,6 +100,7 @@ class Tool(
     companion object {
         const val JSONAPI_TYPE = "resource"
 
+        const val JSON_CODE = "abbreviation"
         const val JSON_ATTACHMENTS = "attachments"
         const val JSON_LATEST_TRANSLATIONS = "latest-translations"
         const val JSON_METATOOL = "metatool"
@@ -110,7 +110,7 @@ class Tool(
 
         val JSONAPI_FIELDS = arrayOf(
             JSON_TYPE,
-            JSON_ABBREVIATION,
+            JSON_CODE,
             JSON_NAME,
             JSON_DESCRIPTION,
             JSON_CATEGORY,

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.work.WorkManager
 import dagger.Lazy
 import java.io.IOException
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -84,6 +85,9 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
 
     suspend fun syncTool(toolCode: String, force: Boolean = false) =
         executeSync<ToolSyncTasks> { syncTool(toolCode, force) }
+
+    suspend fun syncPersonalizedTools(locale: Locale, country: String?, force: Boolean = false) =
+        executeSync<ToolSyncTasks> { syncPersonalizedTools(locale, country, force) }
 
     suspend fun syncGlobalActivity(force: Boolean = false) =
         executeSync<AnalyticsSyncTasks> { syncGlobalActivity(force) }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -3,6 +3,7 @@ package org.cru.godtools.sync.task
 import androidx.annotation.AnyThread
 import java.io.IOException
 import java.net.HttpURLConnection.HTTP_OK
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.async
@@ -38,6 +39,7 @@ internal class ToolSyncTasks @Inject internal constructor(
 ) : BaseSyncTasks() {
     internal companion object {
         const val SYNC_TIME_TOOLS = "last_synced.tools"
+        const val SYNC_TIME_PERSONALIZED_TOOLS = "last_synced.personalized_tools."
 
         private val INCLUDES_GET_TOOL = Includes(
             Tool.JSON_ATTACHMENTS,
@@ -49,6 +51,9 @@ internal class ToolSyncTasks @Inject internal constructor(
             .includes(INCLUDES_GET_TOOL)
             .fields(Tool.JSONAPI_TYPE, *Tool.JSONAPI_FIELDS)
             .fields(Language.JSONAPI_TYPE, *Language.JSONAPI_FIELDS)
+
+        private fun buildPersonalizedToolsApiParams() = JsonApiParams()
+            .fields(Tool.JSONAPI_TYPE, Tool.JSON_CODE)
     }
 
     private val toolsMutex = Mutex()
@@ -80,7 +85,7 @@ internal class ToolSyncTasks @Inject internal constructor(
         if (!force &&
             !lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_TOOL, toolCode, staleAfter = STALE_DURATION_TOOLS)
         ) {
-            return true
+            return@withLock true
         }
 
         // fetch tools from the API, short-circuit if this response is invalid
@@ -96,6 +101,58 @@ internal class ToolSyncTasks @Inject internal constructor(
 
         true
     }
+
+    // region Personalized Tools
+    private val personalizedToolsMutex = MutexMap()
+
+    internal suspend fun syncPersonalizedTools(locale: Locale, country: String?, force: Boolean = false) =
+        coroutineScope {
+            val order = async { country?.let { syncPersonalizedToolOrder(locale, it.uppercase(), force) } ?: true }
+            val defaultOrder = async { syncDefaultPersonalizedToolOrder(locale, force) }
+            order.await() && defaultOrder.await()
+        }
+
+    private suspend fun syncPersonalizedToolOrder(locale: Locale, country: String, force: Boolean) =
+        personalizedToolsMutex.withLock(locale to country) {
+            if (!force &&
+                !lastSyncTimeRepository.isLastSyncStale(
+                    SYNC_TIME_PERSONALIZED_TOOLS,
+                    locale,
+                    country,
+                    staleAfter = STALE_DURATION_TOOLS,
+                )
+            ) {
+                return@withLock true
+            }
+
+            val tools = toolsApi.getToolOrder(locale, country, buildPersonalizedToolsApiParams())
+                .takeIf { it.code() == HTTP_OK }?.body()?.data ?: return@withLock false
+
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, tools)
+            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale, country)
+            true
+        }
+
+    private suspend fun syncDefaultPersonalizedToolOrder(locale: Locale, force: Boolean) =
+        personalizedToolsMutex.withLock(locale) {
+            if (!force &&
+                !lastSyncTimeRepository.isLastSyncStale(
+                    SYNC_TIME_PERSONALIZED_TOOLS,
+                    locale,
+                    staleAfter = STALE_DURATION_TOOLS
+                )
+            ) {
+                return@withLock true
+            }
+
+            val tools = toolsApi.getDefaultToolOrder(locale, buildPersonalizedToolsApiParams())
+                .takeIf { it.code() == HTTP_OK }?.body()?.data ?: return@withLock false
+
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, tools)
+            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale)
+            true
+        }
+    // endregion Personalized Tools
 
     /**
      * @return true if all pending share counts were successfully synced. false if any failed to sync.

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
@@ -3,10 +3,12 @@ package org.cru.godtools.sync.task
 import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.coVerifyAll
 import io.mockk.coVerifySequence
 import io.mockk.just
 import io.mockk.mockk
+import java.util.Locale
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlinx.coroutines.test.runTest
@@ -17,14 +19,23 @@ import org.cru.godtools.db.repository.InMemoryLastSyncTimeRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.sync.repository.SyncRepository
+import org.cru.godtools.sync.task.ToolSyncTasks.Companion.SYNC_TIME_PERSONALIZED_TOOLS
 import retrofit2.Response
 
 class ToolSyncTasksTest {
+    private val locale = Locale.ENGLISH
+    private val country = "US"
+
     private val tool = randomTool()
     private val existingTools = listOf(randomTool())
+    private val personalizedTools = listOf(randomTool(), randomTool())
 
     private val toolsApi: ToolsApi = mockk {
         coEvery { list(any()) } returns Response.success(JsonApiObject.single(tool))
+        coEvery { getToolOrder(any(), any(), any()) } returns
+            Response.success(JsonApiObject.of(*personalizedTools.toTypedArray()))
+        coEvery { getDefaultToolOrder(any(), any()) } returns
+            Response.success(JsonApiObject.of(*personalizedTools.toTypedArray()))
     }
     private val viewsApi: ViewsApi = mockk()
     private val syncRepository: SyncRepository = mockk {
@@ -32,6 +43,7 @@ class ToolSyncTasksTest {
     }
     private val toolsRepository: ToolsRepository = mockk {
         coEvery { getAllTools() } returns existingTools
+        coEvery { storePersonalizedToolOrderFromSync(any(), any(), any()) } just Runs
     }
     private val lastSyncTimeRepository = InMemoryLastSyncTimeRepository()
 
@@ -89,4 +101,74 @@ class ToolSyncTasksTest {
         }
     }
     // endregion syncTools()
+
+    // region syncPersonalizedTools()
+    @Test
+    fun `syncPersonalizedTools(country = non-null)`() = runTest {
+        tasks.syncPersonalizedTools(locale, country)
+        coVerifyAll {
+            toolsApi.getToolOrder(locale, country, any())
+            toolsApi.getDefaultToolOrder(locale, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, personalizedTools)
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, personalizedTools)
+        }
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_PERSONALIZED_TOOLS, locale, country, staleAfter = 60_000)
+        )
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_PERSONALIZED_TOOLS, locale, staleAfter = 60_000)
+        )
+    }
+
+    @Test
+    fun `syncPersonalizedTools(country = null)`() = runTest {
+        tasks.syncPersonalizedTools(locale, null)
+        coVerifyAll {
+            toolsApi.getDefaultToolOrder(locale, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, personalizedTools)
+        }
+        coVerify(exactly = 0) { toolsApi.getToolOrder(any(), any(), any()) }
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_PERSONALIZED_TOOLS, locale, staleAfter = 60_000)
+        )
+    }
+
+    @Test
+    fun `syncPersonalizedTools(force = false) - already synced`() = runTest {
+        with(lastSyncTimeRepository) {
+            setLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale, country, time = System.currentTimeMillis())
+            setLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale, time = System.currentTimeMillis())
+        }
+
+        tasks.syncPersonalizedTools(locale, country, force = false)
+        coVerifyAll { toolsApi wasNot Called }
+    }
+
+    @Test
+    fun `syncPersonalizedTools(force = true) - already synced`() = runTest {
+        with(lastSyncTimeRepository) {
+            setLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale, country, time = System.currentTimeMillis())
+            setLastSyncTime(SYNC_TIME_PERSONALIZED_TOOLS, locale, time = System.currentTimeMillis())
+        }
+
+        tasks.syncPersonalizedTools(locale, country, force = true)
+        coVerifyAll {
+            toolsApi.getToolOrder(locale, country, any())
+            toolsApi.getDefaultToolOrder(locale, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, personalizedTools)
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, personalizedTools)
+        }
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(
+                SYNC_TIME_PERSONALIZED_TOOLS,
+                locale,
+                country.uppercase(),
+                staleAfter = 60_000,
+            )
+        )
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_PERSONALIZED_TOOLS, locale, staleAfter = 60_000)
+        )
+    }
+    // endregion syncPersonalizedTools()
 }


### PR DESCRIPTION
## Summary

- Adds `ToolsApi` endpoints for fetching personalized tool order (`/resources/featured`) and default tool order (`/resources/default_order`)
- Implements `syncPersonalizedTools()` in `ToolSyncTasks` to sync both country-specific and locale-default tool ordering from the API in parallel
- Exposes `syncPersonalizedTools()` on `GodToolsSyncService`
- Promotes `JSON_ABBREVIATION` to a public `JSON_CODE` constant on `Tool` companion object

## Test plan

- [ ] `ToolSyncTasksTest` — covers `syncPersonalizedTools()` with non-null country, null country, already-synced (force=false), and force=true cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)