### PR TITLE
Generate share links for CYOA tools (GT-3080)

### DIFF
--- a/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
+++ b/ui/cyoa-renderer/src/main/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivity.kt
@@ -6,19 +6,26 @@ import android.os.Bundle
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.POP_BACK_STACK_INCLUSIVE
 import androidx.fragment.app.commit
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.switchMap
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.Locale
 import kotlinx.coroutines.flow.combine
 import org.ccci.gto.android.common.androidx.fragment.app.backStackEntries
 import org.ccci.gto.android.common.androidx.fragment.app.hasPendingActions
+import org.ccci.gto.android.common.androidx.lifecycle.ImmutableLiveData
+import org.ccci.gto.android.common.androidx.lifecycle.combineWith
 import org.ccci.gto.android.common.androidx.lifecycle.toggleValue
 import org.cru.godtools.base.HOST_DYNALINKS
 import org.cru.godtools.base.HOST_GODTOOLSAPP_COM
 import org.cru.godtools.base.SCHEME_GODTOOLS
+import org.cru.godtools.base.URI_SHARE_BASE
 import org.cru.godtools.base.tool.activity.MultiLanguageToolActivity
 import org.cru.godtools.base.tool.model.Event
 import org.cru.godtools.shared.tool.parser.model.Manifest
@@ -48,6 +55,14 @@ class CyoaActivity :
 
         // track this tool open
         if (savedInstanceState == null) dataModel.toolCode.value?.let { trackToolOpen(it, Manifest.Type.CYOA) }
+
+        supportFragmentManager.registerFragmentLifecycleCallbacks(
+            object : FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentStarted(fm: FragmentManager, f: Fragment) = updatePageFragmentLiveData()
+                override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) = updatePageFragmentLiveData()
+            },
+            false
+        )
 
         dataModel.activeManifest.observe(this) { it?.let { showInitialPageIfNecessary(it) } }
     }
@@ -181,6 +196,31 @@ class CyoaActivity :
     // endregion Training Tips
     // endregion UI
 
+    // region Share Link Logic
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    public override val shareLinkUriLiveData by lazy {
+        dataModel.activeManifest.combineWith(activePageLiveData) { manifest, page ->
+            manifest?.buildShareLink(page)?.build()?.toString()
+        }
+    }
+
+    private val activePageLiveData by lazy {
+        pageFragmentLiveData.switchMap { it?.page ?: ImmutableLiveData<Page?>(null) }
+    }
+
+    private fun Manifest.buildShareLink(page: Page?): Uri.Builder? {
+        val tool = code ?: return null
+        val locale = locale ?: return null
+        return URI_SHARE_BASE.buildUpon()
+            .appendEncodedPath(locale.toString().lowercase(Locale.ENGLISH))
+            .appendPath("tool")
+            .appendPath("v2")
+            .appendPath(tool)
+            .apply { page?.let { appendPath(it.id) } }
+            .appendQueryParameter("icid", "gtshare")
+    }
+    // endregion Share Link Logic
+
     // region Page management
     @VisibleForTesting
     internal val pageFragment
@@ -189,6 +229,13 @@ class CyoaActivity :
             primaryNavigationFragment as? CyoaPageFragment<*, *>
         }
     private val activePage get() = pageFragment?.page?.value
+
+    private val pageFragmentLiveData = MutableLiveData<CyoaPageFragment<*, *>?>(null)
+
+    private fun updatePageFragmentLiveData() {
+        val fragment = supportFragmentManager.primaryNavigationFragment as? CyoaPageFragment<*, *>
+        if (pageFragmentLiveData.value !== fragment) pageFragmentLiveData.value = fragment
+    }
 
     private fun showInitialPageIfNecessary(manifest: Manifest) {
         if (pageFragment != null) return

--- a/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
+++ b/ui/cyoa-renderer/src/test/kotlin/org/cru/godtools/tool/cyoa/ui/CyoaActivityTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,6 +45,7 @@ import org.cru.godtools.shared.tool.parser.model.page.backgroundColor
 import org.cru.godtools.shared.tool.parser.model.page.backgroundImageGravity
 import org.cru.godtools.shared.tool.parser.model.page.backgroundImageScaleType
 import org.cru.godtools.tool.cyoa.BuildConfig.HOST_GODTOOLS_CUSTOM_URI
+import org.cru.godtools.tool.cyoa.CyoaDeepLink
 import org.cru.godtools.tool.cyoa.R
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -736,6 +738,71 @@ class CyoaActivityTest {
         }
     }
     // endregion Update Manifest
