### PR TITLE
Migrate RoomDatabaseRule to the gto-support androidx-room testing artifact

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ version=6.4.1
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx3g
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 
 android.experimental.enableTestFixturesKotlinSupport=true
 android.nonTransitiveRClass=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -167,6 +167,7 @@ gtoSupport-retrofit2 = { module = "org.ccci.gto.android:gto-support-retrofit2", 
 gtoSupport-scarlet = { module = "org.ccci.gto.android:gto-support-scarlet", version.ref = "gtoSupport" }
 gtoSupport-scarlet-actioncable = { module = "org.ccci.gto.android:gto-support-scarlet-actioncable", version.ref = "gtoSupport" }
 gtoSupport-sync = { module = "org.ccci.gto.android:gto-support-sync", version.ref = "gtoSupport" }
+gtoSupport-testing-androidx-room = { module = "org.ccci.gto.android.testing:gto-support-androidx-room", version.ref = "gtoSupport" }
 gtoSupport-testing-dagger = { module = "org.ccci.gto.android.testing:gto-support-dagger", version.ref = "gtoSupport" }
 gtoSupport-testing-picasso = { module = "org.ccci.gto.android.testing:gto-support-picasso", version.ref = "gtoSupport" }
 gtoSupport-testing-timber = { module = "org.ccci.gto.android.testing:gto-support-timber", version.ref = "gtoSupport" }

--- a/library/db/build.gradle.kts
+++ b/library/db/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.androidx.room.testing)
+    testImplementation(libs.gtoSupport.testing.androidx.room)
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.turbine)
-    testImplementation(testFixtures(libs.gtoSupport.androidx.room))
 }

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/AttachmentsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/AttachmentsRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.AttachmentsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/DownloadedFilesRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/DownloadedFilesRoomRepositoryIT.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.DownloadedFilesRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/FollowupsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/FollowupsRoomRepositoryIT.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.FollowupsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/GlobalActivityRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/GlobalActivityRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.GlobalActivityRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LanguagesRoomRepositoryIT.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.LanguagesRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LastSyncTimeRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/LastSyncTimeRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.LastSyncTimeRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/ToolsRoomRepositoryIT.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.ToolsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TrainingTipsRoomRepositoryIT.kt
@@ -2,7 +2,7 @@ package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.TrainingTipsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TranslationsRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/TranslationsRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.TranslationsRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/UserCountersRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/UserCountersRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.UserCountersRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/UserRoomRepositoryIT.kt
+++ b/library/db/src/test/kotlin/org/cru/godtools/db/room/repository/UserRoomRepositoryIT.kt
@@ -1,7 +1,7 @@
 package org.cru.godtools.db.room.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.db.repository.UserRepositoryIT
 import org.cru.godtools.db.room.GodToolsRoomDatabase
 import org.junit.Rule

--- a/ui/article-aem-renderer/build.gradle.kts
+++ b/ui/article-aem-renderer/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.androidx.room.testing)
+    testImplementation(libs.gtoSupport.testing.androidx.room)
     testImplementation(libs.json)
     testImplementation(libs.kotlin.coroutines.test)
-    testImplementation(testFixtures(libs.gtoSupport.androidx.room))
 }

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryIT.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/AemImportRepositoryIT.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.article.aem.model.AemImport
 import org.cru.godtools.article.aem.model.Article
 import org.junit.Assert.assertEquals

--- a/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryIT.kt
+++ b/ui/article-aem-renderer/src/test/kotlin/org/cru/godtools/article/aem/db/TranslationRepositoryIT.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.util.Locale
 import kotlinx.coroutines.runBlocking
-import org.ccci.gto.android.common.androidx.room.RoomDatabaseRule
+import org.ccci.gto.android.common.testing.androidx.room.RoomDatabaseRule
 import org.cru.godtools.article.aem.model.TranslationRef
 import org.cru.godtools.article.aem.model.toTranslationRefKey
 import org.cru.godtools.model.randomTranslation


### PR DESCRIPTION
## Summary
- Migrate `RoomDatabaseRule` usage from the `gto-support-androidx-room` test fixtures to the published `org.ccci.gto.android.testing:gto-support-androidx-room` testing artifact, updating imports to the new `org.ccci.gto.android.common.testing.androidx.room` package in all Room repository integration tests (`library/db`, `ui/article-aem-renderer`)
- Enable `org.gradle.tooling.parallel` in `gradle.properties`

🤖 Generated with [Claude Code](https://claude.com/claude-code)