### PR TITLE
Upgrade compileSdk and targetSdk to Android 37

### DIFF
--- a/build-logic/src/main/kotlin/AndroidConfiguration.kt
+++ b/build-logic/src/main/kotlin/AndroidConfiguration.kt
@@ -60,7 +60,7 @@ internal fun Project.excludeAndroidSdkDependencies() {
 }
 
 private fun CommonExtension.configureSdk() {
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig.minSdk = 24
 }
 

--- a/build-logic/src/main/kotlin/godtools.application-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/godtools.application-conventions.gradle.kts
@@ -7,7 +7,7 @@ android {
     configureQaBuildType(project)
     configureFlavorDimensions(project)
 
-    defaultConfig.targetSdk = 36
+    defaultConfig.targetSdk = 37
 }
 
 excludeAndroidSdkDependencies()


### PR DESCRIPTION
## Summary
- Bump `compileSdk` and `targetSdk` from 36 → 37 in the shared `build-logic` conventions.

## Test plan
- [x] `./gradlew :build-logic:ktlintCheck ktlintCheck`
- [x] `./gradlew :app:assembleProductionDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)