### PR TITLE
GT-3017 Onboarding Localization

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -40,6 +41,14 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
 
     val coroutineScope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 4 })
+    LaunchedEffect(state.currentPage) {
+        if (pagerState.currentPage != state.currentPage) {
+            pagerState.animateScrollToPage(
+                state.currentPage,
+                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+            )
+        }
+    }
 
     RecordAnalyticsScreen(OnboardingAnalyticsScreenEvent(pagerState.currentPage))
 
@@ -74,6 +83,7 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
             HorizontalPager(
                 key = { it },
                 state = pagerState,
+                userScrollEnabled = state.userScrollEnabled,
                 modifier = Modifier
                     .padding(insets)
                     .consumeWindowInsets(insets)
@@ -90,7 +100,7 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
 
                 when (it) {
                     0 -> OnboardingWelcomePageLayout(
-                        nextPage = nextPage,
+                        nextPage = { eventSink(UiEvent.Next) },
                         eventSink = eventSink,
                     )
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
@@ -8,11 +8,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -40,15 +38,7 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
     val eventSink by rememberUpdatedState(state.eventSink)
 
     val coroutineScope = rememberCoroutineScope()
-    val pagerState = rememberPagerState(pageCount = { 4 })
-    LaunchedEffect(state.currentPage) {
-        if (pagerState.currentPage != state.currentPage) {
-            pagerState.animateScrollToPage(
-                state.currentPage,
-                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
-            )
-        }
-    }
+    val pagerState = state.pagerState
 
     RecordAnalyticsScreen(OnboardingAnalyticsScreenEvent(pagerState.currentPage))
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingLayout.kt
@@ -1,7 +1,5 @@
 package org.cru.godtools.ui.onboarding
 
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,7 +17,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.launch
 import org.ccci.gto.android.common.androidx.compose.material3.ui.appbar.AppBarAction
 import org.ccci.gto.android.common.androidx.compose.material3.ui.appbar.AppBarActionButton
 import org.cru.godtools.R
@@ -79,15 +76,6 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
                     .consumeWindowInsets(insets)
                     .fillMaxSize()
             ) {
-                val nextPage: () -> Unit = {
-                    coroutineScope.launch {
-                        pagerState.animateScrollToPage(
-                            it + 1,
-                            animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
-                        )
-                    }
-                }
-
                 when (it) {
                     0 -> OnboardingWelcomePageLayout(
                         nextPage = { eventSink(UiEvent.Next) },
@@ -96,13 +84,13 @@ fun OnboardingLayout(state: OnboardingPresenter.UiState, modifier: Modifier = Mo
 
                     1 -> OnboardingPageLayout(
                         OnboardingPage.CONVERSATIONS,
-                        nextPage = nextPage,
+                        nextPage = { eventSink(UiEvent.Next) },
                         eventSink = eventSink,
                     )
 
                     2 -> OnboardingPageLayout(
                         OnboardingPage.PREPARE,
-                        nextPage = nextPage,
+                        nextPage = { eventSink(UiEvent.Next) },
                         eventSink = eventSink,
                     )
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -27,7 +27,7 @@ import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.cru.godtools.base.ui.circuit.screen.AppLanguageScreen
 import org.cru.godtools.shared.analytics.TutorialAnalyticsActionNames
 import org.cru.godtools.tutorial.analytics.model.TutorialAnalyticsActionEvent
-import org.cru.godtools.ui.languages.country.CountrySettingsScreen
+import org.cru.godtools.ui.settings.country.CountrySettingsScreen
 import org.cru.godtools.ui.onboarding.OnboardingPresenter.UiState
 import org.greenrobot.eventbus.EventBus
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -84,16 +84,10 @@ class OnboardingPresenter @AssistedInject constructor(
             when (event) {
                 UiEvent.ChangeLanguage -> languageButtonNavigator.goTo(AppLanguageScreen)
 
-                UiEvent.Next -> {
-                    when {
-                        !languageWasSet -> nextButtonNavigator.goTo(AppLanguageScreen)
-
-                        !hasSeenCountrySettings -> countrySettingsNavigator.goTo(CountrySettingsScreen)
-
-                        else -> scope.launch {
-                            pagerState.navigateToPage()
-                        }
-                    }
+                UiEvent.Next -> when {
+                    !languageWasSet -> nextButtonNavigator.goTo(AppLanguageScreen)
+                    !hasSeenCountrySettings -> countrySettingsNavigator.goTo(CountrySettingsScreen)
+                    else -> scope.launch { pagerState.navigateToPage() }
                 }
 
                 UiEvent.Skip -> {

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -27,8 +27,8 @@ import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.cru.godtools.base.ui.circuit.screen.AppLanguageScreen
 import org.cru.godtools.shared.analytics.TutorialAnalyticsActionNames
 import org.cru.godtools.tutorial.analytics.model.TutorialAnalyticsActionEvent
-import org.cru.godtools.ui.settings.country.CountrySettingsScreen
 import org.cru.godtools.ui.onboarding.OnboardingPresenter.UiState
+import org.cru.godtools.ui.settings.country.CountrySettingsScreen
 import org.greenrobot.eventbus.EventBus
 
 class OnboardingPresenter @AssistedInject constructor(

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -52,9 +52,11 @@ class OnboardingPresenter @AssistedInject constructor(
     @Composable
     override fun present(): UiState {
         var languageWasSet by rememberSaveable { mutableStateOf(false) }
+        var hasSeenCountrySettings by rememberSaveable { mutableStateOf(false) }
         val pagerState = rememberPagerState(pageCount = { 4 })
         val scope = rememberCoroutineScope()
         val countrySettingsNavigator = rememberAnsweringNavigator<CountrySettingsScreen.Result>(navigator) {
+            hasSeenCountrySettings = true
             scope.launch {
                 pagerState.animateScrollToPage(
                     1,
@@ -76,14 +78,21 @@ class OnboardingPresenter @AssistedInject constructor(
         LaunchedEffect(Unit) { settings.setFeatureDiscovered(FEATURE_TUTORIAL_ONBOARDING) }
         return UiState(
             pagerState = pagerState,
-            userScrollEnabled = pagerState.currentPage > 0
+            userScrollEnabled = pagerState.currentPage > 0 || languageWasSet
         ) { event ->
             when (event) {
                 UiEvent.ChangeLanguage -> languageButtonNavigator.goTo(AppLanguageScreen)
 
                 UiEvent.Next -> {
-                    if (languageWasSet) {
+                    if (languageWasSet && !hasSeenCountrySettings) {
                         countrySettingsNavigator.goTo(CountrySettingsScreen)
+                    } else if (hasSeenCountrySettings) {
+                        scope.launch {
+                            pagerState.animateScrollToPage(
+                                1,
+                                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+                            )
+                        }
                     } else {
                         nextButtonNavigator.goTo(AppLanguageScreen)
                     }

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -49,6 +49,10 @@ class OnboardingPresenter @AssistedInject constructor(
         data object Finish : UiEvent
     }
 
+    private suspend fun PagerState.navigateToPage(page: Int = currentPage + 1) {
+        animateScrollToPage(page, animationSpec = spring(stiffness = Spring.StiffnessMediumLow))
+    }
+
     @Composable
     override fun present(): UiState {
         var languageWasSet by rememberSaveable { mutableStateOf(false) }
@@ -58,10 +62,7 @@ class OnboardingPresenter @AssistedInject constructor(
         val countrySettingsNavigator = rememberAnsweringNavigator<CountrySettingsScreen.Result>(navigator) {
             hasSeenCountrySettings = true
             scope.launch {
-                pagerState.animateScrollToPage(
-                    1,
-                    animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
-                )
+                pagerState.navigateToPage(1)
             }
         }
         val languageButtonNavigator = rememberAnsweringNavigator<AppLanguageScreen.Result>(navigator) { result ->
@@ -78,23 +79,20 @@ class OnboardingPresenter @AssistedInject constructor(
         LaunchedEffect(Unit) { settings.setFeatureDiscovered(FEATURE_TUTORIAL_ONBOARDING) }
         return UiState(
             pagerState = pagerState,
-            userScrollEnabled = pagerState.currentPage > 0 || languageWasSet
+            userScrollEnabled = (languageWasSet && hasSeenCountrySettings) || pagerState.currentPage > 0
         ) { event ->
             when (event) {
                 UiEvent.ChangeLanguage -> languageButtonNavigator.goTo(AppLanguageScreen)
 
                 UiEvent.Next -> {
-                    if (languageWasSet && !hasSeenCountrySettings) {
-                        countrySettingsNavigator.goTo(CountrySettingsScreen)
-                    } else if (hasSeenCountrySettings) {
-                        scope.launch {
-                            pagerState.animateScrollToPage(
-                                1,
-                                animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
-                            )
+                    when {
+                        !languageWasSet -> nextButtonNavigator.goTo(AppLanguageScreen)
+
+                        !hasSeenCountrySettings -> countrySettingsNavigator.goTo(CountrySettingsScreen)
+
+                        else -> scope.launch {
+                            pagerState.navigateToPage()
                         }
-                    } else {
-                        nextButtonNavigator.goTo(AppLanguageScreen)
                     }
                 }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -2,7 +2,13 @@ package org.cru.godtools.ui.onboarding
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.foundation.rememberAnsweringNavigator
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
@@ -16,6 +22,7 @@ import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.cru.godtools.base.ui.circuit.screen.AppLanguageScreen
 import org.cru.godtools.shared.analytics.TutorialAnalyticsActionNames
 import org.cru.godtools.tutorial.analytics.model.TutorialAnalyticsActionEvent
+import org.cru.godtools.ui.languages.country.CountrySettingsScreen
 import org.cru.godtools.ui.onboarding.OnboardingPresenter.UiState
 import org.greenrobot.eventbus.EventBus
 
@@ -24,21 +31,50 @@ class OnboardingPresenter @AssistedInject constructor(
     private val settings: Settings,
     @Assisted private val navigator: Navigator,
 ) : Presenter<UiState> {
-    data class UiState(val eventSink: (UiEvent) -> Unit = {}) : CircuitUiState
+    data class UiState(
+        val currentPage: Int = 0,
+        val userScrollEnabled: Boolean = false,
+        val eventSink: (UiEvent) -> Unit = {}
+    ) : CircuitUiState
 
     sealed interface UiEvent : CircuitUiEvent {
         data object ChangeLanguage : UiEvent
+        data object Next : UiEvent
         data object Skip : UiEvent
         data object Finish : UiEvent
     }
 
     @Composable
     override fun present(): UiState {
+        var languageWasSet by rememberSaveable { mutableStateOf(false) }
+        var currentPage by rememberSaveable { mutableIntStateOf(0) }
+        val countrySettingsNavigator = rememberAnsweringNavigator<CountrySettingsScreen.Result>(navigator) {
+            currentPage = 1
+        }
+        val languageButtonNavigator = rememberAnsweringNavigator<AppLanguageScreen.Result>(navigator) { result ->
+            if (result is AppLanguageScreen.Result.LanguageSelected) {
+                languageWasSet = true
+            }
+        }
+        val nextButtonNavigator = rememberAnsweringNavigator<AppLanguageScreen.Result>(navigator) { result ->
+            if (result is AppLanguageScreen.Result.LanguageSelected) {
+                languageWasSet = true
+                countrySettingsNavigator.goTo(CountrySettingsScreen)
+            }
+        }
         LaunchedEffect(Unit) { settings.setFeatureDiscovered(FEATURE_TUTORIAL_ONBOARDING) }
 
-        return UiState { event ->
+        val eventSink: (UiEvent) -> Unit = { event ->
             when (event) {
-                UiEvent.ChangeLanguage -> navigator.goTo(AppLanguageScreen)
+                UiEvent.ChangeLanguage -> languageButtonNavigator.goTo(AppLanguageScreen)
+
+                UiEvent.Next -> {
+                    if (languageWasSet) {
+                        countrySettingsNavigator.goTo(CountrySettingsScreen)
+                    } else {
+                        nextButtonNavigator.goTo(AppLanguageScreen)
+                    }
+                }
 
                 UiEvent.Skip -> {
                     eventBus.post(TutorialAnalyticsActionEvent(TutorialAnalyticsActionNames.ONBOARDING_SKIP))
@@ -51,6 +87,12 @@ class OnboardingPresenter @AssistedInject constructor(
                 }
             }
         }
+
+        return UiState(
+            currentPage = currentPage,
+            userScrollEnabled = currentPage > 0,
+            eventSink = eventSink
+        )
     }
 
     @AssistedFactory

--- a/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenter.kt
@@ -1,10 +1,14 @@
 package org.cru.godtools.ui.onboarding
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -17,6 +21,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.launch
 import org.cru.godtools.base.Settings
 import org.cru.godtools.base.Settings.Companion.FEATURE_TUTORIAL_ONBOARDING
 import org.cru.godtools.base.ui.circuit.screen.AppLanguageScreen
@@ -32,7 +37,7 @@ class OnboardingPresenter @AssistedInject constructor(
     @Assisted private val navigator: Navigator,
 ) : Presenter<UiState> {
     data class UiState(
-        val currentPage: Int = 0,
+        val pagerState: PagerState,
         val userScrollEnabled: Boolean = false,
         val eventSink: (UiEvent) -> Unit = {}
     ) : CircuitUiState
@@ -47,9 +52,15 @@ class OnboardingPresenter @AssistedInject constructor(
     @Composable
     override fun present(): UiState {
         var languageWasSet by rememberSaveable { mutableStateOf(false) }
-        var currentPage by rememberSaveable { mutableIntStateOf(0) }
+        val pagerState = rememberPagerState(pageCount = { 4 })
+        val scope = rememberCoroutineScope()
         val countrySettingsNavigator = rememberAnsweringNavigator<CountrySettingsScreen.Result>(navigator) {
-            currentPage = 1
+            scope.launch {
+                pagerState.animateScrollToPage(
+                    1,
+                    animationSpec = spring(stiffness = Spring.StiffnessMediumLow)
+                )
+            }
         }
         val languageButtonNavigator = rememberAnsweringNavigator<AppLanguageScreen.Result>(navigator) { result ->
             if (result is AppLanguageScreen.Result.LanguageSelected) {
@@ -63,8 +74,10 @@ class OnboardingPresenter @AssistedInject constructor(
             }
         }
         LaunchedEffect(Unit) { settings.setFeatureDiscovered(FEATURE_TUTORIAL_ONBOARDING) }
-
-        val eventSink: (UiEvent) -> Unit = { event ->
+        return UiState(
+            pagerState = pagerState,
+            userScrollEnabled = pagerState.currentPage > 0
+        ) { event ->
             when (event) {
                 UiEvent.ChangeLanguage -> languageButtonNavigator.goTo(AppLanguageScreen)
 
@@ -87,12 +100,6 @@ class OnboardingPresenter @AssistedInject constructor(
                 }
             }
         }
-
-        return UiState(
-            currentPage = currentPage,
-            userScrollEnabled = currentPage > 0,
-            eventSink = eventSink
-        )
     }
 
     @AssistedFactory

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsPresenter.kt
@@ -72,7 +72,7 @@ class CountrySettingsPresenter @AssistedInject constructor(
             countryCode = settingCountryCode,
             eventSink = { event ->
                 when (event) {
-                    UiEvent.NavigateBack -> navigator.pop(CountrySettingsScreen.Result.Dismiss)
+                    UiEvent.NavigateBack -> navigator.pop(CountrySettingsScreen.Result.Dismissed)
 
                     is UiEvent.SelectCountry -> {
                         scope.launch {

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsPresenter.kt
@@ -72,12 +72,12 @@ class CountrySettingsPresenter @AssistedInject constructor(
             countryCode = settingCountryCode,
             eventSink = { event ->
                 when (event) {
-                    UiEvent.NavigateBack -> navigator.pop()
+                    UiEvent.NavigateBack -> navigator.pop(CountrySettingsScreen.Result.Dismiss)
 
                     is UiEvent.SelectCountry -> {
                         scope.launch {
                             settings.updateCountrySetting(isoCode = event.isoCode)
-                            navigator.pop()
+                            navigator.pop(CountrySettingsScreen.Result.CountrySelected)
                         }
                     }
                 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsScreen.kt
@@ -8,6 +8,6 @@ import kotlinx.parcelize.Parcelize
 data object CountrySettingsScreen : Screen {
     sealed interface Result : PopResult {
         @Parcelize data object CountrySelected : Result
-        @Parcelize data object Dismiss : Result
+        @Parcelize data object Dismissed : Result
     }
 }

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsScreen.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/country/CountrySettingsScreen.kt
@@ -1,7 +1,13 @@
 package org.cru.godtools.ui.settings.country
 
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data object CountrySettingsScreen : Screen
+data object CountrySettingsScreen : Screen {
+    sealed interface Result : PopResult {
+        @Parcelize data object CountrySelected : Result
+        @Parcelize data object Dismiss : Result
+    }
+}

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
@@ -57,11 +57,11 @@ class AppLanguagePresenter @AssistedInject constructor(
         val eventSink: (UiEvent) -> Unit = remember {
             {
                 when (it) {
-                    UiEvent.NavigateBack -> navigator.pop()
+                    UiEvent.NavigateBack -> navigator.pop(AppLanguageScreen.Result.Dismiss)
 
                     is UiEvent.SelectLanguage -> {
                         if (it.language == appLocale) {
-                            navigator.pop()
+                            navigator.pop(AppLanguageScreen.Result.Dismiss)
                         } else {
                             confirmLanguage = it.language
                         }
@@ -70,7 +70,7 @@ class AppLanguagePresenter @AssistedInject constructor(
                     is UiEvent.ConfirmLanguage -> {
                         settings.appLanguage = it.language
                         confirmLanguage = null
-                        navigator.pop()
+                        navigator.pop(AppLanguageScreen.Result.LanguageSelected)
                     }
 
                     UiEvent.DismissConfirmDialog -> confirmLanguage = null

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
@@ -57,7 +57,7 @@ class AppLanguagePresenter @AssistedInject constructor(
         val eventSink: (UiEvent) -> Unit = remember {
             {
                 when (it) {
-                    UiEvent.NavigateBack -> navigator.pop(AppLanguageScreen.Result.Dismiss)
+                    UiEvent.NavigateBack -> navigator.pop(AppLanguageScreen.Result.Dismissed)
 
                     is UiEvent.SelectLanguage -> {
                         if (it.language == appLocale) {

--- a/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenter.kt
@@ -61,7 +61,7 @@ class AppLanguagePresenter @AssistedInject constructor(
 
                     is UiEvent.SelectLanguage -> {
                         if (it.language == appLocale) {
-                            navigator.pop(AppLanguageScreen.Result.Dismiss)
+                            navigator.pop(AppLanguageScreen.Result.LanguageSelected)
                         } else {
                             confirmLanguage = it.language
                         }

--- a/app/src/test/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenterTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlinx.coroutines.test.runTest
 import org.ccci.gto.android.common.androidx.compose.ui.platform.AndroidUiDispatcherUtil
 import org.cru.godtools.base.Settings
@@ -38,6 +39,24 @@ class OnboardingPresenterTest {
         navigator.assertGoToIsEmpty()
         navigator.assertPopIsEmpty()
     }
+
+    // region Initial State
+    @Test
+    fun `Initial State - currentPage is 0`() = runTest {
+        createPresenter().test {
+            val state = awaitItem()
+            assertEquals(0, state.currentPage)
+        }
+    }
+
+    @Test
+    fun `Initial State - userScrollEnabled is false`() = runTest {
+        createPresenter().test {
+            val state = awaitItem()
+            assertFalse(state.userScrollEnabled)
+        }
+    }
+    // endregion Initial State
 
     // region Feature Discovery
     @Test
@@ -69,6 +88,22 @@ class OnboardingPresenterTest {
         }
     }
     // endregion UiEvent.Skip
+
+    // region UiEvent.Next
+    @Test
+    fun `UiEvent - Next - no language set - navigates to AppLanguageScreen`() = runTest {
+        createPresenter().test {
+            awaitItem().eventSink(OnboardingPresenter.UiEvent.Next)
+            assertEquals(AppLanguageScreen, navigator.awaitNextScreen())
+        }
+    }
+
+    @Test
+    fun `UiEvent - Next - language already set - navigates to CountrySettingsScreen`() = runTest {
+        // TODO: Testing the full answering navigator callback chain requires integration testing.
+        //  The FakeNavigator doesn't trigger rememberAnsweringNavigator callbacks in unit tests.
+    }
+    // endregion UiEvent.Next
 
     // region UiEvent.Finish
     @Test

--- a/app/src/test/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/onboarding/OnboardingPresenterTest.kt
@@ -45,7 +45,7 @@ class OnboardingPresenterTest {
     fun `Initial State - currentPage is 0`() = runTest {
         createPresenter().test {
             val state = awaitItem()
-            assertEquals(0, state.currentPage)
+            assertEquals(0, state.pagerState.currentPage)
         }
     }
 

--- a/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
@@ -113,7 +113,7 @@ class AppLanguagePresenterTest {
     fun `Event - NavigateBack`() = runTest {
         presenter.test {
             awaitItem().eventSink(UiEvent.NavigateBack)
-            navigator.awaitPop()
+            assertEquals(AppLanguageScreen.Result.Dismiss, navigator.awaitPop().result)
         }
     }
     // endregion Event.NavigateBack
@@ -132,7 +132,7 @@ class AppLanguagePresenterTest {
     fun `Event - SelectLanguage - Selected app language`() = runTest {
         presenter.test {
             awaitItem().eventSink(UiEvent.SelectLanguage(Locale.ENGLISH))
-            navigator.awaitPop()
+            assertEquals(AppLanguageScreen.Result.Dismiss, navigator.awaitPop().result)
         }
     }
     // endregion Event.SelectLanguage
@@ -149,7 +149,7 @@ class AppLanguagePresenterTest {
                 eventSink(UiEvent.ConfirmLanguage(selectedLanguage))
             }
 
-            navigator.awaitPop()
+            assertEquals(AppLanguageScreen.Result.LanguageSelected, navigator.awaitPop().result)
             assertNull(expectMostRecentItem().selectedLanguage)
             assertEquals(Locale.FRENCH, appLocaleState.value)
         }

--- a/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
@@ -132,7 +132,7 @@ class AppLanguagePresenterTest {
     fun `Event - SelectLanguage - Selected app language`() = runTest {
         presenter.test {
             awaitItem().eventSink(UiEvent.SelectLanguage(Locale.ENGLISH))
-            assertEquals(AppLanguageScreen.Result.Dismiss, navigator.awaitPop().result)
+            assertEquals(AppLanguageScreen.Result.LanguageSelected, navigator.awaitPop().result)
         }
     }
     // endregion Event.SelectLanguage

--- a/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/settings/language/app/AppLanguagePresenterTest.kt
@@ -113,7 +113,7 @@ class AppLanguagePresenterTest {
     fun `Event - NavigateBack`() = runTest {
         presenter.test {
             awaitItem().eventSink(UiEvent.NavigateBack)
-            assertEquals(AppLanguageScreen.Result.Dismiss, navigator.awaitPop().result)
+            assertEquals(AppLanguageScreen.Result.Dismissed, navigator.awaitPop().result)
         }
     }
     // endregion Event.NavigateBack

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
@@ -8,6 +8,6 @@ import kotlinx.parcelize.Parcelize
 data object AppLanguageScreen : Screen {
     sealed interface Result : PopResult {
         @Parcelize data object LanguageSelected : Result
-        @Parcelize data object Dismiss : Result
+        @Parcelize data object Dismissed : Result
     }
 }

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
@@ -1,7 +1,13 @@
 package org.cru.godtools.base.ui.circuit.screen
 
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data object AppLanguageScreen : Screen
+data object AppLanguageScreen : Screen {
+    sealed interface Result : PopResult {
+        @Parcelize data object SetLanguage : Result
+        @Parcelize data object DismissAppLanguage : Result
+    }
+}

--- a/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
+++ b/ui/base/src/main/kotlin/org/cru/godtools/base/ui/circuit/screen/AppLanguageScreen.kt
@@ -7,7 +7,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data object AppLanguageScreen : Screen {
     sealed interface Result : PopResult {
-        @Parcelize data object SetLanguage : Result
-        @Parcelize data object DismissAppLanguage : Result
+        @Parcelize data object LanguageSelected : Result
+        @Parcelize data object Dismiss : Result
     }
 }


### PR DESCRIPTION
- **Add pop result to app language screen to track result**
- **Modify popResult names and add for presenter**
- **Add pop result to navigator.pop in UiEvents**
- **Modify tests to reflect newly added pop result**
- **Add result interface for pop results to send to presenter**
- **Receive newly added pop results in UiEvents**
- **Sync pager to presenter page state via LaunchedEffect and disable swipe on welcome**
- **Add answering navigators and Next event for language/country flow in presenter**
- **Add initial state and Next event tests to OnboardingPresenterTest**
- **Change event passed to prevent block from continue onboarding**
- **Change test to pass with the previous dismiss select language event blocking onboarding**
