### PR TITLE
GT-3101 Hide the Featured Tools section without country specific data

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducer.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducer.kt
@@ -4,10 +4,8 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.ccci.gto.android.common.kotlin.coroutines.flow.combineTransformLatest
@@ -25,13 +23,16 @@ internal class FeaturedToolsFlowProducer @Inject constructor(
         val baseFlow = when (mode) {
             Mode.PERSONALIZATION -> {
                 val languageFlow = if (language != null) flowOf(language) else settings.appLanguageFlow
-                val fallbackFlow = languageFlow.flatMapLatest { toolsRepository.getFeaturedToolsFlow(it, null) }
 
                 languageFlow
                     .combineTransformLatest(settings.getPersonalizationCountryFlow()) { lang, country ->
-                        emitAll(toolsRepository.getFeaturedToolsFlow(lang, country))
+                        when (country) {
+                            // the featured tools section is hidden when no country has been selected
+                            null -> emit(emptyList())
+
+                            else -> emitAll(toolsRepository.getFeaturedToolsFlow(lang, country))
+                        }
                     }
-                    .combine(fallbackFlow) { featured, fallback -> featured.ifEmpty { fallback } }
                     .distinctUntilChanged()
             }
 

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
@@ -72,6 +72,7 @@ class FeaturedToolsFlowProducerTest {
     // region PERSONALIZATION mode
     @Test
     fun `getFlow - Personalization - uses getFeaturedToolsFlow`() = runTest {
+        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(any(), any()) }
         verify(exactly = 0) { toolsRepository.getNormalToolsFlow() }
@@ -80,12 +81,14 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - uses appLanguageFlow when no language provided`() = runTest {
         appLanguageFlow.value = Locale.FRENCH
+        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, any()) }
     }
 
     @Test
     fun `getFlow - Personalization - uses provided language`() = runTest {
+        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION, language = Locale.GERMAN).first()
         verify { toolsRepository.getFeaturedToolsFlow(Locale.GERMAN, any()) }
         verify(exactly = 0) { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, any()) }
@@ -101,28 +104,34 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - returns featured tools when non-empty`() = runTest {
         val tool = createTool()
-        val fallbackTool = createTool()
         countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(listOf(tool))
-        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, null) } returns flowOf(listOf(fallbackTool))
 
         assertEquals(listOf(tool), producer.getFlow(mode = Mode.PERSONALIZATION).first())
     }
 
     @Test
-    fun `getFlow - Personalization - falls back to language only when no country-specific tools`() = runTest {
-        val fallbackTool = createTool()
+    fun `getFlow - Personalization - GT-3101 - no featured tools when no country is selected`() = runTest {
+        countryFlow.value = null
+
+        assertEquals(emptyList(), producer.getFlow(mode = Mode.PERSONALIZATION).first())
+        verify(exactly = 0) { toolsRepository.getFeaturedToolsFlow(any(), any()) }
+    }
+
+    @Test
+    fun `getFlow - Personalization - GT-3101 - no featured tools when none exist for the selected country`() = runTest {
         countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(emptyList())
-        every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, null) } returns flowOf(listOf(fallbackTool))
 
-        assertEquals(listOf(fallbackTool), producer.getFlow(mode = Mode.PERSONALIZATION).first())
+        assertEquals(emptyList(), producer.getFlow(mode = Mode.PERSONALIZATION).first())
+        verify(exactly = 0) { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, null) }
     }
 
     @Test
     fun `getFlow - Personalization - excludes hidden tools`() = runTest {
         val hidden = createTool(isHidden = true)
         val visible = createTool(isHidden = false)
+        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(any(), any()) } returns flowOf(listOf(hidden, visible))
 
         assertEquals(listOf(visible), producer.getFlow(mode = Mode.PERSONALIZATION).first())
