### PR TITLE
Remove explicit setup-java distribution, inferred from .tool-versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -44,7 +43,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -66,7 +64,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -105,7 +102,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -145,7 +141,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/record-snapshots.yml
+++ b/.github/workflows/record-snapshots.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v5
         with:
-          distribution: "temurin"
           java-version-file: ".tool-versions"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
Starting with setup-java v5.6.0 the distribution is inferred from the `.tool-versions` file, so the explicit `distribution: "temurin"` input is no longer needed. `.tool-versions` already pins `java temurin-25.0.4+7.0.LTS`, and the workflows use the floating `actions/setup-java@v5` tag which resolves to a version with this support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)