### PR TITLE
GT-2870 Show value indicator on lesson feedback readiness slider

### DIFF
--- a/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogOverlay.kt
+++ b/ui/lesson-renderer/src/main/kotlin/org/cru/godtools/tool/lesson/ui/feedback/LessonFeedbackDialogOverlay.kt
@@ -1,10 +1,16 @@
 package org.cru.godtools.tool.lesson.ui.feedback
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Label
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -16,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -58,6 +65,7 @@ class LessonFeedbackDialogOverlay(private val pageReached: Int) : Overlay<Lesson
                         }
                     }
 
+                    val readinessInteractionSource = remember { MutableInteractionSource() }
                     Text(
                         stringResource(R.string.lesson_feedback_question_readiness),
                         modifier = Modifier.padding(top = 16.dp)
@@ -68,6 +76,24 @@ class LessonFeedbackDialogOverlay(private val pageReached: Int) : Overlay<Lesson
                         onValueChange = { readiness = it },
                         valueRange = 1f..10f,
                         steps = 8,
+                        interactionSource = readinessInteractionSource,
+                        thumb = {
+                            Label(
+                                label = {
+                                    PlainTooltip(shape = CircleShape) {
+                                        Text(
+                                            readiness.toInt().toString(),
+                                            modifier = Modifier
+                                                .sizeIn(24.dp, 32.dp)
+                                                .wrapContentSize()
+                                        )
+                                    }
+                                },
+                                interactionSource = readinessInteractionSource,
+                            ) {
+                                SliderDefaults.Thumb(interactionSource = readinessInteractionSource)
+                            }
+                        },
                         track = {
                             SliderDefaults.Track(
                                 sliderState = it,


### PR DESCRIPTION
## Summary
- Wrap the readiness slider thumb with M3's `Label` + `PlainTooltip` so the current value (1–10) is shown while the user is dragging, matching the [M3 slider value indicator spec](https://m3.material.io/components/sliders/specs).

## Test plan
- [ ] Open a lesson, complete it, and confirm the feedback dialog shows the value indicator above the readiness slider thumb while dragging.
- [ ] Verify the indicator disappears on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)