### PR TITLE
Dashboard refactor: move UiState/UiEvent to Presenters, extract tool filter logic

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenu.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/filters/FilterMenu.kt
@@ -46,7 +46,7 @@ object FilterMenu {
     data class UiState<T>(
         val menuExpanded: MutableState<Boolean> = mutableStateOf(false),
         val query: MutableState<String> = mutableStateOf(""),
-        val items: ImmutableList<Item<T>> = persistentListOf(),
+        val items: List<Item<T>> = persistentListOf(),
         val selectedItem: T? = null,
         val eventSink: (Event<T>) -> Unit = {},
     ) : CircuitUiState {

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayout.kt
@@ -33,8 +33,8 @@ import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.components.SingletonComponent
 import org.cru.godtools.R
 import org.cru.godtools.ui.banner.Banners
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiEvent
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiState
+import org.cru.godtools.ui.dashboard.home.HomePresenter.UiEvent
+import org.cru.godtools.ui.dashboard.home.HomePresenter.UiState
 import org.cru.godtools.ui.tools.LessonToolCard
 import org.cru.godtools.ui.tools.SquareToolCard
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomePresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomePresenter.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuitx.android.IntentScreen
@@ -28,8 +30,7 @@ import org.cru.godtools.base.CONFIG_UI_DASHBOARD_HOME_FAVORITE_TOOLS
 import org.cru.godtools.base.Settings
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiEvent
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiState
+import org.cru.godtools.ui.dashboard.home.HomePresenter.UiState
 import org.cru.godtools.ui.dashboard.tools.ToolsScreen
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen
 import org.cru.godtools.ui.tools.ToolCard
@@ -48,6 +49,21 @@ class HomePresenter @AssistedInject constructor(
     @Assisted
     private val navigator: Navigator,
 ) : Presenter<UiState> {
+    // region UiState / UiEvent
+    data class UiState(
+        val dataLoaded: Boolean = true,
+        val banner: BannerType? = null,
+        val spotlightLessons: List<ToolCard.State> = emptyList(),
+        val favoriteTools: List<ToolCard.State> = emptyList(),
+        val eventSink: (UiEvent) -> Unit = {},
+    ) : CircuitUiState
+
+    sealed interface UiEvent : CircuitUiEvent {
+        data object ViewAllFavorites : UiEvent
+        data object ViewAllTools : UiEvent
+    }
+    // endregion UiState / UiEvent
+
     @Composable
     override fun present(): UiState {
         val spotlightLessons = rememberSpotlightLessons()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/home/HomeScreen.kt
@@ -1,24 +1,7 @@
 package org.cru.godtools.ui.dashboard.home
 
-import com.slack.circuit.runtime.CircuitUiEvent
-import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
-import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.tools.ToolCard
 
 @Parcelize
-data object HomeScreen : Screen {
-    data class UiState(
-        val dataLoaded: Boolean = true,
-        val banner: BannerType? = null,
-        val spotlightLessons: List<ToolCard.State> = emptyList(),
-        val favoriteTools: List<ToolCard.State> = emptyList(),
-        val eventSink: (UiEvent) -> Unit = {},
-    ) : CircuitUiState
-
-    sealed interface UiEvent : CircuitUiEvent {
-        data object ViewAllFavorites : UiEvent
-        data object ViewAllTools : UiEvent
-    }
-}
+data object HomeScreen : Screen

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
@@ -18,7 +18,7 @@ import org.cru.godtools.ui.languages.LanguageName
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
-internal fun LessonFilters(state: LessonsScreen.UiState, modifier: Modifier = Modifier) {
+internal fun LessonFilters(state: LessonsPresenter.UiState, modifier: Modifier = Modifier) {
     FlowRow(modifier = modifier) {
         Text(
             stringResource(R.string.dashboard_lessons_section_filter_label),

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -16,11 +16,12 @@ import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.components.SingletonComponent
 import org.cru.godtools.R
+import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiState
 import org.cru.godtools.ui.tools.LessonToolCard
 
 @Composable
 @CircuitInject(LessonsScreen::class, SingletonComponent::class)
-internal fun LessonsLayout(state: LessonsScreen.UiState, modifier: Modifier = Modifier) {
+internal fun LessonsLayout(state: UiState, modifier: Modifier = Modifier) {
     LazyColumn(contentPadding = PaddingValues(16.dp), modifier = modifier) {
         item("header", "header") {
             LessonsHeader()

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenter.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuitx.android.IntentScreen
@@ -21,7 +22,6 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import java.util.Locale
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
@@ -43,6 +43,7 @@ import org.cru.godtools.db.repository.TranslationsRepository
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Language.Companion.filterByDisplayAndNativeName
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiState
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardPresenter
 import org.cru.godtools.util.createToolIntent
@@ -59,13 +60,20 @@ class LessonsPresenter @AssistedInject constructor(
     private val translationsRepository: TranslationsRepository,
     @param:DispatcherType(IO) private val ioDispatcher: CoroutineDispatcher,
     @Assisted private val navigator: Navigator,
-) : Presenter<LessonsScreen.UiState> {
+) : Presenter<UiState> {
+    // region UiState
+    data class UiState(
+        val languageFilter: FilterMenu.UiState<Language> = FilterMenu.UiState(),
+        val lessons: List<ToolCard.State> = emptyList(),
+    ) : CircuitUiState
+    // endregion UiState
+
     @Composable
-    override fun present(): LessonsScreen.UiState {
+    override fun present(): UiState {
         val appLanguage by settings.appLanguageFlow.collectAsState()
         val languageFilter = rememberLanguagesFilter()
 
-        return LessonsScreen.UiState(
+        return UiState(
             languageFilter = languageFilter,
             lessons = rememberLessons(languageFilter.selectedItem?.code ?: appLanguage),
         )
@@ -131,13 +139,13 @@ class LessonsPresenter @AssistedInject constructor(
     }
 
     @Composable
-    private fun rememberLessons(locale: Locale): ImmutableList<ToolCard.State> {
+    private fun rememberLessons(locale: Locale): List<ToolCard.State> {
         val lessons by remember(locale) {
             toolsRepository.getLessonsFlowByLanguage(locale)
                 .map { it.filterNot { it.isHidden }.sortedBy { it.defaultOrder } }
         }.collectAsState(emptyList())
 
-        return lessons.mapTo(persistentListOf<ToolCard.State>().builder()) { tool ->
+        return lessons.map { tool ->
             key(tool.code) {
                 lateinit var toolState: ToolCard.State
                 toolState = toolCardPresenter.present(
@@ -167,7 +175,7 @@ class LessonsPresenter @AssistedInject constructor(
                 )
                 toolState
             }
-        }.build()
+        }
     }
 
     @AssistedFactory

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsScreen.kt
@@ -1,18 +1,7 @@
 package org.cru.godtools.ui.dashboard.lessons
 
-import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.parcelize.Parcelize
-import org.cru.godtools.model.Language
-import org.cru.godtools.ui.dashboard.filters.FilterMenu
-import org.cru.godtools.ui.tools.ToolCard
 
 @Parcelize
-data object LessonsScreen : Screen {
-    data class UiState(
-        val languageFilter: FilterMenu.UiState<Language> = FilterMenu.UiState(),
-        val lessons: ImmutableList<ToolCard.State> = persistentListOf(),
-    ) : CircuitUiState
-}
+data object LessonsScreen : Screen

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FilteredToolsFlowProducer.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FilteredToolsFlowProducer.kt
@@ -1,0 +1,28 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import org.cru.godtools.db.repository.ToolsRepository
+import org.cru.godtools.model.Tool
+
+internal class FilteredToolsFlowProducer @Inject constructor(private val toolsRepository: ToolsRepository) {
+    fun getFlow(category: String? = null, language: Locale? = null): Flow<List<Tool>> {
+        val baseFlow = when (language) {
+            null -> toolsRepository.getNormalToolsFlow()
+            else -> toolsRepository.getNormalToolsFlowByLanguage(language)
+        }
+
+        val defaultVariantsFlow = toolsRepository.getMetaToolsFlow()
+            .map { it.associateBy({ it.code }, { it.defaultVariantCode }) }
+
+        return baseFlow
+            .map { it.filterNot { it.isHidden }.sortedBy { it.defaultOrder } }
+            .combine(defaultVariantsFlow) { tools, defaultVariants ->
+                tools.filter { it.metatoolCode == null || it.code == defaultVariants[it.metatoolCode] }
+            }
+            .map { tools -> if (category == null) tools else tools.filter { it.category == category } }
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
@@ -35,7 +35,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.dashboard.filters.FilterMenuItem
 import org.cru.godtools.ui.dashboard.filters.LazyFilterMenu
-import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Filters
+import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
 import org.cru.godtools.ui.languages.LanguageName
 import org.jetbrains.annotations.VisibleForTesting
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
@@ -35,6 +35,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.dashboard.filters.FilterMenuItem
 import org.cru.godtools.ui.dashboard.filters.LazyFilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Filters
 import org.cru.godtools.ui.languages.LanguageName
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -43,7 +44,7 @@ private val DROPDOWN_MAX_HEIGHT = 700.dp
 internal const val TEST_TAG_FILTER_DROPDOWN = "filter_dropdown"
 
 @Composable
-internal fun ToolFilters(filters: ToolsScreen.Filters, modifier: Modifier = Modifier) {
+internal fun ToolFilters(filters: Filters, modifier: Modifier = Modifier) {
     Column(modifier.fillMaxWidth()) {
         Text(
             stringResource(R.string.dashboard_tools_section_filter_label),

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersStateProducer.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersStateProducer.kt
@@ -1,0 +1,154 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import com.slack.circuit.runtime.CircuitUiState
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.Locale
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
+import org.ccci.gto.android.common.dagger.coroutines.DispatcherType
+import org.ccci.gto.android.common.dagger.coroutines.DispatcherType.Type.IO
+import org.cru.godtools.base.Settings
+import org.cru.godtools.db.repository.LanguagesRepository
+import org.cru.godtools.db.repository.TranslationsRepository
+import org.cru.godtools.db.repository.rememberLanguage
+import org.cru.godtools.model.Language
+import org.cru.godtools.model.Language.Companion.filterByDisplayAndNativeName
+import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
+
+interface ToolFiltersStateProducer {
+    data class Filters(
+        val categoryFilter: FilterMenu.UiState<String?> = FilterMenu.UiState(),
+        val languageFilter: FilterMenu.UiState<Language?> = FilterMenu.UiState(),
+    ) : CircuitUiState
+
+    @Composable
+    fun produce(): Filters
+}
+
+internal class DefaultToolFiltersStateProducer @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val filteredToolsFlowProducer: FilteredToolsFlowProducer,
+    private val languagesRepository: LanguagesRepository,
+    private val settings: Settings,
+    private val translationsRepository: TranslationsRepository,
+    @param:DispatcherType(IO) private val ioDispatcher: CoroutineDispatcher,
+) : ToolFiltersStateProducer {
+    @Composable
+    override fun produce(): Filters {
+        val scope = rememberCoroutineScope()
+
+        val selectedCategory by remember { settings.getDashboardFilterCategoryFlow() }.collectAsState(null)
+        val selectedLocale by remember { settings.getDashboardFilterLocaleFlow() }.collectAsState(null)
+
+        val languageMenuExpanded = rememberSaveable { mutableStateOf(false) }
+        val languageQuery = rememberSaveable { mutableStateOf("") }
+        LaunchedEffect(languageMenuExpanded.value) {
+            if (!languageMenuExpanded.value) languageQuery.value = ""
+        }
+
+        return Filters(
+            categoryFilter = FilterMenu.UiState(
+                menuExpanded = rememberSaveable { mutableStateOf(false) },
+                items = rememberFilterCategories(selectedLocale),
+                query = remember { mutableStateOf("") },
+                selectedItem = selectedCategory,
+                eventSink = {
+                    when (it) {
+                        is FilterMenu.Event.SelectItem -> scope.launch {
+                            settings.updateDashboardFilterCategory(it.item)
+                        }
+                    }
+                }
+            ),
+            languageFilter = FilterMenu.UiState(
+                menuExpanded = languageMenuExpanded,
+                items = rememberFilterLanguages(selectedCategory, languageQuery.value),
+                selectedItem = languagesRepository.rememberLanguage(selectedLocale),
+                query = languageQuery,
+                eventSink = {
+                    when (it) {
+                        is FilterMenu.Event.SelectItem -> scope.launch {
+                            settings.updateDashboardFilterLocale(it.item?.code)
+                        }
+                    }
+                }
+            ),
+        )
+    }
+
+    @Composable
+    private fun rememberFilterCategories(selectedLanguage: Locale?) = remember(selectedLanguage) {
+        filteredToolsFlowProducer.getFlow(language = selectedLanguage).map {
+            it.groupBy { it.category }
+                .map { (category, tools) -> FilterMenu.UiState.Item(category, tools.size) }
+        }
+    }.collectAsState(emptyList()).value
+
+    @Composable
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun rememberFilterLanguages(category: String?, query: String): List<FilterMenu.UiState.Item<Language?>> {
+        val scope = rememberCoroutineScope()
+
+        val categoryFlow = remember { MutableStateFlow(category) }.apply { value = category }
+        val queryFlow = remember { MutableStateFlow(query) }.apply { value = query }
+
+        val languagesFlow = remember {
+            categoryFlow
+                .flatMapLatest {
+                    when (it) {
+                        null -> languagesRepository.getLanguagesFlow()
+                        else -> languagesRepository.getLanguagesFlowForToolCategory(it)
+                    }
+                }
+                .combine(settings.appLanguageFlow) { languages, appLang ->
+                    languages.sortedWith(Language.displayNameComparator(context, appLang))
+                }
+                .flowOn(ioDispatcher)
+                .shareIn(scope, started = SharingStarted.WhileSubscribed(5_000), replay = 1)
+        }
+
+        return remember(category) {
+            val toolCountsFlow = filteredToolsFlowProducer.getFlow(category = category)
+                .map { it.mapNotNullTo(mutableSetOf()) { it.code } }
+                .distinctUntilChanged()
+                .flatMapLatest { translationsRepository.getTranslationsFlowForTools(it) }
+                .map { translations ->
+                    translations
+                        .groupBy { it.languageCode }
+                        .mapValues { it.value.distinctBy { it.toolCode }.count() }
+                }
+
+            combine(
+                languagesFlow,
+                settings.appLanguageFlow,
+                queryFlow,
+            ) { languages, appLang, query -> languages.filterByDisplayAndNativeName(query, context, appLang) }
+                .flowOn(ioDispatcher)
+                .combine(toolCountsFlow) { languages, toolCounts ->
+                    languages
+                        .let { listOf(null) + it }
+                        .map { FilterMenu.UiState.Item(it, toolCounts[it?.code] ?: 0) }
+                }
+        }.collectAsState(emptyList()).value
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -24,6 +24,7 @@ import dagger.hilt.components.SingletonComponent
 import org.ccci.gto.android.common.androidx.compose.foundation.layout.padding
 import org.cru.godtools.R
 import org.cru.godtools.ui.banner.Banners
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState
 import org.cru.godtools.ui.tools.SquareToolCard
 import org.cru.godtools.ui.tools.ToolCard
 
@@ -31,7 +32,7 @@ internal val MARGIN_TOOLS_LAYOUT_HORIZONTAL = 16.dp
 
 @Composable
 @CircuitInject(ToolsScreen::class, SingletonComponent::class)
-internal fun ToolsLayout(state: ToolsScreen.State, modifier: Modifier = Modifier) {
+internal fun ToolsLayout(state: UiState, modifier: Modifier = Modifier) {
     val banner by rememberUpdatedState(state.banner)
     val spotlightTools by rememberUpdatedState(state.spotlightTools)
     val filters by rememberUpdatedState(state.filters)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsModule.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsModule.kt
@@ -1,0 +1,13 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ToolsModule {
+    @Binds
+    abstract fun toolFiltersStateProducer(impl: DefaultToolFiltersStateProducer): ToolFiltersStateProducer
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dagger.assisted.Assisted
@@ -49,6 +51,7 @@ import org.cru.godtools.model.Language.Companion.filterByDisplayAndNativeName
 import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.banner.BannerType
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen
 import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardPresenter
@@ -65,16 +68,36 @@ class ToolsPresenter @AssistedInject constructor(
     private val translationsRepository: TranslationsRepository,
     @param:DispatcherType(IO) private val ioDispatcher: CoroutineDispatcher,
     @Assisted private val navigator: Navigator,
-) : Presenter<ToolsScreen.State> {
+) : Presenter<UiState> {
+    // region UiState / UiEvent
+    data class UiState(
+        val banner: BannerType? = null,
+        val dataLoaded: Boolean = true,
+        val spotlightTools: List<ToolCard.State> = emptyList(),
+        val filters: Filters = Filters(),
+        val tools: List<ToolCard.State> = emptyList(),
+        val eventSink: (ToolsPresenter.UiEvent) -> Unit = {},
+    ) : CircuitUiState {
+        data class Filters(
+            val categoryFilter: FilterMenu.UiState<String?> = FilterMenu.UiState(),
+            val languageFilter: FilterMenu.UiState<Language?> = FilterMenu.UiState(),
+        ) : CircuitUiState
+    }
+
+    sealed interface UiEvent : CircuitUiEvent {
+        data class OpenToolDetails(val tool: String, val source: String? = null) : UiEvent
+    }
+    // endregion UiState / UiEvent
+
     @Composable
-    override fun present(): ToolsScreen.State {
+    override fun present(): UiState {
         val filters = rememberFilters()
         val selectedLocale by rememberUpdatedState(filters.languageFilter.selectedItem?.code)
 
-        val eventSink: (ToolsScreen.Event) -> Unit = remember {
+        val eventSink: (UiEvent) -> Unit = remember {
             {
                 when (it) {
-                    is ToolsScreen.Event.OpenToolDetails -> {
+                    is UiEvent.OpenToolDetails -> {
                         if (it.source != null) {
                             eventBus.post(OpenAnalyticsActionEvent(ACTION_OPEN_TOOL_DETAILS, it.tool, it.source))
                         }
@@ -94,7 +117,7 @@ class ToolsPresenter @AssistedInject constructor(
             eventSink = eventSink,
         )
 
-        return ToolsScreen.State(
+        return UiState(
             banner = rememberBanner(),
             dataLoaded = spotlightTools != null && tools != null,
             spotlightTools = spotlightTools.orEmpty(),
@@ -111,7 +134,7 @@ class ToolsPresenter @AssistedInject constructor(
     }.collectAsState(null).value
 
     @Composable
-    private fun rememberFilters(): ToolsScreen.Filters {
+    private fun rememberFilters(): UiState.Filters {
         val scope = rememberCoroutineScope()
 
         val selectedCategory by remember { settings.getDashboardFilterCategoryFlow() }.collectAsState(null)
@@ -123,7 +146,7 @@ class ToolsPresenter @AssistedInject constructor(
             if (!languageMenuExpanded.value) languageQuery.value = ""
         }
 
-        return ToolsScreen.Filters(
+        return UiState.Filters(
             categoryFilter = FilterMenu.UiState(
                 menuExpanded = rememberSaveable { mutableStateOf(false) },
                 items = rememberFilterCategories(selectedLocale),
@@ -217,7 +240,7 @@ class ToolsPresenter @AssistedInject constructor(
     @Composable
     private fun rememberSpotlightTools(
         secondLanguage: Language?,
-        eventSink: (ToolsScreen.Event) -> Unit,
+        eventSink: (UiEvent) -> Unit,
     ): List<ToolCard.State>? {
         val tools by remember {
             toolsRepository.getNormalToolsFlow()
@@ -236,7 +259,7 @@ class ToolsPresenter @AssistedInject constructor(
                         ToolCard.Event.Click,
                         ToolCard.Event.OpenTool,
                         ToolCard.Event.OpenToolDetails ->
-                            toolCode?.let { eventSink(ToolsScreen.Event.OpenToolDetails(it, SOURCE_SPOTLIGHT)) }
+                            toolCode?.let { eventSink(UiEvent.OpenToolDetails(it, SOURCE_SPOTLIGHT)) }
 
                         ToolCard.Event.PinTool,
                         ToolCard.Event.UnpinTool -> error("$it should be handled by the ToolCardPresenter")
@@ -250,7 +273,7 @@ class ToolsPresenter @AssistedInject constructor(
     private fun rememberTools(
         category: String?,
         language: Language?,
-        eventSink: (ToolsScreen.Event) -> Unit,
+        eventSink: (UiEvent) -> Unit,
     ): List<ToolCard.State>? {
         val tools by rememberFilteredToolsFlow(category, language?.code).collectAsState(null)
         val eventSink by rememberUpdatedState(eventSink)
@@ -266,7 +289,7 @@ class ToolsPresenter @AssistedInject constructor(
                             ToolCard.Event.Click,
                             ToolCard.Event.OpenTool,
                             ToolCard.Event.OpenToolDetails ->
-                                toolCode?.let { eventSink(ToolsScreen.Event.OpenToolDetails(it, SOURCE_ALL_TOOLS)) }
+                                toolCode?.let { eventSink(UiEvent.OpenToolDetails(it, SOURCE_ALL_TOOLS)) }
 
                             ToolCard.Event.PinTool,
                             ToolCard.Event.UnpinTool -> error("$it should be handled by the ToolCardPresenter")

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
@@ -1,16 +1,11 @@
 package org.cru.godtools.ui.dashboard.tools
 
-import android.content.Context
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
@@ -19,39 +14,18 @@ import com.slack.circuit.runtime.presenter.Presenter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import java.util.Locale
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
-import org.ccci.gto.android.common.dagger.coroutines.DispatcherType
-import org.ccci.gto.android.common.dagger.coroutines.DispatcherType.Type.IO
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.ACTION_OPEN_TOOL_DETAILS
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_ALL_TOOLS
 import org.cru.godtools.analytics.model.OpenAnalyticsActionEvent.Companion.SOURCE_SPOTLIGHT
 import org.cru.godtools.base.Settings
-import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
-import org.cru.godtools.db.repository.TranslationsRepository
-import org.cru.godtools.db.repository.rememberLanguage
 import org.cru.godtools.model.Language
-import org.cru.godtools.model.Language.Companion.filterByDisplayAndNativeName
 import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
 import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen
 import org.cru.godtools.ui.tools.ToolCard
@@ -59,16 +33,12 @@ import org.cru.godtools.ui.tools.ToolCardPresenter
 import org.greenrobot.eventbus.EventBus
 
 class ToolsPresenter @AssistedInject internal constructor(
-    @param:ApplicationContext
-    private val context: Context,
     private val eventBus: EventBus,
     private val settings: Settings,
     private val toolCardPresenter: ToolCardPresenter,
-    private val languagesRepository: LanguagesRepository,
     private val toolsRepository: ToolsRepository,
-    private val translationsRepository: TranslationsRepository,
     private val filteredToolsFlowProducer: FilteredToolsFlowProducer,
-    @param:DispatcherType(IO) private val ioDispatcher: CoroutineDispatcher,
+    private val toolFiltersStateProducer: ToolFiltersStateProducer,
     @Assisted private val navigator: Navigator,
 ) : Presenter<UiState> {
     // region UiState / UiEvent
@@ -78,13 +48,8 @@ class ToolsPresenter @AssistedInject internal constructor(
         val spotlightTools: List<ToolCard.State> = emptyList(),
         val filters: Filters = Filters(),
         val tools: List<ToolCard.State> = emptyList(),
-        val eventSink: (ToolsPresenter.UiEvent) -> Unit = {},
-    ) : CircuitUiState {
-        data class Filters(
-            val categoryFilter: FilterMenu.UiState<String?> = FilterMenu.UiState(),
-            val languageFilter: FilterMenu.UiState<Language?> = FilterMenu.UiState(),
-        ) : CircuitUiState
-    }
+        val eventSink: (UiEvent) -> Unit = {},
+    ) : CircuitUiState
 
     sealed interface UiEvent : CircuitUiEvent {
         data class OpenToolDetails(val tool: String, val source: String? = null) : UiEvent
@@ -93,7 +58,7 @@ class ToolsPresenter @AssistedInject internal constructor(
 
     @Composable
     override fun present(): UiState {
-        val filters = rememberFilters()
+        val filters = toolFiltersStateProducer.produce()
         val selectedLocale by rememberUpdatedState(filters.languageFilter.selectedItem?.code)
 
         val eventSink: (UiEvent) -> Unit = remember {
@@ -134,112 +99,6 @@ class ToolsPresenter @AssistedInject internal constructor(
         settings.isFeatureDiscoveredFlow(Settings.FEATURE_TOOL_FAVORITE)
             .map { if (!it) BannerType.TOOL_LIST_FAVORITES else null }
     }.collectAsState(null).value
-
-    @Composable
-    private fun rememberFilters(): UiState.Filters {
-        val scope = rememberCoroutineScope()
-
-        val selectedCategory by remember { settings.getDashboardFilterCategoryFlow() }.collectAsState(null)
-        val selectedLocale by remember { settings.getDashboardFilterLocaleFlow() }.collectAsState(null)
-
-        val languageMenuExpanded = rememberSaveable { mutableStateOf(false) }
-        val languageQuery = rememberSaveable { mutableStateOf("") }
-        LaunchedEffect(languageMenuExpanded.value) {
-            if (!languageMenuExpanded.value) languageQuery.value = ""
-        }
-
-        return UiState.Filters(
-            categoryFilter = FilterMenu.UiState(
-                menuExpanded = rememberSaveable { mutableStateOf(false) },
-                items = rememberFilterCategories(selectedLocale),
-                query = remember { mutableStateOf("") },
-                selectedItem = selectedCategory,
-                eventSink = {
-                    when (it) {
-                        is FilterMenu.Event.SelectItem -> scope.launch {
-                            settings.updateDashboardFilterCategory(it.item)
-                        }
-                    }
-                }
-            ),
-            languageFilter = FilterMenu.UiState(
-                menuExpanded = languageMenuExpanded,
-                items = rememberFilterLanguages(selectedCategory, languageQuery.value),
-                selectedItem = languagesRepository.rememberLanguage(selectedLocale),
-                query = languageQuery,
-                eventSink = {
-                    when (it) {
-                        is FilterMenu.Event.SelectItem -> scope.launch {
-                            settings.updateDashboardFilterLocale(it.item?.code)
-                        }
-                    }
-                }
-            ),
-        )
-    }
-
-    @Composable
-    private fun rememberFilterCategories(selectedLanguage: Locale?): ImmutableList<FilterMenu.UiState.Item<String?>> {
-        return remember(selectedLanguage) {
-            filteredToolsFlowProducer.getFlow(language = selectedLanguage).map {
-                it.groupBy { it.category }
-                    .map { (category, tools) -> FilterMenu.UiState.Item(category, tools.size) }
-                    .toImmutableList()
-            }
-        }.collectAsState(persistentListOf()).value
-    }
-
-    @Composable
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun rememberFilterLanguages(
-        category: String?,
-        query: String,
-    ): ImmutableList<FilterMenu.UiState.Item<Language?>> {
-        val scope = rememberCoroutineScope()
-
-        val categoryFlow = remember { MutableStateFlow(category) }.apply { value = category }
-        val queryFlow = remember { MutableStateFlow(query) }.apply { value = query }
-
-        val languagesFlow = remember {
-            categoryFlow
-                .flatMapLatest {
-                    when (it) {
-                        null -> languagesRepository.getLanguagesFlow()
-                        else -> languagesRepository.getLanguagesFlowForToolCategory(it)
-                    }
-                }
-                .combine(settings.appLanguageFlow) { languages, appLang ->
-                    languages.sortedWith(Language.displayNameComparator(context, appLang))
-                }
-                .flowOn(ioDispatcher)
-                .shareIn(scope, started = SharingStarted.WhileSubscribed(5_000), replay = 1)
-        }
-
-        return remember(category) {
-            val toolCountsFlow = filteredToolsFlowProducer.getFlow(category = category)
-                .map { it.mapNotNullTo(mutableSetOf()) { it.code } }
-                .distinctUntilChanged()
-                .flatMapLatest { translationsRepository.getTranslationsFlowForTools(it) }
-                .map { translations ->
-                    translations
-                        .groupBy { it.languageCode }
-                        .mapValues { it.value.distinctBy { it.toolCode }.count() }
-                }
-
-            combine(
-                languagesFlow,
-                settings.appLanguageFlow,
-                queryFlow,
-            ) { languages, appLang, query -> languages.filterByDisplayAndNativeName(query, context, appLang) }
-                .flowOn(ioDispatcher)
-                .combine(toolCountsFlow) { languages, toolCounts ->
-                    languages
-                        .let { listOf(null) + it }
-                        .map { FilterMenu.UiState.Item(it, toolCounts[it?.code] ?: 0) }
-                        .toImmutableList()
-                }
-        }.collectAsState(persistentListOf()).value
-    }
 
     @Composable
     private fun rememberSpotlightTools(

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
@@ -27,13 +27,14 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.dagger.coroutines.DispatcherType
 import org.ccci.gto.android.common.dagger.coroutines.DispatcherType.Type.IO
@@ -57,7 +58,7 @@ import org.cru.godtools.ui.tools.ToolCard
 import org.cru.godtools.ui.tools.ToolCardPresenter
 import org.greenrobot.eventbus.EventBus
 
-class ToolsPresenter @AssistedInject constructor(
+class ToolsPresenter @AssistedInject internal constructor(
     @param:ApplicationContext
     private val context: Context,
     private val eventBus: EventBus,
@@ -66,6 +67,7 @@ class ToolsPresenter @AssistedInject constructor(
     private val languagesRepository: LanguagesRepository,
     private val toolsRepository: ToolsRepository,
     private val translationsRepository: TranslationsRepository,
+    private val filteredToolsFlowProducer: FilteredToolsFlowProducer,
     @param:DispatcherType(IO) private val ioDispatcher: CoroutineDispatcher,
     @Assisted private val navigator: Navigator,
 ) : Presenter<UiState> {
@@ -178,10 +180,8 @@ class ToolsPresenter @AssistedInject constructor(
 
     @Composable
     private fun rememberFilterCategories(selectedLanguage: Locale?): ImmutableList<FilterMenu.UiState.Item<String?>> {
-        val filteredToolsFlow = rememberFilteredToolsFlow(language = selectedLanguage)
-
-        return remember(filteredToolsFlow) {
-            filteredToolsFlow.map {
+        return remember(selectedLanguage) {
+            filteredToolsFlowProducer.getFlow(language = selectedLanguage).map {
                 it.groupBy { it.category }
                     .map { (category, tools) -> FilterMenu.UiState.Item(category, tools.size) }
                     .toImmutableList()
@@ -195,12 +195,13 @@ class ToolsPresenter @AssistedInject constructor(
         category: String?,
         query: String,
     ): ImmutableList<FilterMenu.UiState.Item<Language?>> {
+        val scope = rememberCoroutineScope()
+
         val categoryFlow = remember { MutableStateFlow(category) }.apply { value = category }
         val queryFlow = remember { MutableStateFlow(query) }.apply { value = query }
-        val toolsFlow = rememberFilteredToolsFlow(category = category)
 
-        return remember {
-            val languagesFlow = categoryFlow
+        val languagesFlow = remember {
+            categoryFlow
                 .flatMapLatest {
                     when (it) {
                         null -> languagesRepository.getLanguagesFlow()
@@ -211,8 +212,11 @@ class ToolsPresenter @AssistedInject constructor(
                     languages.sortedWith(Language.displayNameComparator(context, appLang))
                 }
                 .flowOn(ioDispatcher)
+                .shareIn(scope, started = SharingStarted.WhileSubscribed(5_000), replay = 1)
+        }
 
-            val toolCountsFlow = toolsFlow
+        return remember(category) {
+            val toolCountsFlow = filteredToolsFlowProducer.getFlow(category = category)
                 .map { it.mapNotNullTo(mutableSetOf()) { it.code } }
                 .distinctUntilChanged()
                 .flatMapLatest { translationsRepository.getTranslationsFlowForTools(it) }
@@ -275,7 +279,9 @@ class ToolsPresenter @AssistedInject constructor(
         language: Language?,
         eventSink: (UiEvent) -> Unit,
     ): List<ToolCard.State>? {
-        val tools by rememberFilteredToolsFlow(category, language?.code).collectAsState(null)
+        val locale = language?.code
+        val tools by remember(category, locale) { filteredToolsFlowProducer.getFlow(category, locale) }
+            .collectAsState(null)
         val eventSink by rememberUpdatedState(eventSink)
 
         return tools?.map { tool ->
@@ -297,33 +303,6 @@ class ToolsPresenter @AssistedInject constructor(
                     }
                 )
             }
-        }
-    }
-
-    @Composable
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun rememberFilteredToolsFlow(category: String? = null, language: Locale? = null): Flow<List<Tool>> {
-        val categoryFlow = remember { MutableStateFlow(category) }.apply { value = category }
-        val languageFlow = remember { MutableStateFlow(language) }.apply { value = language }
-
-        return remember {
-            val defaultVariantsFlow = toolsRepository.getMetaToolsFlow()
-                .map { it.associateBy({ it.code }, { it.defaultVariantCode }) }
-
-            languageFlow
-                .flatMapLatest {
-                    when (it) {
-                        null -> toolsRepository.getNormalToolsFlow()
-                        else -> toolsRepository.getNormalToolsFlowByLanguage(it)
-                    }
-                }
-                .map { it.filterNot { it.isHidden }.sortedBy { it.defaultOrder } }
-                .combine(defaultVariantsFlow) { tools, defaultVariants ->
-                    tools.filter { it.metatoolCode == null || it.code == defaultVariants[it.metatoolCode] }
-                }
-                .combine(categoryFlow) { tools, category ->
-                    if (category == null) tools else tools.filter { it.category == category }
-                }
         }
     }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsScreen.kt
@@ -1,31 +1,7 @@
 package org.cru.godtools.ui.dashboard.tools
 
-import com.slack.circuit.runtime.CircuitUiEvent
-import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
-import org.cru.godtools.model.Language
-import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.filters.FilterMenu
-import org.cru.godtools.ui.tools.ToolCard
 
 @Parcelize
-data object ToolsScreen : Screen {
-    data class State(
-        val banner: BannerType? = null,
-        val dataLoaded: Boolean = true,
-        val spotlightTools: List<ToolCard.State> = emptyList(),
-        val filters: Filters = Filters(),
-        val tools: List<ToolCard.State> = emptyList(),
-        val eventSink: (Event) -> Unit = {},
-    ) : CircuitUiState
-
-    data class Filters(
-        val categoryFilter: FilterMenu.UiState<String?> = FilterMenu.UiState(),
-        val languageFilter: FilterMenu.UiState<Language?> = FilterMenu.UiState(),
-    ) : CircuitUiState
-
-    sealed interface Event : CircuitUiEvent {
-        data class OpenToolDetails(val tool: String, val source: String? = null) : Event
-    }
-}
+data object ToolsScreen : Screen

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/DefaultToolFiltersStateProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/DefaultToolFiltersStateProducerTest.kt
@@ -1,0 +1,270 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.slack.circuit.test.presenterTestOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.excludeRecords
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.ccci.gto.android.common.androidx.compose.ui.platform.AndroidUiDispatcherUtil
+import org.cru.godtools.base.Settings
+import org.cru.godtools.db.repository.LanguagesRepository
+import org.cru.godtools.db.repository.TranslationsRepository
+import org.cru.godtools.model.Language
+import org.cru.godtools.model.Tool
+import org.cru.godtools.model.Translation
+import org.cru.godtools.model.randomTool
+import org.cru.godtools.model.randomTranslation
+import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = Application::class)
+@Suppress("UnusedFlow")
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultToolFiltersStateProducerTest {
+    private val appLanguage = MutableStateFlow(Locale.ENGLISH)
+    private val filteredToolsFlow = MutableStateFlow(emptyList<Tool>())
+    private val languagesFlow = MutableStateFlow(emptyList<Language>())
+    private val gospelLanguagesFlow = MutableStateFlow(emptyList<Language>())
+    private val selectedCategory = MutableStateFlow<String?>(null)
+    private val selectedLocale = MutableStateFlow<Locale?>(null)
+
+    private val testScope = TestScope()
+
+    private val filteredToolsFlowProducer: FilteredToolsFlowProducer = mockk {
+        every { getFlow(any(), any()) } returns filteredToolsFlow
+    }
+    private val languagesRepository: LanguagesRepository = mockk {
+        every { findLanguageFlow(any()) } returns flowOf(null)
+        every { getLanguagesFlow() } returns languagesFlow
+        every { getLanguagesFlowForToolCategory(Tool.CATEGORY_GOSPEL) } returns gospelLanguagesFlow
+
+        excludeRecords { this@mockk.equals(any()) }
+    }
+    private val settings: Settings = mockk {
+        every { appLanguage } returns this@DefaultToolFiltersStateProducerTest.appLanguage.value
+        every { appLanguageFlow } returns this@DefaultToolFiltersStateProducerTest.appLanguage
+        every { getDashboardFilterCategoryFlow() } returns selectedCategory
+        every { getDashboardFilterLocaleFlow() } returns selectedLocale
+        coEvery { updateDashboardFilterCategory(any()) } answers { selectedCategory.value = firstArg() }
+        coEvery { updateDashboardFilterLocale(any()) } answers { selectedLocale.value = firstArg() }
+    }
+    private val translationsRepository: TranslationsRepository = mockk {
+        every { getTranslationsFlowForTools(any()) } returns flowOf(emptyList())
+    }
+
+    private lateinit var producer: DefaultToolFiltersStateProducer
+
+    @BeforeTest
+    fun setup() {
+        producer = DefaultToolFiltersStateProducer(
+            context = ApplicationProvider.getApplicationContext(),
+            filteredToolsFlowProducer = filteredToolsFlowProducer,
+            languagesRepository = languagesRepository,
+            settings = settings,
+            translationsRepository = translationsRepository,
+            ioDispatcher = UnconfinedTestDispatcher(testScope.testScheduler),
+        )
+    }
+
+    @AfterTest
+    fun cleanup() = AndroidUiDispatcherUtil.runScheduledDispatches()
+
+    // region Filters.categoryFilter.items
+    @Test
+    fun `Filters - categoryFilter - items - distinct & ordered by tool order`() = testScope.runTest {
+        filteredToolsFlow.value = listOf(
+            randomTool(category = Tool.CATEGORY_ARTICLES),
+            randomTool(category = Tool.CATEGORY_GOSPEL),
+            randomTool(category = Tool.CATEGORY_ARTICLES),
+        )
+
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            assertEquals(
+                listOf(
+                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_ARTICLES, 2),
+                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1)
+                ),
+                expectMostRecentItem().categoryFilter.items
+            )
+        }
+    }
+
+    @Test
+    fun `Filters - categoryFilter - items - uses selected language`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            awaitItem().languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
+            expectMostRecentItem()
+
+            verify { filteredToolsFlowProducer.getFlow(language = Locale.FRENCH) }
+        }
+    }
+    // endregion Filters.categoryFilter.items
+
+    // region Filters.languageFilter.items
+    @Test
+    fun `Filters - languageFilter - items - no category`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
+            assertEquals(
+                listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
+                ),
+                expectMostRecentItem().languageFilter.items
+            )
+        }
+
+        verifyAll { languagesRepository.getLanguagesFlow() }
+    }
+
+    @Test
+    fun `Filters - languageFilter - items - for category`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            awaitItem().categoryFilter.eventSink(FilterMenu.Event.SelectItem(Tool.CATEGORY_GOSPEL))
+
+            gospelLanguagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
+            assertEquals(
+                listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
+                ),
+                expectMostRecentItem().languageFilter.items
+            )
+        }
+    }
+
+    @Test
+    fun `Filters - languageFilter - items - include tool count`() = testScope.runTest {
+        val translationsFlow = MutableStateFlow(emptyList<Translation>())
+        every { translationsRepository.getTranslationsFlowForTools(setOf("tool1", "tool2")) } returns translationsFlow
+
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            filteredToolsFlow.value = listOf(
+                randomTool("tool1", isHidden = false),
+                randomTool("tool2", isHidden = false),
+            )
+            translationsFlow.value = listOf(
+                randomTranslation("tool1", Locale.ENGLISH),
+                randomTranslation("tool1", Locale.FRENCH),
+                randomTranslation("tool2", Locale.ENGLISH, version = 1),
+                randomTranslation("tool2", Locale.ENGLISH, version = 2),
+            )
+            languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
+
+            assertEquals(
+                listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 2),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 1)
+                ),
+                expectMostRecentItem().languageFilter.items
+            )
+        }
+    }
+
+    @Test
+    fun `Filters - languageFilter - items - filtered by query`() = testScope.runTest {
+        languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
+
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            expectMostRecentItem().languageFilter.let {
+                it.menuExpanded.value = true
+                assertEquals(
+                    listOf(
+                        FilterMenu.UiState.Item(null, 0),
+                        FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
+                        FilterMenu.UiState.Item(Language(Locale.FRENCH), 0),
+                    ),
+                    it.items
+                )
+                it.query.value = "french"
+            }
+
+            assertEquals(
+                listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
+                ),
+                expectMostRecentItem().languageFilter.items
+            )
+        }
+
+        verifyAll { languagesRepository.getLanguagesFlow() }
+    }
+    // endregion Filters.languageFilter.items
+
+    // region Filters.languageFilter.selectedItem
+    @Test
+    fun `Filters - languageFilter - selectedItem - no language selected`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            assertNull(expectMostRecentItem().languageFilter.selectedItem)
+        }
+
+        verify(inverse = true) { languagesRepository.findLanguageFlow(any()) }
+    }
+
+    @Test
+    fun `Filters - languageFilter - selectedItem - language not found`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            awaitItem().languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.ENGLISH)))
+
+            assertNull(expectMostRecentItem().languageFilter.selectedItem)
+        }
+
+        verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
+    }
+
+    @Test
+    fun `Filters - languageFilter - selectedItem - language selected`() = testScope.runTest {
+        val language = Language(Locale.ENGLISH)
+        every { languagesRepository.findLanguageFlow(Locale.ENGLISH) } returns flowOf(language)
+
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            awaitItem().languageFilter.eventSink(FilterMenu.Event.SelectItem(language))
+
+            assertEquals(language, expectMostRecentItem().languageFilter.selectedItem)
+        }
+
+        verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
+    }
+    // endregion Filters.languageFilter.selectedItem
+
+    // region Filters.languageFilter.menuExpanded
+    @Test
+    fun `Filters - languageFilter - menuExpanded - resets query when set to false`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce() }) {
+            val state = expectMostRecentItem().languageFilter
+
+            state.menuExpanded.value = true
+            state.query.value = "test"
+            assertEquals("test", state.query.value)
+
+            state.menuExpanded.value = false
+            assertEquals("", state.query.value)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+    // endregion Filters.languageFilter.menuExpanded
+}

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FakeToolFiltersStateProducer.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FakeToolFiltersStateProducer.kt
@@ -1,0 +1,13 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
+
+class FakeToolFiltersStateProducer : ToolFiltersStateProducer {
+    val filters = MutableStateFlow(Filters())
+
+    @Composable
+    override fun produce() = filters.collectAsState().value
+}

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FilteredToolsFlowProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FilteredToolsFlowProducerTest.kt
@@ -1,0 +1,187 @@
+package org.cru.godtools.ui.dashboard.tools
+
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.cru.godtools.db.repository.ToolsRepository
+import org.cru.godtools.model.Tool
+import org.cru.godtools.model.randomTool
+
+@Suppress("UnusedFlow")
+class FilteredToolsFlowProducerTest {
+    private val metatoolsFlow = MutableStateFlow(emptyList<Tool>())
+    private val normalToolsFlow = MutableStateFlow(emptyList<Tool>())
+
+    private val toolsRepository: ToolsRepository = mockk {
+        every { getNormalToolsFlow() } returns normalToolsFlow
+        every { getNormalToolsFlowByLanguage(any()) } returns flowOf(emptyList())
+        every { getMetaToolsFlow() } returns metatoolsFlow
+    }
+
+    private val producer = FilteredToolsFlowProducer(toolsRepository)
+
+    // region language selection
+    @Test
+    fun `getFlow - no language - uses getNormalToolsFlow`() = runTest {
+        producer.getFlow(language = null).first()
+        verify { toolsRepository.getNormalToolsFlow() }
+        verify(exactly = 0) { toolsRepository.getNormalToolsFlowByLanguage(any()) }
+    }
+
+    @Test
+    fun `getFlow - with language - uses getNormalToolsFlowByLanguage`() = runTest {
+        producer.getFlow(language = Locale.FRENCH).first()
+        verify { toolsRepository.getNormalToolsFlowByLanguage(Locale.FRENCH) }
+        verify(exactly = 0) { toolsRepository.getNormalToolsFlow() }
+    }
+    // endregion language selection
+
+    // region hidden filter
+    @Test
+    fun `getFlow - hidden tools are excluded`() = runTest {
+        val hidden = createTool(isHidden = true)
+        val visible = createTool(isHidden = false)
+
+        normalToolsFlow.value = listOf(hidden, visible)
+        assertEquals(listOf(visible), producer.getFlow().first())
+    }
+
+    @Test
+    fun `getFlow - visible tools are included`() = runTest {
+        val tool = createTool(isHidden = false)
+
+        normalToolsFlow.value = listOf(tool)
+        assertEquals(listOf(tool), producer.getFlow().first())
+    }
+    // endregion hidden filter
+
+    // region sort order
+    @Test
+    fun `getFlow - tools sorted by defaultOrder`() = runTest {
+        val tools = List(5) { createTool(defaultOrder = it) }
+
+        normalToolsFlow.value = tools.shuffled()
+        assertEquals(tools, producer.getFlow().first())
+    }
+    // endregion sort order
+
+    // region default variant filtering
+    @Test
+    fun `getFlow - non-variant tools always included`() = runTest {
+        val tool = createTool(metatoolCode = null)
+
+        normalToolsFlow.value = listOf(tool)
+        assertEquals(listOf(tool), producer.getFlow().first())
+    }
+
+    @Test
+    fun `getFlow - default variant is included`() = runTest {
+        val meta = randomTool("meta", type = Tool.Type.META, defaultVariantCode = "default")
+        val defaultVariant = randomTool("default", metatoolCode = "meta", isHidden = false)
+
+        metatoolsFlow.value = listOf(meta)
+        normalToolsFlow.value = listOf(defaultVariant)
+        assertEquals(listOf(defaultVariant), producer.getFlow().first())
+    }
+
+    @Test
+    fun `getFlow - non-default variant is excluded`() = runTest {
+        val meta = randomTool("meta", type = Tool.Type.META, defaultVariantCode = "default")
+        val nonDefault = randomTool("other", metatoolCode = "meta", isHidden = false)
+
+        metatoolsFlow.value = listOf(meta)
+        normalToolsFlow.value = listOf(nonDefault)
+        assertEquals(emptyList(), producer.getFlow().first())
+    }
+
+    @Test
+    fun `getFlow - variant with no matching metatool is excluded`() = runTest {
+        val orphan = randomTool("orphan", metatoolCode = "missing-meta", isHidden = false)
+
+        normalToolsFlow.value = listOf(orphan)
+        assertEquals(emptyList(), producer.getFlow().first())
+    }
+
+    @Test
+    fun `getFlow - default variant updates when metatool changes`() = runTest {
+        val metaV1 = randomTool("meta", type = Tool.Type.META, defaultVariantCode = "v1")
+        val metaV2 = randomTool("meta", type = Tool.Type.META, defaultVariantCode = "v2")
+        val v1 = randomTool("v1", metatoolCode = "meta", isHidden = false)
+        val v2 = randomTool("v2", metatoolCode = "meta", isHidden = false)
+
+        producer.getFlow().test {
+            normalToolsFlow.value = listOf(v1, v2)
+            metatoolsFlow.value = listOf(metaV1)
+            assertEquals(listOf(v1), expectMostRecentItem())
+
+            metatoolsFlow.value = listOf(metaV2)
+            assertEquals(listOf(v2), expectMostRecentItem())
+        }
+    }
+    // endregion default variant filtering
+
+    // region category filter
+    @Test
+    fun `getFlow - null category includes all tools`() = runTest {
+        val gospel = createTool(category = Tool.CATEGORY_GOSPEL)
+        val articles = createTool(category = Tool.CATEGORY_ARTICLES)
+
+        normalToolsFlow.value = listOf(gospel, articles)
+        assertEquals(setOf(gospel, articles), producer.getFlow(category = null).first().toSet())
+    }
+
+    @Test
+    fun `getFlow - category filter includes only matching tools`() = runTest {
+        val gospel = createTool(category = Tool.CATEGORY_GOSPEL)
+        val articles = createTool(category = Tool.CATEGORY_ARTICLES)
+
+        normalToolsFlow.value = listOf(gospel, articles)
+        assertEquals(listOf(gospel), producer.getFlow(category = Tool.CATEGORY_GOSPEL).first())
+    }
+
+    @Test
+    fun `getFlow - category filter excludes tools with different category`() = runTest {
+        val tool = createTool(category = Tool.CATEGORY_ARTICLES)
+
+        normalToolsFlow.value = listOf(tool)
+        assertEquals(emptyList(), producer.getFlow(category = Tool.CATEGORY_GOSPEL).first())
+    }
+    // endregion category filter
+
+    // region combined filters
+    @Test
+    fun `getFlow - category and language filters applied together`() = runTest {
+        val languageToolsFlow = MutableStateFlow(emptyList<Tool>())
+        every { toolsRepository.getNormalToolsFlowByLanguage(Locale.FRENCH) } returns languageToolsFlow
+
+        val gospel = createTool(category = Tool.CATEGORY_GOSPEL)
+        val articles = createTool(category = Tool.CATEGORY_ARTICLES)
+
+        languageToolsFlow.value = listOf(gospel, articles)
+        assertEquals(
+            listOf(gospel),
+            producer.getFlow(category = Tool.CATEGORY_GOSPEL, language = Locale.FRENCH).first()
+        )
+    }
+    // endregion combined filters
+
+    private fun createTool(
+        category: String? = null,
+        defaultOrder: Int = 0,
+        isHidden: Boolean = false,
+        metatoolCode: String? = null,
+    ) = randomTool(
+        category = category,
+        defaultOrder = defaultOrder,
+        isHidden = isHidden,
+        metatoolCode = metatoolCode
+    )
+}

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayoutPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/home/HomeLayoutPaparazziTest.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.cru.godtools.base.ui.BasePaparazziTest
 import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiState
+import org.cru.godtools.ui.dashboard.home.HomePresenter.UiState
 import org.cru.godtools.ui.tools.ToolCardStateTestData
 import org.junit.Assume.assumeTrue
 import org.junit.runner.RunWith

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/home/HomePresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/home/HomePresenterTest.kt
@@ -36,7 +36,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.model.randomTranslation
 import org.cru.godtools.ui.banner.BannerType
-import org.cru.godtools.ui.dashboard.home.HomeScreen.UiEvent
+import org.cru.godtools.ui.dashboard.home.HomePresenter.UiEvent
 import org.cru.godtools.ui.dashboard.tools.ToolsScreen
 import org.cru.godtools.ui.tooldetails.ToolDetailsScreen
 import org.cru.godtools.ui.tools.ToolCard

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayoutPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayoutPaparazziTest.kt
@@ -15,7 +15,6 @@ import java.util.Locale
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -24,7 +23,7 @@ import kotlinx.coroutines.test.setMain
 import org.cru.godtools.base.ui.BasePaparazziTest
 import org.cru.godtools.model.Language
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
-import org.cru.godtools.ui.dashboard.lessons.LessonsScreen.UiState
+import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiState
 import org.cru.godtools.ui.tools.ToolCardStateTestData
 import org.junit.runner.RunWith
 
@@ -44,7 +43,7 @@ class LessonsLayoutPaparazziTest(
         languageFilter = FilterMenu.UiState(
             selectedItem = Language(Locale.ENGLISH)
         ),
-        lessons = persistentListOf(
+        lessons = listOf(
             ToolCardStateTestData.tool.copy(toolCode = "lesson1", translation = null),
             ToolCardStateTestData.tool.copy(toolCode = "lesson2", translation = null),
             ToolCardStateTestData.tool.copy(toolCode = "lesson3", translation = null),

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenterTest.kt
@@ -122,12 +122,12 @@ class LessonsPresenterTest {
 
     // This logic is based on the Sample AnsweringNavigatorTest in the circuit library.
     // see: https://github.com/slackhq/circuit/blob/main/circuit-foundation/src/jvmTest/kotlin/com/slack/circuit/foundation/AnsweringNavigatorTest.kt
-    private fun testPresenterWithStateRestoration(): ReceiveTurbine<LessonsScreen.UiState> {
-        val presenterState = Turbine<LessonsScreen.UiState>()
+    private fun testPresenterWithStateRestoration(): ReceiveTurbine<LessonsPresenter.UiState> {
+        val presenterState = Turbine<LessonsPresenter.UiState>()
 
         val circuit = Circuit.Builder()
-            .addPresenter<LessonsScreen, LessonsScreen.UiState> { s, n, _ -> presenter }
-            .addUi<LessonsScreen, LessonsScreen.UiState> { state, _ -> SideEffect { presenterState.add(state) } }
+            .addPresenter<LessonsScreen, LessonsPresenter.UiState> { s, n, _ -> presenter }
+            .addUi<LessonsScreen, LessonsPresenter.UiState> { state, _ -> SideEffect { presenterState.add(state) } }
             .build()
 
         stateRestorationTester.setContent {

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayoutPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayoutPaparazziTest.kt
@@ -29,6 +29,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
 import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState
 import org.cru.godtools.ui.tools.ToolCardStateTestData
 import org.junit.Assume.assumeTrue
@@ -104,7 +105,7 @@ class ToolsLayoutPaparazziTest(
     @Test
     fun `ToolsLayout() - Filters Selected`() = snapshotToolsLayout(
         state.copy(
-            filters = UiState.Filters(
+            filters = Filters(
                 categoryFilter = FilterMenu.UiState(selectedItem = Tool.CATEGORY_GOSPEL),
                 languageFilter = FilterMenu.UiState(
                     selectedItem = Language(Locale.ENGLISH),
@@ -118,7 +119,7 @@ class ToolsLayoutPaparazziTest(
     @Ignore("LayoutLib does not correctly support Popups/Windows currently")
     fun `ToolsLayout() - Language Filter Expanded`() = snapshotToolsLayout(
         state.copy(
-            filters = UiState.Filters(
+            filters = Filters(
                 languageFilter = FilterMenu.UiState(
                     selectedItem = Language(Locale.ENGLISH),
                     menuExpanded = mutableStateOf(true),

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayoutPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayoutPaparazziTest.kt
@@ -29,6 +29,7 @@ import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState
 import org.cru.godtools.ui.tools.ToolCardStateTestData
 import org.junit.Assume.assumeTrue
 import org.junit.runner.RunWith
@@ -50,7 +51,7 @@ class ToolsLayoutPaparazziTest(
         ToolCardStateTestData.tool.copy(toolCode = "spotlight3", tool = randomTool("spotlight3", isFavorite = false)),
     )
 
-    private val state = ToolsScreen.State(
+    private val state = UiState(
         dataLoaded = true,
         spotlightTools = spotlightTools,
         tools = tools,
@@ -103,7 +104,7 @@ class ToolsLayoutPaparazziTest(
     @Test
     fun `ToolsLayout() - Filters Selected`() = snapshotToolsLayout(
         state.copy(
-            filters = ToolsScreen.Filters(
+            filters = UiState.Filters(
                 categoryFilter = FilterMenu.UiState(selectedItem = Tool.CATEGORY_GOSPEL),
                 languageFilter = FilterMenu.UiState(
                     selectedItem = Language(Locale.ENGLISH),
@@ -117,7 +118,7 @@ class ToolsLayoutPaparazziTest(
     @Ignore("LayoutLib does not correctly support Popups/Windows currently")
     fun `ToolsLayout() - Language Filter Expanded`() = snapshotToolsLayout(
         state.copy(
-            filters = ToolsScreen.Filters(
+            filters = UiState.Filters(
                 languageFilter = FilterMenu.UiState(
                     selectedItem = Language(Locale.ENGLISH),
                     menuExpanded = mutableStateOf(true),
@@ -132,7 +133,7 @@ class ToolsLayoutPaparazziTest(
         )
     )
 
-    private fun snapshotToolsLayout(state: ToolsScreen.State) = snapshot {
+    private fun snapshotToolsLayout(state: UiState) = snapshot {
         ToolsLayout(
             state,
             modifier = Modifier

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
@@ -43,12 +43,13 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)
+@Suppress("UnusedFlow")
 @OptIn(ExperimentalCoroutinesApi::class)
 class ToolsPresenterTest {
     private val appLanguage = MutableStateFlow(Locale.ENGLISH)
     private val isFavoritesFeatureDiscovered = MutableStateFlow(true)
-    private val metatoolsFlow = MutableStateFlow(emptyList<Tool>())
     private val toolsFlow = MutableStateFlow(emptyList<Tool>())
+    private val filteredToolsFlow = MutableStateFlow(emptyList<Tool>())
     private val languagesFlow = MutableStateFlow(emptyList<Language>())
     private val gospelLanguagesFlow = MutableStateFlow(emptyList<Language>())
     private val selectedCategory = MutableStateFlow<String?>(null)
@@ -56,6 +57,9 @@ class ToolsPresenterTest {
 
     private val testScope = TestScope()
 
+    private val filteredToolsFlowProducer: FilteredToolsFlowProducer = mockk {
+        every { getFlow(any(), any()) } returns filteredToolsFlow
+    }
     private val languagesRepository: LanguagesRepository = mockk {
         every { findLanguageFlow(any()) } returns flowOf(null)
         every { getLanguagesFlow() } returns languagesFlow
@@ -75,8 +79,6 @@ class ToolsPresenterTest {
     }
     private val toolsRepository: ToolsRepository = mockk {
         every { getNormalToolsFlow() } returns toolsFlow
-        every { getNormalToolsFlowByLanguage(any()) } returns flowOf(emptyList())
-        every { getMetaToolsFlow() } returns metatoolsFlow
     }
     private val translationsRepository: TranslationsRepository = mockk {
         every { getTranslationsFlowForTools(any()) } returns flowOf(emptyList())
@@ -99,6 +101,7 @@ class ToolsPresenterTest {
             languagesRepository = languagesRepository,
             toolsRepository = toolsRepository,
             translationsRepository = translationsRepository,
+            filteredToolsFlowProducer = filteredToolsFlowProducer,
             ioDispatcher = UnconfinedTestDispatcher(testScope.testScheduler),
             navigator = navigator,
         )
@@ -163,49 +166,17 @@ class ToolsPresenterTest {
 
     // region State.filters.categoryFilter.items
     @Test
-    fun `State - filters - categoryFilter - items - no language`() = testScope.runTest {
-        toolsFlow.value = listOf(
-            randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false, defaultOrder = 0),
-            randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = false, defaultOrder = 1),
+    fun `State - filters - categoryFilter - items - distinct & ordered by tool order`() = testScope.runTest {
+        filteredToolsFlow.value = listOf(
+            randomTool(category = Tool.CATEGORY_ARTICLES),
+            randomTool(category = Tool.CATEGORY_GOSPEL),
+            randomTool(category = Tool.CATEGORY_ARTICLES),
         )
 
         presenter.test {
             assertEquals(
                 listOf(
-                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1),
-                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_ARTICLES, 1)
-                ),
-                expectMostRecentItem().filters.categoryFilter.items
-            )
-        }
-    }
-
-    @Test
-    fun `State - filters - categoryFilter - items - distinct categories`() = testScope.runTest {
-        toolsFlow.value = listOf(
-            randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
-            randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
-        )
-
-        presenter.test {
-            assertEquals(
-                listOf(FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 2)),
-                expectMostRecentItem().filters.categoryFilter.items
-            )
-        }
-    }
-
-    @Test
-    fun `State - filters - categoryFilter - items - ordered by tool default order`() = testScope.runTest {
-        toolsFlow.value = listOf(
-            randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false, defaultOrder = 1),
-            randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = false, defaultOrder = 0),
-        )
-
-        presenter.test {
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_ARTICLES, 1),
+                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_ARTICLES, 2),
                     FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1)
                 ),
                 expectMostRecentItem().filters.categoryFilter.items
@@ -214,34 +185,12 @@ class ToolsPresenterTest {
     }
 
     @Test
-    fun `State - filters - categoryFilter - items - exclude non-default variants`() = testScope.runTest {
-        val meta = randomTool("meta", defaultVariantCode = "tool")
-        toolsFlow.value = listOf(
-            randomTool("tool", category = Tool.CATEGORY_GOSPEL, metatoolCode = "meta", isHidden = false),
-            randomTool("other", category = Tool.CATEGORY_ARTICLES, metatoolCode = "meta", isHidden = false),
-        )
-
+    fun `State - filters - categoryFilter - items - uses selected language`() = testScope.runTest {
         presenter.test {
-            metatoolsFlow.value = listOf(meta)
-            assertEquals(
-                listOf(FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1)),
-                expectMostRecentItem().filters.categoryFilter.items
-            )
-        }
-    }
+            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
+            expectMostRecentItem()
 
-    @Test
-    fun `State - filters - categoryFilter - items - exclude hidden tools`() = testScope.runTest {
-        toolsFlow.value = listOf(
-            randomTool(category = Tool.CATEGORY_GOSPEL, metatoolCode = null, isHidden = false),
-            randomTool(category = Tool.CATEGORY_ARTICLES, metatoolCode = null, isHidden = true),
-        )
-
-        presenter.test {
-            assertEquals(
-                listOf(FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1)),
-                expectMostRecentItem().filters.categoryFilter.items
-            )
+            verify { filteredToolsFlowProducer.getFlow(language = Locale.FRENCH) }
         }
     }
     // endregion State.filters.categoryFilter.items
@@ -293,9 +242,9 @@ class ToolsPresenterTest {
         every { translationsRepository.getTranslationsFlowForTools(setOf("tool1", "tool2")) } returns translationsFlow
 
         presenter.test {
-            toolsFlow.value = listOf(
-                randomTool("tool1", metatoolCode = null, isHidden = false),
-                randomTool("tool2", metatoolCode = null, isHidden = false),
+            filteredToolsFlow.value = listOf(
+                randomTool("tool1", isHidden = false),
+                randomTool("tool2", isHidden = false),
             )
             translationsFlow.value = listOf(
                 randomTranslation("tool1", Locale.ENGLISH),
@@ -403,34 +352,4 @@ class ToolsPresenterTest {
         }
     }
     // endregion FiltersEvent.ToggleLanguagesMenu
-
-    // region State.tools
-    @Test
-    fun `State - tools - return only default variants`() = testScope.runTest {
-        val meta = Tool("meta", Tool.Type.META, defaultVariantCode = "variant2")
-        val variant1 = Tool("variant1", metatoolCode = "meta")
-        val variant2 = Tool("variant2", metatoolCode = "meta")
-
-        presenter.test {
-            assertEquals(emptyList(), awaitItem().tools)
-
-            metatoolsFlow.value = listOf(meta)
-            toolsFlow.value = listOf(variant1, variant2)
-            assertEquals(listOf(variant2), expectMostRecentItem().tools.map { it.tool })
-        }
-    }
-
-    @Test
-    fun `State - tools - Don't return hidden tools`() = testScope.runTest {
-        val hidden = randomTool("hidden", isHidden = true, metatoolCode = null)
-        val visible = randomTool("visible", isHidden = false, metatoolCode = null)
-
-        presenter.test {
-            assertEquals(emptyList(), awaitItem().tools)
-
-            toolsFlow.value = listOf(hidden, visible)
-            assertEquals(listOf(visible), expectMostRecentItem().tools.map { it.tool })
-        }
-    }
-    // endregion State.tools
 }

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenterTest.kt
@@ -1,39 +1,30 @@
 package org.cru.godtools.ui.dashboard.tools
 
 import android.app.Application
-import androidx.test.core.app.ApplicationProvider
+import androidx.compose.runtime.mutableStateOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.jeppeman.mockposable.mockk.everyComposable
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
-import io.mockk.coEvery
 import io.mockk.every
-import io.mockk.excludeRecords
 import io.mockk.mockk
-import io.mockk.verify
-import io.mockk.verifyAll
 import java.util.Locale
+import kotlin.random.Random
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.androidx.compose.ui.platform.AndroidUiDispatcherUtil
 import org.cru.godtools.base.Settings
-import org.cru.godtools.db.repository.LanguagesRepository
 import org.cru.godtools.db.repository.ToolsRepository
-import org.cru.godtools.db.repository.TranslationsRepository
 import org.cru.godtools.model.Language
 import org.cru.godtools.model.Tool
-import org.cru.godtools.model.Translation
 import org.cru.godtools.model.randomTool
-import org.cru.godtools.model.randomTranslation
 import org.cru.godtools.ui.banner.BannerType
 import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.tools.ToolCard
@@ -43,76 +34,45 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = Application::class)
-@Suppress("UnusedFlow")
 @OptIn(ExperimentalCoroutinesApi::class)
 class ToolsPresenterTest {
-    private val appLanguage = MutableStateFlow(Locale.ENGLISH)
     private val isFavoritesFeatureDiscovered = MutableStateFlow(true)
     private val toolsFlow = MutableStateFlow(emptyList<Tool>())
     private val filteredToolsFlow = MutableStateFlow(emptyList<Tool>())
-    private val languagesFlow = MutableStateFlow(emptyList<Language>())
-    private val gospelLanguagesFlow = MutableStateFlow(emptyList<Language>())
-    private val selectedCategory = MutableStateFlow<String?>(null)
-    private val selectedLocale = MutableStateFlow<Locale?>(null)
-
-    private val testScope = TestScope()
 
     private val filteredToolsFlowProducer: FilteredToolsFlowProducer = mockk {
         every { getFlow(any(), any()) } returns filteredToolsFlow
     }
-    private val languagesRepository: LanguagesRepository = mockk {
-        every { findLanguageFlow(any()) } returns flowOf(null)
-        every { getLanguagesFlow() } returns languagesFlow
-        every { getLanguagesFlowForToolCategory(Tool.CATEGORY_GOSPEL) } returns gospelLanguagesFlow
-
-        excludeRecords { this@mockk.equals(any()) }
-    }
     private val navigator = FakeNavigator(ToolsScreen)
     private val settings: Settings = mockk {
-        every { appLanguage } returns this@ToolsPresenterTest.appLanguage.value
-        every { appLanguageFlow } returns this@ToolsPresenterTest.appLanguage
         every { isFeatureDiscoveredFlow(Settings.FEATURE_TOOL_FAVORITE) } returns isFavoritesFeatureDiscovered
-        every { getDashboardFilterCategoryFlow() } returns selectedCategory
-        every { getDashboardFilterLocaleFlow() } returns selectedLocale
-        coEvery { updateDashboardFilterCategory(any()) } answers { selectedCategory.value = firstArg() }
-        coEvery { updateDashboardFilterLocale(any()) } answers { selectedLocale.value = firstArg() }
     }
     private val toolsRepository: ToolsRepository = mockk {
         every { getNormalToolsFlow() } returns toolsFlow
     }
-    private val translationsRepository: TranslationsRepository = mockk {
-        every { getTranslationsFlowForTools(any()) } returns flowOf(emptyList())
-    }
+    private val toolFiltersStateProducer = FakeToolFiltersStateProducer()
 
     private val toolCardPresenter: ToolCardPresenter = mockk {
         everyComposable { present(tool = any(), secondLanguage = any(), eventSink = any()) }
             .answers { ToolCard.State(tool = firstArg()) }
     }
 
-    private lateinit var presenter: ToolsPresenter
-
-    @BeforeTest
-    fun setup() {
-        presenter = ToolsPresenter(
-            context = ApplicationProvider.getApplicationContext(),
-            eventBus = mockk(),
-            settings = settings,
-            toolCardPresenter = toolCardPresenter,
-            languagesRepository = languagesRepository,
-            toolsRepository = toolsRepository,
-            translationsRepository = translationsRepository,
-            filteredToolsFlowProducer = filteredToolsFlowProducer,
-            ioDispatcher = UnconfinedTestDispatcher(testScope.testScheduler),
-            navigator = navigator,
-        )
-    }
+    private val presenter = ToolsPresenter(
+        eventBus = mockk(),
+        settings = settings,
+        toolCardPresenter = toolCardPresenter,
+        toolsRepository = toolsRepository,
+        filteredToolsFlowProducer = filteredToolsFlowProducer,
+        toolFiltersStateProducer = toolFiltersStateProducer,
+        navigator = navigator,
+    )
 
     @AfterTest
     fun cleanup() = AndroidUiDispatcherUtil.runScheduledDispatches()
 
     // region State.banner
     @Test
-    fun `State - banner - none`() = testScope.runTest {
+    fun `State - banner - none`() = runTest {
         presenter.test {
             isFavoritesFeatureDiscovered.value = true
             assertNull(expectMostRecentItem().banner)
@@ -120,7 +80,7 @@ class ToolsPresenterTest {
     }
 
     @Test
-    fun `State - banner - favorites`() = testScope.runTest {
+    fun `State - banner - favorites`() = runTest {
         presenter.test {
             isFavoritesFeatureDiscovered.value = false
             assertEquals(BannerType.TOOL_LIST_FAVORITES, expectMostRecentItem().banner)
@@ -130,7 +90,7 @@ class ToolsPresenterTest {
 
     // region State.spotlightTools
     @Test
-    fun `Property spotlightTools`() = testScope.runTest {
+    fun `Property spotlightTools`() = runTest {
         val normalTool = randomTool("normal", isHidden = false, isSpotlight = false)
         val spotlightTool = randomTool("spotlight", isHidden = false, isSpotlight = true)
 
@@ -141,7 +101,7 @@ class ToolsPresenterTest {
     }
 
     @Test
-    fun `Property spotlightTools - Don't show hidden tools`() = testScope.runTest {
+    fun `Property spotlightTools - Don't show hidden tools`() = runTest {
         val hiddenTool = randomTool("normal", isHidden = true, isSpotlight = true)
         val spotlightTool = randomTool("spotlight", isHidden = false, isSpotlight = true)
 
@@ -152,7 +112,7 @@ class ToolsPresenterTest {
     }
 
     @Test
-    fun `Property spotlightTools - Sorted by default order`() = testScope.runTest {
+    fun `Property spotlightTools - Sorted by default order`() = runTest {
         val tools = List(10) {
             randomTool("tool$it", Tool.Type.TRACT, defaultOrder = it, isHidden = false, isSpotlight = true)
         }
@@ -164,192 +124,39 @@ class ToolsPresenterTest {
     }
     // endregion State.spotlightTools
 
-    // region State.filters.categoryFilter.items
+    // region State.filters
     @Test
-    fun `State - filters - categoryFilter - items - distinct & ordered by tool order`() = testScope.runTest {
-        filteredToolsFlow.value = listOf(
-            randomTool(category = Tool.CATEGORY_ARTICLES),
-            randomTool(category = Tool.CATEGORY_GOSPEL),
-            randomTool(category = Tool.CATEGORY_ARTICLES),
+    @OptIn(ExperimentalUuidApi::class)
+    fun `State - filters`() = runTest {
+        val filters = ToolFiltersStateProducer.Filters(
+            categoryFilter = FilterMenu.UiState(
+                menuExpanded = mutableStateOf(Random.nextBoolean()),
+                items = listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Tool.CATEGORY_GOSPEL, 0),
+                    FilterMenu.UiState.Item(Tool.CATEGORY_ARTICLES, 0),
+                ),
+                query = mutableStateOf(Uuid.random().toString()),
+                selectedItem = null,
+                eventSink = {},
+            ),
+            languageFilter = FilterMenu.UiState(
+                menuExpanded = mutableStateOf(Random.nextBoolean()),
+                items = listOf(
+                    FilterMenu.UiState.Item(null, 0),
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0),
+                ),
+                query = mutableStateOf(Uuid.random().toString()),
+                selectedItem = null,
+                eventSink = {},
+            )
         )
+        toolFiltersStateProducer.filters.value = filters
 
         presenter.test {
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_ARTICLES, 2),
-                    FilterMenu.UiState.Item<String?>(Tool.CATEGORY_GOSPEL, 1)
-                ),
-                expectMostRecentItem().filters.categoryFilter.items
-            )
+            assertEquals(filters, expectMostRecentItem().filters)
         }
     }
-
-    @Test
-    fun `State - filters - categoryFilter - items - uses selected language`() = testScope.runTest {
-        presenter.test {
-            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
-            expectMostRecentItem()
-
-            verify { filteredToolsFlowProducer.getFlow(language = Locale.FRENCH) }
-        }
-    }
-    // endregion State.filters.categoryFilter.items
-
-    // region State.filters.languageFilter.items
-    @Test
-    fun `State - filters - languageFilter - items - no category`() = testScope.runTest {
-        val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
-
-        presenter.test {
-            languagesFlow.value = languages
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item(null, 0),
-                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
-                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
-                ),
-                expectMostRecentItem().filters.languageFilter.items
-            )
-        }
-
-        verifyAll {
-            languagesRepository.getLanguagesFlow()
-        }
-    }
-
-    @Test
-    fun `State - filters - languageFilter - items - for category`() = testScope.runTest {
-        val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
-
-        presenter.test {
-            awaitItem().filters.categoryFilter.eventSink(FilterMenu.Event.SelectItem(Tool.CATEGORY_GOSPEL))
-
-            gospelLanguagesFlow.value = languages
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item(null, 0),
-                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
-                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
-                ),
-                expectMostRecentItem().filters.languageFilter.items
-            )
-        }
-    }
-
-    @Test
-    fun `State - filters - languageFilter - items - include tool count`() = testScope.runTest {
-        val translationsFlow = MutableStateFlow(emptyList<Translation>())
-        every { translationsRepository.getTranslationsFlowForTools(setOf("tool1", "tool2")) } returns translationsFlow
-
-        presenter.test {
-            filteredToolsFlow.value = listOf(
-                randomTool("tool1", isHidden = false),
-                randomTool("tool2", isHidden = false),
-            )
-            translationsFlow.value = listOf(
-                randomTranslation("tool1", Locale.ENGLISH),
-                randomTranslation("tool1", Locale.FRENCH),
-                randomTranslation("tool2", Locale.ENGLISH, version = 1),
-                randomTranslation("tool2", Locale.ENGLISH, version = 2),
-            )
-            languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
-
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item(null, 0),
-                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 2),
-                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 1)
-                ),
-                expectMostRecentItem().filters.languageFilter.items
-            )
-        }
-    }
-
-    @Test
-    fun `State - filters - languageFilter - items - filtered by query`() = testScope.runTest {
-        val languages = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
-        languagesFlow.value = languages
-
-        presenter.test {
-            expectMostRecentItem().filters.languageFilter.let {
-                it.menuExpanded.value = true
-                assertEquals(
-                    listOf(
-                        FilterMenu.UiState.Item(null, 0),
-                        FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
-                        FilterMenu.UiState.Item(Language(Locale.FRENCH), 0),
-                    ),
-                    it.items
-                )
-                it.query.value = "french"
-            }
-
-            assertEquals(
-                listOf(
-                    FilterMenu.UiState.Item(null, 0),
-                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
-                ),
-                expectMostRecentItem().filters.languageFilter.items
-            )
-        }
-
-        verifyAll {
-            languagesRepository.getLanguagesFlow()
-        }
-    }
-    // endregion State.filters.languageFilter.items
-
-    // region State.filters.languageFilter.selectedItem
-    @Test
-    fun `State - filters - languageFilter - selectedItem - no language selected`() = testScope.runTest {
-        presenter.test {
-            assertNull(expectMostRecentItem().filters.languageFilter.selectedItem)
-        }
-
-        verify(inverse = true) { languagesRepository.findLanguageFlow(any()) }
-    }
-
-    @Test
-    fun `State - filters - languageFilter - selectedItem - language not found`() = testScope.runTest {
-        presenter.test {
-            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.ENGLISH)))
-
-            assertNull(expectMostRecentItem().filters.languageFilter.selectedItem)
-        }
-
-        verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
-    }
-
-    @Test
-    fun `State - filters - languageFilter - selectedItem - language selected`() = testScope.runTest {
-        val language = Language(Locale.ENGLISH)
-        every { languagesRepository.findLanguageFlow(Locale.ENGLISH) } returns flowOf(language)
-
-        presenter.test {
-            awaitItem().filters.languageFilter.eventSink(FilterMenu.Event.SelectItem(language))
-
-            assertEquals(language, expectMostRecentItem().filters.languageFilter.selectedItem)
-        }
-
-        verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
-    }
-    // endregion State.filters.languageFilter.selectedItem
-
-    // region State.filters.languageFilter.menuExpanded
-    @Test
-    fun `State - filters - languageFilter - menuExpanded - resets query when set to false`() = testScope.runTest {
-        presenter.test {
-            val state = expectMostRecentItem().filters.languageFilter
-
-            state.menuExpanded.value = true
-            state.query.value = "test"
-            assertEquals("test", state.query.value)
-
-            state.menuExpanded.value = false
-            assertEquals("", state.query.value)
-
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-    // endregion FiltersEvent.ToggleLanguagesMenu
+    // endregion State.filters
 }


### PR DESCRIPTION
## Summary
- Moves `UiState`/`UiEvent` from Screen objects into their respective Presenters (`HomePresenter`, `LessonsPresenter`, `ToolsPresenter`) to align with Circuit conventions
- Extracts `DefaultFilteredToolsFlowProducer` from `ToolsPresenter` into its own injectable class
- Extracts `DefaultToolFiltersStateProducer` from `ToolsPresenter` into its own injectable `@Composable` state producer
- Switches `FilterMenu.UiState.items` from `ImmutableList` to `List` to align with project convention

## Test plan
- [ ] `DefaultFilteredToolsFlowProducerTest` — covers hidden filter, sort order, default variant filtering, category filter, language filter, and combined filters
- [ ] `DefaultToolFiltersStateProducerTest` — covers category/language filter items, tool counts, query filtering, selected item, and query reset on menu close
- [ ] `ToolsPresenterTest` — updated to mock `FilteredToolsFlowProducer` and use `FakeToolFiltersStateProducer`; verifies category filter passes selected language to producer
- [ ] Run `./gradlew :app:testProductionDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)