### PR TITLE
Fix TutorialLayout IndexOutOfBoundsException when app language changes page count

### DIFF
--- a/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
+++ b/ui/tutorial-renderer/src/main/kotlin/org/cru/godtools/tutorial/layout/TutorialLayout.kt
@@ -59,7 +59,9 @@ fun TutorialLayout(state: UiState, modifier: Modifier = Modifier) {
     val locale = LocalAppLanguage.current
     val pages = remember(pageSet, locale) { pageSet.pagesFor(locale) }
     val pagerState = rememberPagerState { pages.size }
-    val currentPage by remember { derivedStateOf { pages[pagerState.currentPage] } }
+    val currentPage by remember(pages) {
+        derivedStateOf { pages[pagerState.currentPage.coerceAtMost(pages.lastIndex)] }
+    }
 
     RecordAnalyticsScreen(TutorialAnalyticsScreenEvent(pageSet, currentPage, pagerState.currentPage, locale))
 


### PR DESCRIPTION
 `pagerState.currentPage` is not clamped synchronously when a locale change shrinks the page list, causing `pages[currentPage]` to throw during composition.

 Used `coerceAtMost` instead of `coerceIn` since `pagerState.currentPage` is always >= 0, so only the upper bound needs guarding.

 Fixes #4544