+
+    // region Share Link Logic
+    @Test
+    fun `Share Link - contains current page`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario {
+            it.onActivity {
+                it.shareLinkUriLiveData.observeForever { }
+
+                assertEquals("https://knowgod.com/en/tool/v2/test/page1?icid=gtshare", it.shareLinkUriLiveData.value)
+            }
+        }
+    }
+
+    @Test
+    fun `Share Link - updates on navigation`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario {
+            it.onActivity {
+                it.shareLinkUriLiveData.observeForever { }
+
+                it.showPage(page2)
+                it.assertPageStack("page1", "page2")
+                assertEquals("https://knowgod.com/en/tool/v2/test/page2?icid=gtshare", it.shareLinkUriLiveData.value)
+
+                it.onBackPressed()
+                it.assertPageStack("page1")
+                assertEquals("https://knowgod.com/en/tool/v2/test/page1?icid=gtshare", it.shareLinkUriLiveData.value)
+            }
+        }
+    }
+
+    @Test
+    fun `Share Link - parseable by CyoaDeepLink`() {
+        manifestEnglish.value = manifest(listOf(page1, page2))
+
+        scenario {
+            it.onActivity {
+                it.shareLinkUriLiveData.observeForever { }
+
+                it.showPage(page2)
+                it.assertPageStack("page1", "page2")
+
+                val uri = Uri.parse(it.shareLinkUriLiveData.value)
+                val deepLink = assertNotNull(CyoaDeepLink.parseKnowGodDeepLink(uri))
+                assertEquals(TOOL, deepLink.tool)
+                assertEquals("page2", deepLink.page)
+                assertEquals(Locale.ENGLISH, deepLink.activeLocale)
+            }
+        }
+    }
+
+    @Test
+    fun `Share Link - no active manifest`() {
+        scenario {
+            it.onActivity {
+                it.shareLinkUriLiveData.observeForever { }
+
+                assertNull(it.shareLinkUriLiveData.value)
+            }
+        }
+    }
+    // endregion Share Link Logic
 
     private val CyoaActivity.dataModel get() = viewModels<MultiLanguageToolActivityDataModel>().value
 


### PR DESCRIPTION
## Summary
CYOA tools currently have no share link at all — `CyoaActivity` inherits the empty `shareLinkUriLiveData` from `BaseToolActivity`, so the share button never appears. This adds outgoing share link generation matching the knowgod.com URL pattern the incoming deep link parser (`CyoaDeepLink`) already supports:

```
https://knowgod.com/{locale}/tool/v2/{tool}/{page}?icid=gtshare
```

## Changes
- Track the currently displayed page fragment in `pageFragmentLiveData`, updated via `FragmentLifecycleCallbacks` (covers forward navigation, back navigation, and page dismissal)
- Override `shareLinkUriLiveData` to combine the active manifest with the current page, so the link updates on both language changes and page navigation
- The share menu item and QR code action appear automatically via the existing `BaseToolActivity` wiring once the link is non-null

The `{position}` path segment supported by `CyoaDeepLink` for card/page-collection pages is intentionally not included — the ticket's example URL omits it, and it can be added as a follow-up if needed.

## Tests
- Share link contains the current page id
- Link updates when navigating forward and back
- Generated links round-trip through `CyoaDeepLink.parseKnowGodDeepLink` (same tool/page/locale)
- No link before a manifest is loaded

🎫 [GT-3080](https://jira.cru.org/browse/GT-3080)

🤖 Generated with [Claude Code](https://claude.com/claude-code)