### PR TITLE
[GT-3013] Update personalized tools sync to new resources endpoints

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducer.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducer.kt
@@ -4,10 +4,8 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.kotlin.coroutines.flow.combineTransformLatest
@@ -25,13 +23,15 @@ internal class FeaturedToolsFlowProducer @Inject constructor(
         val baseFlow = when (mode) {
             Mode.PERSONALIZATION -> {
                 val languageFlow = if (language != null) flowOf(language) else settings.appLanguageFlow
-                val fallbackFlow = languageFlow.flatMapLatest { toolsRepository.getFeaturedToolsFlow(it, null) }
 
+                // featured tools are only available when a country is selected, there is no fallback behavior
                 languageFlow
                     .combineTransformLatest(settings.getPersonalizationCountryFlow()) { lang, country ->
-                        emitAll(toolsRepository.getFeaturedToolsFlow(lang, country))
+                        when (country) {
+                            null -> emit(emptyList())
+                            else -> emitAll(toolsRepository.getFeaturedToolsFlow(lang, country))
+                        }
                     }
-                    .combine(fallbackFlow) { featured, fallback -> featured.ifEmpty { fallback } }
                     .distinctUntilChanged()
             }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsPresenter.kt
@@ -186,7 +186,7 @@ class ToolsPresenter @AssistedInject internal constructor(
     private fun SyncTracker.syncData(locale: Locale, force: Boolean = false) = launchSync {
         val country = settings.getCountrySettingFlow().first()
         coroutineScope {
-            launch { syncService.syncFeaturedTools(locale, country, force) }
+            if (country != null) launch { syncService.syncFeaturedTools(locale, country, force) }
             launch { syncService.syncToolOrder(locale, country, force) }
         }
     }

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
@@ -20,7 +20,7 @@ import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Mode
 @Suppress("UnusedFlow")
 class FeaturedToolsFlowProducerTest {
     private val appLanguageFlow = MutableStateFlow(Locale.ENGLISH)
-    private val countryFlow = MutableStateFlow<String?>(null)
+    private val countryFlow = MutableStateFlow<String?>("US")
     private val normalToolsFlow = MutableStateFlow(emptyList<Tool>())
 
     private val settings: Settings = mockk {
@@ -93,30 +93,24 @@ class FeaturedToolsFlowProducerTest {
 
     @Test
     fun `getFlow - Personalization - uses Settings getPersonalizationCountryFlow for country`() = runTest {
-        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(any(), "US") }
     }
 
     @Test
-    fun `getFlow - Personalization - returns featured tools when non-empty`() = runTest {
+    fun `getFlow - Personalization - returns featured tools`() = runTest {
         val tool = createTool()
-        val fallbackTool = createTool()
-        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(listOf(tool))
-        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, null) } returns flowOf(listOf(fallbackTool))
 
         assertEquals(listOf(tool), producer.getFlow(mode = Mode.PERSONALIZATION).first())
     }
 
     @Test
-    fun `getFlow - Personalization - falls back to language only when no country-specific tools`() = runTest {
-        val fallbackTool = createTool()
-        countryFlow.value = "US"
-        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(emptyList())
-        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, null) } returns flowOf(listOf(fallbackTool))
+    fun `getFlow - Personalization - empty when no country selected`() = runTest {
+        countryFlow.value = null
 
-        assertEquals(listOf(fallbackTool), producer.getFlow(mode = Mode.PERSONALIZATION).first())
+        assertEquals(emptyList(), producer.getFlow(mode = Mode.PERSONALIZATION).first())
+        verify(exactly = 0) { toolsRepository.getFeaturedToolsFlow(any(), any()) }
     }
 
     @Test
@@ -131,7 +125,8 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - updates when appLanguage changes`() = runTest {
         val frenchTool = createTool()
-        every { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, null) } returns flowOf(listOf(frenchTool))
+        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(emptyList())
+        every { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, "US") } returns flowOf(listOf(frenchTool))
 
         producer.getFlow(mode = Mode.PERSONALIZATION).test {
             assertEquals(emptyList(), awaitItem())
@@ -147,10 +142,10 @@ class FeaturedToolsFlowProducerTest {
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(listOf(usTool))
 
         producer.getFlow(mode = Mode.PERSONALIZATION).test {
-            assertEquals(emptyList(), awaitItem())
-
-            countryFlow.value = "US"
             assertEquals(listOf(usTool), awaitItem())
+
+            countryFlow.value = null
+            assertEquals(emptyList(), awaitItem())
         }
     }
     // endregion PERSONALIZATION mode

--- a/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
+++ b/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
@@ -32,10 +32,16 @@ interface ToolsApi {
         @QueryMap params: JsonApiParams,
     ): Response<JsonApiObject<Tool>>
 
-    @GET("$PATH_RESOURCES/default_order")
-    suspend fun getToolOrder(
+    @GET("$PATH_RESOURCES/ranked")
+    suspend fun getRankedTools(
         @Query(PARAM_FILTER_LANGUAGE) locale: Locale,
-        @Query(PARAM_FILTER_COUNTRY) country: String? = null,
+        @Query(PARAM_FILTER_COUNTRY) country: String,
+        @QueryMap params: JsonApiParams,
+    ): Response<JsonApiObject<Tool>>
+
+    @GET("$PATH_RESOURCES/default-order")
+    suspend fun getDefaultToolOrder(
+        @Query(PARAM_FILTER_LANGUAGE) locale: Locale,
         @QueryMap params: JsonApiParams,
     ): Response<JsonApiObject<Tool>>
 }

--- a/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
+++ b/library/api/src/main/kotlin/org/cru/godtools/api/ToolsApi.kt
@@ -28,7 +28,7 @@ interface ToolsApi {
     @GET("$PATH_RESOURCES/featured")
     suspend fun getFeaturedTools(
         @Query(PARAM_FILTER_LANGUAGE) locale: Locale,
-        @Query(PARAM_FILTER_COUNTRY) country: String? = null,
+        @Query(PARAM_FILTER_COUNTRY) country: String,
         @QueryMap params: JsonApiParams,
     ): Response<JsonApiObject<Tool>>
 

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.dagger.getValue
@@ -89,8 +91,12 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
     suspend fun syncFeaturedTools(locale: Locale, country: String, force: Boolean = false) =
         executeSync<ToolSyncTasks> { syncFeaturedTools(locale, country, force) }
 
-    suspend fun syncToolOrder(locale: Locale, country: String?, force: Boolean = false) =
-        executeSync<ToolSyncTasks> { syncToolOrder(locale, country, force) }
+    suspend fun syncToolOrder(locale: Locale, country: String?, force: Boolean = false) = coroutineScope {
+        listOfNotNull(
+            country?.let { async { executeSync<ToolSyncTasks> { syncRankedTools(locale, it, force) } } },
+            async { executeSync<ToolSyncTasks> { syncDefaultToolOrder(locale, force) } },
+        ).awaitAll().all { it }
+    }
 
     suspend fun syncGlobalActivity(force: Boolean = false) =
         executeSync<AnalyticsSyncTasks> { syncGlobalActivity(force) }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/GodToolsSyncService.kt
@@ -86,7 +86,7 @@ class GodToolsSyncService @VisibleForTesting internal constructor(
     suspend fun syncTool(toolCode: String, force: Boolean = false) =
         executeSync<ToolSyncTasks> { syncTool(toolCode, force) }
 
-    suspend fun syncFeaturedTools(locale: Locale, country: String?, force: Boolean = false) =
+    suspend fun syncFeaturedTools(locale: Locale, country: String, force: Boolean = false) =
         executeSync<ToolSyncTasks> { syncFeaturedTools(locale, country, force) }
 
     suspend fun syncToolOrder(locale: Locale, country: String?, force: Boolean = false) =

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -40,7 +40,8 @@ internal class ToolSyncTasks @Inject internal constructor(
     internal companion object {
         const val SYNC_TIME_TOOLS = "last_synced.tools"
         const val SYNC_TIME_FEATURED_TOOLS = "last_synced.featured_tools."
-        const val SYNC_TIME_TOOL_ORDER = "last_synced.tool_order."
+        const val SYNC_TIME_DEFAULT_TOOL_ORDER = "last_synced.default_tool_order."
+        const val SYNC_TIME_RANKED_TOOLS = "last_synced.ranked_tools."
 
         private val INCLUDES_GET_TOOL = Includes(
             Tool.JSON_ATTACHMENTS,
@@ -133,28 +134,51 @@ internal class ToolSyncTasks @Inject internal constructor(
     // endregion Featured Tools
 
     // region Tool Order
-    private val toolOrderMutex = MutexMap()
+    private val defaultToolOrderMutex = MutexMap()
+    private val rankedToolsMutex = MutexMap()
 
-    internal suspend fun syncToolOrder(locale: Locale, country: String?, force: Boolean = false): Boolean {
-        val normalizedCountry = country?.uppercase()
-
-        toolOrderMutex.withLock(locale to normalizedCountry) {
+    internal suspend fun syncDefaultToolOrder(locale: Locale, force: Boolean = false): Boolean {
+        defaultToolOrderMutex.withLock(locale) {
             if (!force &&
                 !lastSyncTimeRepository.isLastSyncStale(
-                    SYNC_TIME_TOOL_ORDER,
+                    SYNC_TIME_DEFAULT_TOOL_ORDER,
                     locale,
-                    normalizedCountry.orEmpty(),
                     staleAfter = STALE_DURATION_TOOLS,
                 )
             ) {
                 return true
             }
 
-            val tools = toolsApi.getToolOrder(locale, normalizedCountry, buildToolPlaceholderParams())
+            val tools = toolsApi.getDefaultToolOrder(locale, buildToolPlaceholderParams())
+                .takeIf { it.code() == HTTP_OK }?.body()?.data ?: return false
+
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, tools)
+            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_DEFAULT_TOOL_ORDER, locale)
+
+            return true
+        }
+    }
+
+    internal suspend fun syncRankedTools(locale: Locale, country: String, force: Boolean = false): Boolean {
+        val normalizedCountry = country.uppercase()
+
+        rankedToolsMutex.withLock(locale to normalizedCountry) {
+            if (!force &&
+                !lastSyncTimeRepository.isLastSyncStale(
+                    SYNC_TIME_RANKED_TOOLS,
+                    locale,
+                    normalizedCountry,
+                    staleAfter = STALE_DURATION_TOOLS,
+                )
+            ) {
+                return true
+            }
+
+            val tools = toolsApi.getRankedTools(locale, normalizedCountry, buildToolPlaceholderParams())
                 .takeIf { it.code() == HTTP_OK }?.body()?.data ?: return false
 
             toolsRepository.storePersonalizedToolOrderFromSync(locale, normalizedCountry, tools)
-            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_TOOL_ORDER, locale, normalizedCountry.orEmpty())
+            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_RANKED_TOOLS, locale, normalizedCountry)
 
             return true
         }

--- a/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
+++ b/library/sync/src/main/kotlin/org/cru/godtools/sync/task/ToolSyncTasks.kt
@@ -106,15 +106,15 @@ internal class ToolSyncTasks @Inject internal constructor(
     // region Featured Tools
     private val featuredToolsMutex = MutexMap()
 
-    internal suspend fun syncFeaturedTools(locale: Locale, country: String?, force: Boolean = false): Boolean {
-        val normalizedCountry = country?.uppercase()
+    internal suspend fun syncFeaturedTools(locale: Locale, country: String, force: Boolean = false): Boolean {
+        val normalizedCountry = country.uppercase()
 
         featuredToolsMutex.withLock(locale to normalizedCountry) {
             if (!force &&
                 !lastSyncTimeRepository.isLastSyncStale(
                     SYNC_TIME_FEATURED_TOOLS,
                     locale,
-                    normalizedCountry.orEmpty(),
+                    normalizedCountry,
                     staleAfter = STALE_DURATION_TOOLS,
                 )
             ) {
@@ -125,7 +125,7 @@ internal class ToolSyncTasks @Inject internal constructor(
                 .takeIf { it.code() == HTTP_OK }?.body()?.data ?: return false
 
             toolsRepository.storeFeaturedToolsFromSync(locale, normalizedCountry, tools)
-            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_FEATURED_TOOLS, locale, normalizedCountry.orEmpty())
+            lastSyncTimeRepository.updateLastSyncTime(SYNC_TIME_FEATURED_TOOLS, locale, normalizedCountry)
 
             return true
         }

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
@@ -118,18 +118,6 @@ class ToolSyncTasksTest {
     }
 
     @Test
-    fun `syncFeaturedTools(country = null)`() = runTest {
-        tasks.syncFeaturedTools(locale, null)
-        coVerifyAll {
-            toolsApi.getFeaturedTools(locale, null, any())
-            toolsRepository.storeFeaturedToolsFromSync(locale, null, apiFeaturedTools)
-        }
-        assertFalse(
-            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_FEATURED_TOOLS, locale, "", staleAfter = 60_000)
-        )
-    }
-
-    @Test
     fun `syncFeaturedTools(force = false) - already synced`() = runTest {
         with(lastSyncTimeRepository) {
             setLastSyncTime(SYNC_TIME_FEATURED_TOOLS, locale, country, time = System.currentTimeMillis())

--- a/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
+++ b/library/sync/src/test/kotlin/org/cru/godtools/sync/task/ToolSyncTasksTest.kt
@@ -18,8 +18,9 @@ import org.cru.godtools.db.repository.InMemoryLastSyncTimeRepository
 import org.cru.godtools.db.repository.ToolsRepository
 import org.cru.godtools.model.randomTool
 import org.cru.godtools.sync.repository.SyncRepository
+import org.cru.godtools.sync.task.ToolSyncTasks.Companion.SYNC_TIME_DEFAULT_TOOL_ORDER
 import org.cru.godtools.sync.task.ToolSyncTasks.Companion.SYNC_TIME_FEATURED_TOOLS
-import org.cru.godtools.sync.task.ToolSyncTasks.Companion.SYNC_TIME_TOOL_ORDER
+import org.cru.godtools.sync.task.ToolSyncTasks.Companion.SYNC_TIME_RANKED_TOOLS
 import retrofit2.Response
 
 class ToolSyncTasksTest {
@@ -29,14 +30,17 @@ class ToolSyncTasksTest {
     private val tool = randomTool()
     private val existingTools = listOf(randomTool())
     private val apiFeaturedTools = listOf(randomTool(), randomTool())
-    private val apiToolOrder = listOf(randomTool(), randomTool())
+    private val apiDefaultToolOrder = listOf(randomTool(), randomTool())
+    private val apiRankedTools = listOf(randomTool(), randomTool())
 
     private val toolsApi: ToolsApi = mockk {
         coEvery { list(any()) } returns Response.success(JsonApiObject.single(tool))
         coEvery { getFeaturedTools(any(), any(), any()) } returns
             Response.success(JsonApiObject.of(*apiFeaturedTools.toTypedArray()))
-        coEvery { getToolOrder(any(), any(), any()) } returns
-            Response.success(JsonApiObject.of(*apiToolOrder.toTypedArray()))
+        coEvery { getDefaultToolOrder(any(), any()) } returns
+            Response.success(JsonApiObject.of(*apiDefaultToolOrder.toTypedArray()))
+        coEvery { getRankedTools(any(), any(), any()) } returns
+            Response.success(JsonApiObject.of(*apiRankedTools.toTypedArray()))
     }
     private val viewsApi: ViewsApi = mockk()
     private val syncRepository: SyncRepository = mockk {
@@ -147,43 +151,26 @@ class ToolSyncTasksTest {
     }
     // endregion syncFeaturedTools()
 
-    // region syncToolOrder()
+    // region syncDefaultToolOrder()
     @Test
-    fun `syncToolOrder()`() = runTest {
-        tasks.syncToolOrder(locale, country)
+    fun `syncDefaultToolOrder()`() = runTest {
+        tasks.syncDefaultToolOrder(locale)
         coVerifyAll {
-            toolsApi.getToolOrder(locale, country, any())
-            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, apiToolOrder)
+            toolsApi.getDefaultToolOrder(locale, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, apiDefaultToolOrder)
         }
         assertFalse(
-            lastSyncTimeRepository.isLastSyncStale(
-                SYNC_TIME_TOOL_ORDER,
-                locale,
-                country,
-                staleAfter = 60_000
-            )
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_DEFAULT_TOOL_ORDER, locale, staleAfter = 60_000)
         )
     }
 
     @Test
-    fun `syncToolOrder(country = null)`() = runTest {
-        tasks.syncToolOrder(locale, null)
-        coVerifyAll {
-            toolsApi.getToolOrder(locale, null, any())
-            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, apiToolOrder)
-        }
-        assertFalse(
-            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_TOOL_ORDER, locale, "", staleAfter = 60_000)
-        )
-    }
-
-    @Test
-    fun `syncToolOrder(force = false) - already synced`() = runTest {
+    fun `syncDefaultToolOrder(force = false) - already synced`() = runTest {
         with(lastSyncTimeRepository) {
-            setLastSyncTime(SYNC_TIME_TOOL_ORDER, locale, country, time = System.currentTimeMillis())
+            setLastSyncTime(SYNC_TIME_DEFAULT_TOOL_ORDER, locale, time = System.currentTimeMillis())
         }
 
-        tasks.syncToolOrder(locale, country, force = false)
+        tasks.syncDefaultToolOrder(locale, force = false)
         coVerifyAll {
             toolsApi wasNot Called
             toolsRepository wasNot Called
@@ -191,24 +178,62 @@ class ToolSyncTasksTest {
     }
 
     @Test
-    fun `syncToolOrder(force = true) - already synced`() = runTest {
+    fun `syncDefaultToolOrder(force = true) - already synced`() = runTest {
         with(lastSyncTimeRepository) {
-            setLastSyncTime(SYNC_TIME_TOOL_ORDER, locale, country, time = System.currentTimeMillis())
+            setLastSyncTime(SYNC_TIME_DEFAULT_TOOL_ORDER, locale, time = System.currentTimeMillis())
         }
 
-        tasks.syncToolOrder(locale, country, force = true)
+        tasks.syncDefaultToolOrder(locale, force = true)
         coVerifyAll {
-            toolsApi.getToolOrder(locale, country, any())
-            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, apiToolOrder)
+            toolsApi.getDefaultToolOrder(locale, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, null, apiDefaultToolOrder)
         }
         assertFalse(
-            lastSyncTimeRepository.isLastSyncStale(
-                SYNC_TIME_TOOL_ORDER,
-                locale,
-                country,
-                staleAfter = 60_000,
-            )
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_DEFAULT_TOOL_ORDER, locale, staleAfter = 60_000)
         )
     }
-    // endregion syncToolOrder()
+    // endregion syncDefaultToolOrder()
+
+    // region syncRankedTools()
+    @Test
+    fun `syncRankedTools()`() = runTest {
+        tasks.syncRankedTools(locale, country)
+        coVerifyAll {
+            toolsApi.getRankedTools(locale, country, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, apiRankedTools)
+        }
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_RANKED_TOOLS, locale, country, staleAfter = 60_000)
+        )
+    }
+
+    @Test
+    fun `syncRankedTools(force = false) - already synced`() = runTest {
+        with(lastSyncTimeRepository) {
+            setLastSyncTime(SYNC_TIME_RANKED_TOOLS, locale, country, time = System.currentTimeMillis())
+        }
+
+        tasks.syncRankedTools(locale, country, force = false)
+        coVerifyAll {
+            toolsApi wasNot Called
+            toolsRepository wasNot Called
+        }
+    }
+
+    @Test
+    fun `syncRankedTools(force = true) - already synced`() = runTest {
+        with(lastSyncTimeRepository) {
+            setLastSyncTime(SYNC_TIME_RANKED_TOOLS, locale, country, time = System.currentTimeMillis())
+        }
+
+        tasks.syncRankedTools(locale, country, force = true)
+        coVerifyAll {
+            toolsApi.getRankedTools(locale, country, any())
+            toolsRepository.storePersonalizedToolOrderFromSync(locale, country, apiRankedTools)
+        }
+        assertFalse(
+            lastSyncTimeRepository.isLastSyncStale(SYNC_TIME_RANKED_TOOLS, locale, country, staleAfter = 60_000)
+        )
+    }
+    // endregion syncRankedTools()
 }


### PR DESCRIPTION
The personalization API has been split into 3 endpoints, all requiring a language filter:

- `/resources/featured` — also requires a country filter, no fallback behavior
- `/resources/ranked` — also requires a country filter, falls back to default-order
- `/resources/default-order` — language only

## Changes

**Require a country for the featured tools sync**
- `getFeaturedTools` now takes a non-null country through the API, sync task, and sync service
- The featured tools sync is skipped when no country is selected
- `FeaturedToolsFlowProducer` no longer falls back to language-only featured tools; it emits an empty list when no country is selected

**Split the tool order sync into default-order and ranked endpoints**
- `getToolOrder` (`/resources/default_order`) replaced by `getDefaultToolOrder` (`/resources/default-order`, language only) and `getRankedTools` (`/resources/ranked`, language + country)
- `ToolSyncTasks` gains `syncDefaultToolOrder`/`syncRankedTools` with separate stale-tracking keys
- `GodToolsSyncService.syncToolOrder` fans out to both endpoints concurrently, skipping ranked when no country is selected
- The existing ranked → default-order fallback behavior is unchanged (default-order is stored as the `country = ""` personalized order rows)

No DB schema changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)