@@ -131,7 +140,8 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - updates when appLanguage changes`() = runTest {
         val frenchTool = createTool()
-        every { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, null) } returns flowOf(listOf(frenchTool))
+        countryFlow.value = "US"
+        every { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, "US") } returns flowOf(listOf(frenchTool))
 
         producer.getFlow(mode = Mode.PERSONALIZATION).test {
             assertEquals(emptyList(), awaitItem())

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/FeaturedToolsFlowProducerTest.kt
@@ -20,7 +20,7 @@ import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Mode
 @Suppress("UnusedFlow")
 class FeaturedToolsFlowProducerTest {
     private val appLanguageFlow = MutableStateFlow(Locale.ENGLISH)
-    private val countryFlow = MutableStateFlow<String?>(null)
+    private val countryFlow = MutableStateFlow<String?>("US")
     private val normalToolsFlow = MutableStateFlow(emptyList<Tool>())
 
     private val settings: Settings = mockk {
@@ -72,7 +72,6 @@ class FeaturedToolsFlowProducerTest {
     // region PERSONALIZATION mode
     @Test
     fun `getFlow - Personalization - uses getFeaturedToolsFlow`() = runTest {
-        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(any(), any()) }
         verify(exactly = 0) { toolsRepository.getNormalToolsFlow() }
@@ -81,14 +80,12 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - uses appLanguageFlow when no language provided`() = runTest {
         appLanguageFlow.value = Locale.FRENCH
-        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, any()) }
     }
 
     @Test
     fun `getFlow - Personalization - uses provided language`() = runTest {
-        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION, language = Locale.GERMAN).first()
         verify { toolsRepository.getFeaturedToolsFlow(Locale.GERMAN, any()) }
         verify(exactly = 0) { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, any()) }
@@ -96,7 +93,6 @@ class FeaturedToolsFlowProducerTest {
 
     @Test
     fun `getFlow - Personalization - uses Settings getPersonalizationCountryFlow for country`() = runTest {
-        countryFlow.value = "US"
         producer.getFlow(mode = Mode.PERSONALIZATION).first()
         verify { toolsRepository.getFeaturedToolsFlow(any(), "US") }
     }
@@ -104,7 +100,6 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - returns featured tools when non-empty`() = runTest {
         val tool = createTool()
-        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(listOf(tool))
 
         assertEquals(listOf(tool), producer.getFlow(mode = Mode.PERSONALIZATION).first())
@@ -120,7 +115,6 @@ class FeaturedToolsFlowProducerTest {
 
     @Test
     fun `getFlow - Personalization - GT-3101 - no featured tools when none exist for the selected country`() = runTest {
-        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(emptyList())
 
         assertEquals(emptyList(), producer.getFlow(mode = Mode.PERSONALIZATION).first())
@@ -131,7 +125,6 @@ class FeaturedToolsFlowProducerTest {
     fun `getFlow - Personalization - excludes hidden tools`() = runTest {
         val hidden = createTool(isHidden = true)
         val visible = createTool(isHidden = false)
-        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(any(), any()) } returns flowOf(listOf(hidden, visible))
 
         assertEquals(listOf(visible), producer.getFlow(mode = Mode.PERSONALIZATION).first())
@@ -140,7 +133,6 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - updates when appLanguage changes`() = runTest {
         val frenchTool = createTool()
-        countryFlow.value = "US"
         every { toolsRepository.getFeaturedToolsFlow(Locale.FRENCH, "US") } returns flowOf(listOf(frenchTool))
 
         producer.getFlow(mode = Mode.PERSONALIZATION).test {
@@ -154,6 +146,7 @@ class FeaturedToolsFlowProducerTest {
     @Test
     fun `getFlow - Personalization - updates when country changes`() = runTest {
         val usTool = createTool()
+        countryFlow.value = null
         every { toolsRepository.getFeaturedToolsFlow(Locale.ENGLISH, "US") } returns flowOf(listOf(usTool))
 
         producer.getFlow(mode = Mode.PERSONALIZATION).test {


### PR DESCRIPTION
Resolves [GT-3101](https://jira.cru.org/browse/GT-3101)

Per the MVP Content Data Flow decision tree in the [Figma design](https://www.figma.com/design/gdsgXh4cAeBAVrJzH7YoEOU6/GodTools-app-master-file?node-id=14815-135), the Featured Tools section on the personalized dashboard should only be visible when the user has selected a country **and** featured data exists for their language & country combo. Every branch of the tree where no country is selected, or no featured data exists for the combo, ends in "Featured Section Hidden".

## Changes

- `FeaturedToolsFlowProducer` no longer falls back to the language-only featured list (which aggregates featured tools across all countries) when the country-specific list is empty. It now emits an empty list when no country is selected, and only the exact language+country featured list otherwise.
- The section already hides itself when the list is empty via the existing `isNotEmpty()` check in `ToolsLayout`, so no UI changes were needed.
- Tests updated: the fallback test is replaced with two tests pinning the new behavior (no country → empty without querying; country with no data → empty without falling back).

## Note for the sync side (GT-3011)

`ToolsPresenter` still triggers `syncFeaturedTools(locale, country)` when no country is selected, which downloads the language-only featured data into a bucket nothing reads anymore. Left untouched here since sync behavior belongs to GT-3011 — flagging in case it's worth pruning there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)