### PR TITLE
GT-3102 Adjust the personalized tools language filter

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFilters.kt
@@ -37,6 +37,7 @@ import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.dashboard.filters.FilterMenuItem
 import org.cru.godtools.ui.dashboard.filters.LazyFilterMenu
 import org.cru.godtools.ui.dashboard.tools.ToolFiltersStateProducer.Filters
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Mode
 import org.jetbrains.annotations.VisibleForTesting
 
 private val DROPDOWN_MAX_HEIGHT = 700.dp
@@ -44,7 +45,7 @@ private val DROPDOWN_MAX_HEIGHT = 700.dp
 internal const val TEST_TAG_FILTER_DROPDOWN = "filter_dropdown"
 
 @Composable
-internal fun ToolFilters(filters: Filters, modifier: Modifier = Modifier) {
+internal fun ToolFilters(filters: Filters, mode: Mode, modifier: Modifier = Modifier) {
     Column(modifier.fillMaxWidth()) {
         Text(
             stringResource(R.string.dashboard_tools_section_filter_label),
@@ -59,7 +60,7 @@ internal fun ToolFilters(filters: Filters, modifier: Modifier = Modifier) {
             modifier = Modifier.padding(horizontal = 16.dp)
         ) {
             CategoryFilter(filters.categoryFilter, modifier = Modifier.weight(1f))
-            LanguageFilter(filters.languageFilter, modifier = Modifier.weight(1f))
+            LanguageFilter(filters.languageFilter, mode = mode, modifier = Modifier.weight(1f))
         }
     }
 }
@@ -123,30 +124,36 @@ internal fun CategoryFilter(state: FilterMenu.UiState<String?>, modifier: Modifi
 
 @Composable
 @VisibleForTesting
-internal fun LanguageFilter(state: FilterMenu.UiState<Language?>, modifier: Modifier = Modifier) = LazyFilterMenu(
-    state,
-    buttonLabelText = when (val lang = state.selectedItem) {
-        null -> stringResource(R.string.dashboard_tools_section_filter_language_any)
-        else -> lang.getDisplayName(LocalContext.current, LocalAppLanguage.current)
-    },
-    searchPlaceholder = { Text(stringResource(R.string.language_settings_downloadable_languages_search)) },
-    itemKey = { (lang) ->
-        when (lang) {
-            null -> "Any Language"
-            else -> lang.code
-        }
-    },
-    itemLabel = { (lang) ->
-        when (lang) {
-            null -> Text(stringResource(R.string.dashboard_tools_section_filter_language_any))
-            else -> LanguageName(lang)
-        }
-    },
-    itemSupportingText = { (lang, count) ->
-        when (lang) {
-            null -> stringResource(R.string.dashboard_tools_section_filter_available_tools_all)
-            else -> pluralStringResource(R.plurals.dashboard_tools_section_filter_available_tools, count, count)
-        }
-    },
-    modifier = modifier,
-)
+internal fun LanguageFilter(state: FilterMenu.UiState<Language?>, mode: Mode, modifier: Modifier = Modifier) =
+    LazyFilterMenu(
+        state,
+        buttonLabelText = when (val lang = state.selectedItem) {
+            null -> when (mode) {
+                Mode.PERSONALIZATION -> ""
+                Mode.ALL_TOOLS -> stringResource(R.string.dashboard_tools_section_filter_language_any)
+            }
+
+            else -> lang.getDisplayName(LocalContext.current, LocalAppLanguage.current)
+        },
+        searchPlaceholder = { Text(stringResource(R.string.language_settings_downloadable_languages_search)) },
+        itemKey = { (lang) ->
+            when (lang) {
+                null -> "Any Language"
+                else -> lang.code
+            }
+        },
+        itemLabel = { (lang) ->
+            when (lang) {
+                null -> Text(stringResource(R.string.dashboard_tools_section_filter_language_any))
+                else -> LanguageName(lang)
+            }
+        },
+        itemSupportingText = { (lang, count) ->
+            when {
+                mode == Mode.PERSONALIZATION -> null
+                lang == null -> stringResource(R.string.dashboard_tools_section_filter_available_tools_all)
+                else -> pluralStringResource(R.plurals.dashboard_tools_section_filter_available_tools, count, count)
+            }
+        },
+        modifier = modifier,
+    )

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersStateProducer.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersStateProducer.kt
@@ -59,7 +59,17 @@ internal class DefaultToolFiltersStateProducer @Inject constructor(
         val scope = rememberCoroutineScope()
 
         val selectedCategory by remember { settings.getDashboardFilterCategoryFlow() }.collectAsState(null)
-        val selectedLocale by remember { settings.getDashboardFilterLocaleFlow() }.collectAsState(null)
+        val appLanguage by settings.appLanguageFlow.collectAsState()
+        val storedLocale by remember(mode) {
+            when (mode) {
+                Mode.PERSONALIZATION -> settings.getDashboardPersonalizedFilterLocaleFlow()
+                Mode.ALL_TOOLS -> settings.getDashboardFilterLocaleFlow()
+            }
+        }.collectAsState(null)
+        val selectedLocale = when (mode) {
+            Mode.PERSONALIZATION -> storedLocale ?: appLanguage
+            Mode.ALL_TOOLS -> storedLocale
+        }
 
         val languageMenuExpanded = rememberSaveable { mutableStateOf(false) }
         val languageQuery = rememberSaveable { mutableStateOf("") }
@@ -89,7 +99,10 @@ internal class DefaultToolFiltersStateProducer @Inject constructor(
                 eventSink = {
                     when (it) {
                         is FilterMenu.Event.SelectItem -> scope.launch {
-                            settings.updateDashboardFilterLocale(it.item?.code)
+                            when (mode) {
+                                Mode.PERSONALIZATION -> settings.updateDashboardPersonalizedFilterLocale(it.item?.code)
+                                Mode.ALL_TOOLS -> settings.updateDashboardFilterLocale(it.item?.code)
+                            }
                         }
                     }
                 }
@@ -151,7 +164,12 @@ internal class DefaultToolFiltersStateProducer @Inject constructor(
                 .flowOn(ioDispatcher)
                 .combine(toolCountsFlow) { languages, toolCounts ->
                     languages
-                        .let { listOf(null) + it }
+                        .let {
+                            when (mode) {
+                                Mode.PERSONALIZATION -> it
+                                Mode.ALL_TOOLS -> listOf(null) + it
+                            }
+                        }
                         .map { FilterMenu.UiState.Item(it, toolCounts[it?.code] ?: 0) }
                 }
         }.collectAsState(emptyList()).value

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/tools/ToolsLayout.kt
@@ -115,6 +115,7 @@ internal fun ToolsLayout(state: UiState, modifier: Modifier = Modifier) {
 
             ToolFilters(
                 filters = filters,
+                mode = state.mode,
                 modifier = Modifier
                     .animateItem()
                     .padding(vertical = 16.dp)

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/DefaultToolFiltersStateProducerTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/tools/DefaultToolFiltersStateProducerTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.slack.circuit.test.presenterTestOf
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.mockk
@@ -48,6 +49,7 @@ class DefaultToolFiltersStateProducerTest {
     private val gospelLanguagesFlow = MutableStateFlow(emptyList<Language>())
     private val selectedCategory = MutableStateFlow<String?>(null)
     private val selectedLocale = MutableStateFlow<Locale?>(null)
+    private val selectedPersonalizedLocale = MutableStateFlow<Locale?>(null)
 
     private val testScope = TestScope()
 
@@ -66,8 +68,12 @@ class DefaultToolFiltersStateProducerTest {
         every { appLanguageFlow } returns this@DefaultToolFiltersStateProducerTest.appLanguage
         every { getDashboardFilterCategoryFlow() } returns selectedCategory
         every { getDashboardFilterLocaleFlow() } returns selectedLocale
+        every { getDashboardPersonalizedFilterLocaleFlow() } returns selectedPersonalizedLocale
         coEvery { updateDashboardFilterCategory(any()) } answers { selectedCategory.value = firstArg() }
         coEvery { updateDashboardFilterLocale(any()) } answers { selectedLocale.value = firstArg() }
+        coEvery { updateDashboardPersonalizedFilterLocale(any()) } answers {
+            selectedPersonalizedLocale.value = firstArg()
+        }
     }
     private val translationsRepository: TranslationsRepository = mockk {
         every { getTranslationsFlowForTools(any()) } returns flowOf(emptyList())
@@ -155,6 +161,20 @@ class DefaultToolFiltersStateProducerTest {
         }
 
         verifyAll { languagesRepository.getLanguagesFlow() }
+    }
+
+    @Test
+    fun `Filters - languageFilter - items - GT-3102 - Personalized has no Any language option`() = testScope.runTest {
+        presenterTestOf(presentFunction = { producer.produce(Mode.PERSONALIZATION) }) {
+            languagesFlow.value = listOf(Language(Locale.ENGLISH), Language(Locale.FRENCH))
+            assertEquals(
+                listOf<FilterMenu.UiState.Item<Language?>>(
+                    FilterMenu.UiState.Item(Language(Locale.ENGLISH), 0),
+                    FilterMenu.UiState.Item(Language(Locale.FRENCH), 0)
+                ),
+                expectMostRecentItem().languageFilter.items
+            )
+        }
     }
 
     @Test
@@ -268,6 +288,43 @@ class DefaultToolFiltersStateProducerTest {
 
         verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
     }
+
+    @Test
+    fun `Filters - languageFilter - selectedItem - GT-3102 - Personalized defaults to the app language`() =
+        testScope.runTest {
+            val language = Language(Locale.ENGLISH)
+            every { languagesRepository.findLanguageFlow(Locale.ENGLISH) } returns flowOf(language)
+
+            presenterTestOf(presentFunction = { producer.produce(Mode.PERSONALIZATION) }) {
+                assertEquals(language, expectMostRecentItem().languageFilter.selectedItem)
+            }
+
+            verify { languagesRepository.findLanguageFlow(Locale.ENGLISH) }
+        }
+
+    @Test
+    fun `Filters - languageFilter - selectedItem - GT-3102 - Personalized updates the personalized setting`() =
+        testScope.runTest {
+            presenterTestOf(presentFunction = { producer.produce(Mode.PERSONALIZATION) }) {
+                awaitItem().languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
+                expectMostRecentItem()
+            }
+
+            coVerify { settings.updateDashboardPersonalizedFilterLocale(Locale.FRENCH) }
+            coVerify(exactly = 0) { settings.updateDashboardFilterLocale(any()) }
+        }
+
+    @Test
+    fun `Filters - languageFilter - selectedItem - GT-3102 - All Tools doesn't update the personalized setting`() =
+        testScope.runTest {
+            presenterTestOf(presentFunction = { producer.produce(Mode.ALL_TOOLS) }) {
+                awaitItem().languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
+                expectMostRecentItem()
+            }
+
+            coVerify { settings.updateDashboardFilterLocale(Locale.FRENCH) }
+            coVerify(exactly = 0) { settings.updateDashboardPersonalizedFilterLocale(any()) }
+        }
     // endregion Filters.languageFilter.selectedItem
 
     // region Filters.languageFilter.menuExpanded

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52ab4f3b8068dc4cd0149e9ef4b4fe7de164c937ff96a83acad1a769d7570fb3
-size 168034
+oid sha256:a497038f4b71f4e11b242930e993a31a2080fffa0a5055781582229d11b70b57
+size 167426

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,in,NIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,in,NIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95921eb6241d9617e786c6a32bad17926b656fd324ce293f1f682978e2a938e4
-size 88465
+oid sha256:4a2596565fbf6be39ba4e985317c9ae1e8d5b3b041a9781c8d7e19b97f0d8f6f
+size 87769

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,in,NOTNIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,in,NOTNIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11b109fb54a1ae19e88652efb4c91f01dbb46cb8c149e6d9045bee0c7105c1a2
-size 88649
+oid sha256:30d6ec405bbe446cddbce28c3f661e581a3d9d3771b34bfef7ff5eae28402b7f
+size 87933

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a372e1d366312138d81dc0e02bb7399c3653fe6022c1cdd8cb7f0d8a44eab472
-size 86808
+oid sha256:06f1eb100d9e44615ec7e318a1368f1ec1815837dc57df4a8cd3106434eca39e
+size 86163

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8df7941a9b83d54e58437f00cea32ccfb7c1c7069d20f217a6069b846a4772dc
-size 87215
+oid sha256:ce706c02a639ba69966703f5706cc3ac94c6233d283484409962fcafb2cc211e
+size 86600

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45a0081d5b2ed7025a3c289c3be22099581ee57fcc5d8184a2372e8d648e8660
-size 73336
+oid sha256:65c63dc9243572e38b6323fb6ac5e86c22a0d85c6cc4a4e4b93e03b528d2790b
+size 72306

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bace108f18b26b4dba80e5a047091215df488d791eecf3e9d79ad6c836d9291e
-size 160719
+oid sha256:2caff9a30b1f61347f38f1eea0c13b655fd6dac59c1f18925ed6eda62d2e1ad1
+size 159013

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Nexus_5,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8765a440547eba4d5a24f06155f5850a09ee172e70a8262a553100bc4ace887
-size 72000
+oid sha256:357c5c6187d50dfcd085a9446f1cc5436e6c99ae1040901ab85970b4b6b3b31f
+size 71043

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a7bbe4a9791dda7e0d64860195906bd36e666e0cffd1029f0ae67263ce7ef52
-size 53834
+oid sha256:3b7dd9b009e6cdedc3f6352991ae48e6b832a6ccde22360ce7850b6db0d928c1
+size 53090

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_Localization_Settings_Box[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9438172eb74a1bb2d8ddcecdc95c347fd5ea35c6282b4fb27e2a955b0df2e7f
-size 52931
+oid sha256:53c064d180c0020806e01357dcf7bd247cab453fc8e1752e045f5c877e80fd3f
+size 52228

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Nexus_5,locale=null,NOTNIGHT,ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52ab4f3b8068dc4cd0149e9ef4b4fe7de164c937ff96a83acad1a769d7570fb3
-size 168034
+oid sha256:a497038f4b71f4e11b242930e993a31a2080fffa0a5055781582229d11b70b57
+size 167426

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Pixel_6_Pro,locale=null,NIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbe7c9db92f7e870cbd3ac9cafed76f664ddc5c114ba76951ab58603bfb06c0c
-size 85809
+oid sha256:f9a2540384f5500b5992750c3565e04b849d5eec3edf410595edb3317b710617
+size 85092

--- a/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
+++ b/app/src/test/snapshots/images/org.cru.godtools.ui.dashboard_DashboardLayoutPaparazziTest_ToolsLayout()_-_Personalization_-_No_Tools[Pixel_6_Pro,locale=null,NOTNIGHT,NO_ACCESSIBILITY].png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e90b169da3b81254f1882b8d400e5cb0b7b24f9f5e3a00ca3bfdae2f3956d015
-size 85693
+oid sha256:6dfaac9dbf73a8e61e4508729a4642d6e61f91b773c9c9f824950d2808654bf7
+size 85142

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/DashboardLayoutPaparazziTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/DashboardLayoutPaparazziTest.kt
@@ -133,7 +133,10 @@ class DashboardLayoutPaparazziTest(
 
     @Test
     fun `ToolsLayout() - Personalization`() {
-        toolsState = toolsState.copy(mode = ToolsPresenter.UiState.Mode.PERSONALIZATION)
+        toolsState = toolsState.copy(
+            mode = ToolsPresenter.UiState.Mode.PERSONALIZATION,
+            filters = Filters(languageFilter = FilterMenu.UiState(selectedItem = Language(Locale.ENGLISH))),
+        )
         snapshotDashboardLayout(state.copy(initialPage = ToolsScreen))
     }
 
@@ -142,6 +145,7 @@ class DashboardLayoutPaparazziTest(
         assumeTrue(locale == null)
         toolsState = toolsState.copy(
             mode = ToolsPresenter.UiState.Mode.PERSONALIZATION,
+            filters = Filters(languageFilter = FilterMenu.UiState(selectedItem = Language(Locale.ENGLISH))),
             tools = emptyList()
         )
         snapshotDashboardLayout(state.copy(initialPage = ToolsScreen))
@@ -199,6 +203,7 @@ class DashboardLayoutPaparazziTest(
         assumeTrue(locale == null)
         toolsState = toolsState.copy(
             mode = ToolsPresenter.UiState.Mode.PERSONALIZATION,
+            filters = Filters(languageFilter = FilterMenu.UiState(selectedItem = Language(Locale.ENGLISH))),
             spotlightTools = emptyList(),
             tools = emptyList(),
         )

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/tools/ToolFiltersTest.kt
@@ -20,6 +20,7 @@ import org.cru.godtools.model.Tool
 import org.cru.godtools.ui.dashboard.filters.FilterMenu.Event
 import org.cru.godtools.ui.dashboard.filters.FilterMenu.UiState
 import org.cru.godtools.ui.dashboard.filters.FilterMenu.UiState.Item
+import org.cru.godtools.ui.dashboard.tools.ToolsPresenter.UiState.Mode
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -149,7 +150,8 @@ class ToolFiltersTest {
                 UiState(
                     selectedItem = Language(Locale.ENGLISH),
                     eventSink = events,
-                )
+                ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
@@ -165,6 +167,7 @@ class ToolFiltersTest {
                     selectedItem = null,
                     eventSink = events,
                 ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
@@ -182,6 +185,7 @@ class ToolFiltersTest {
                     selectedItem = Language(Locale.ENGLISH),
                     eventSink = events,
                 ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
@@ -204,6 +208,7 @@ class ToolFiltersTest {
                     ),
                     eventSink = events,
                 ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
@@ -227,6 +232,7 @@ class ToolFiltersTest {
                     selectedItem = Language(Locale.FRENCH),
                     eventSink = events,
                 ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
@@ -246,12 +252,51 @@ class ToolFiltersTest {
                         Item(Language(Locale.GERMAN), 1),
                     ),
                     eventSink = events,
-                )
+                ),
+                mode = Mode.ALL_TOOLS,
             )
         }
 
         composeTestRule.onNodeWithText("French", substring = true, ignoreCase = true).performClick()
         events.assertEvents(Event.SelectItem(Language(Locale.FRENCH)))
+    }
+
+    @Test
+    fun `LanguageFilter() - Personalized - GT-3102 - Doesn't show Any Language when no language is specified`() {
+        composeTestRule.setContent {
+            LanguageFilter(
+                UiState(
+                    selectedItem = null,
+                    eventSink = events,
+                ),
+                mode = Mode.PERSONALIZATION,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Any language", substring = true, ignoreCase = true).assertDoesNotExist()
+        events.assertNoEvents()
+    }
+
+    @Test
+    fun `LanguageFilter() - Personalized - GT-3102 - Doesn't show tools available counts`() {
+        composeTestRule.setContent {
+            LanguageFilter(
+                UiState(
+                    menuExpanded = remember { mutableStateOf(true) },
+                    items = persistentListOf(
+                        Item(Language(Locale.FRENCH), 1),
+                        Item(Language(Locale.GERMAN), 2),
+                    ),
+                    eventSink = events,
+                ),
+                mode = Mode.PERSONALIZATION,
+            )
+        }
+
+        composeTestRule.onNodeWithText("French", substring = true, ignoreCase = true).assertExists()
+        composeTestRule.onNodeWithText("Tool available", substring = true, ignoreCase = true).assertDoesNotExist()
+        composeTestRule.onNodeWithText("Tools available", substring = true, ignoreCase = true).assertDoesNotExist()
+        events.assertNoEvents()
     }
     // endregion LanguageFilter
 }

--- a/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
@@ -67,6 +67,8 @@ class Settings internal constructor(private val context: Context, coroutineScope
         // Dashboard Settings
         private val KEY_DASHBOARD_FILTER_CATEGORY = stringPreferencesKey("dashboardFilterCategory")
         private val KEY_DASHBOARD_FILTER_LOCALE = stringPreferencesKey("dashboardFilterLocale")
+        private val KEY_DASHBOARD_PERSONALIZED_FILTER_LOCALE =
+            stringPreferencesKey("dashboardPersonalizedFilterLocale")
 
         // Personalization Settings
         private val KEY_PERSONALIZATION_COUNTRY = stringPreferencesKey("personalizationCountry")
@@ -162,6 +164,21 @@ class Settings internal constructor(private val context: Context, coroutineScope
                 when (locale) {
                     null -> remove(KEY_DASHBOARD_FILTER_LOCALE)
                     else -> set(KEY_DASHBOARD_FILTER_LOCALE, locale.toLanguageTag())
+                }
+            }
+        }
+    }
+
+    fun getDashboardPersonalizedFilterLocaleFlow() = dataStorePreferences.data
+        .map { it[KEY_DASHBOARD_PERSONALIZED_FILTER_LOCALE]?.let { Locale.forLanguageTag(it) } }
+        .distinctUntilChanged()
+
+    suspend fun updateDashboardPersonalizedFilterLocale(locale: Locale?) {
+        dataStorePreferences.updateData {
+            it.toMutablePreferences().apply {
+                when (locale) {
+                    null -> remove(KEY_DASHBOARD_PERSONALIZED_FILTER_LOCALE)
+                    else -> set(KEY_DASHBOARD_PERSONALIZED_FILTER_LOCALE, locale.toLanguageTag())
                 }
             }
         }

--- a/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
@@ -87,6 +87,19 @@ class SettingsTest {
             assertNull(awaitItem())
         }
     }
+
+    @Test
+    fun testDashboardPersonalizedFilterLocale() = runTest {
+        settings.getDashboardPersonalizedFilterLocaleFlow().test {
+            assertNull(awaitItem())
+
+            settings.updateDashboardPersonalizedFilterLocale(Locale.ENGLISH)
+            assertEquals(Locale.ENGLISH, awaitItem())
+
+            settings.updateDashboardPersonalizedFilterLocale(null)
+            assertNull(awaitItem())
+        }
+    }
     // endregion Dashboard Settings
 
     // region produceAppLocaleState()


### PR DESCRIPTION
Resolves [GT-3102](https://jira.cru.org/browse/GT-3102)

Gives the Personalized tools language filter its own persisted setting so the Personalized and All Tools filter selections are independent, per the ticket spec and the [Figma design](https://www.figma.com/design/gdsgXh4cAeBAVrJzH7YoEOU6/GodTools-app-master-file?node-id=14815-135).

## Changes

- New `dashboardPersonalizedFilterLocale` setting. Unset resolves to the app language, which satisfies the first-run default with no migration — while the existing All Tools setting keeps its unset = "Any language" behavior.
- `DefaultToolFiltersStateProducer` is mode-aware: it reads/writes the per-tab setting, resolves the personalized default, and omits the "Any language" item in personalized mode.
- `LanguageFilter` hides the "# Tools available" supporting text in personalized mode, and never renders the "Any language" label there (including the brief state before the stored language loads, matching how Lessons behaves).
- The Personalization Paparazzi scenarios now set a selected language to reflect the realistic filter state — those goldens are re-recorded via the Record Snapshots workflow.

## Intentionally unchanged

- The category filter remains shared between tabs — the ticket only covers the language filter. Asking Jillian whether the category dropdown's counts should also be hidden, since the "unwieldy number" rationale could apply there too.
- The Figma mockup still shows "Any language" on the personalized button; the ticket text explicitly supersedes that.
- The filter's position (between Featured and the ranked list) already matched the design — no layout change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)