### PR TITLE
Adjust personalized lessons language filter (GT-3097)

### DIFF
--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonFilters.kt
@@ -15,6 +15,7 @@ import org.cru.godtools.R
 import org.cru.godtools.base.LocalAppLanguage
 import org.cru.godtools.ui.common.LanguageName
 import org.cru.godtools.ui.dashboard.filters.LazyFilterMenu
+import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiState.Mode
 
 @Composable
 @OptIn(ExperimentalLayoutApi::class)
@@ -33,7 +34,12 @@ internal fun LessonFilters(state: LessonsPresenter.UiState, modifier: Modifier =
             itemKey = { (it) -> it.code },
             itemLabel = { LanguageName(it.item) },
             itemSupportingText = { (_, count) ->
-                pluralStringResource(R.plurals.dashboard_lessons_section_filter_available_lessons, count, count)
+                when (state.mode) {
+                    Mode.PERSONALIZATION -> null
+
+                    Mode.ALL_LESSONS ->
+                        pluralStringResource(R.plurals.dashboard_lessons_section_filter_available_lessons, count, count)
+                }
             },
             modifier = Modifier
                 .weight(1f)

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayout.kt
@@ -58,6 +58,9 @@ internal fun LessonsLayout(state: UiState, modifier: Modifier = Modifier) {
             HorizontalDivider(
                 modifier = Modifier.padding(vertical = 12.dp, horizontal = MARGIN_LESSONS_LAYOUT_HORIZONTAL)
             )
+        }
+
+        item("filters", "filters") {
             LessonFilters(state, modifier = Modifier.padding(horizontal = MARGIN_LESSONS_LAYOUT_HORIZONTAL))
         }
 

--- a/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenter.kt
+++ b/app/src/main/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenter.kt
@@ -3,12 +3,12 @@ package org.cru.godtools.ui.dashboard.lessons
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -29,13 +29,17 @@ import java.util.Locale
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ccci.gto.android.common.dagger.coroutines.DispatcherType
 import org.ccci.gto.android.common.dagger.coroutines.DispatcherType.Type.IO
 import org.ccci.gto.android.common.sync.SyncTracker
@@ -105,7 +109,7 @@ class LessonsPresenter @AssistedInject internal constructor(
         }
 
         val appLanguage by settings.appLanguageFlow.collectAsState()
-        val languageFilter = rememberLanguagesFilter()
+        val languageFilter = rememberLanguagesFilter(mode)
 
         RegisterSyncTask(languageFilter.selectedItem?.code ?: appLanguage)
 
@@ -127,23 +131,26 @@ class LessonsPresenter @AssistedInject internal constructor(
 
     @Composable
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun rememberLanguagesFilter(): FilterMenu.UiState<Language> {
-        val appLanguage by settings.appLanguageFlow.collectAsState()
-        var locale by rememberSaveable { mutableStateOf(appLanguage to appLanguage) }
-        LaunchedEffect(appLanguage) { if (locale.first != appLanguage) locale = appLanguage to appLanguage }
+    private fun rememberLanguagesFilter(mode: UiState.Mode): FilterMenu.UiState<Language> {
+        val selectedLocaleFlow = remember(mode) {
+            when (mode) {
+                UiState.Mode.PERSONALIZATION -> settings.getDashboardPersonalizedLessonsFilterLocaleFlow()
+                UiState.Mode.ALL_LESSONS -> settings.getDashboardLessonsFilterLocaleFlow()
+            }.combine(settings.appLanguageFlow) { stored, appLanguage -> stored ?: appLanguage }
+        }
 
+        val scope = rememberCoroutineScope()
         val query = rememberSaveable { mutableStateOf("") }
         val languagesFlow = rememberLanguagesFlow()
 
         return FilterMenu.UiState(
             menuExpanded = rememberSaveable { mutableStateOf(false) },
             query = query,
-            selectedItem = remember {
-                snapshotFlow { locale.second }
-                    .flatMapLatest { locale ->
-                        languagesRepository.findLanguageFlow(locale).map { it ?: Language(locale) }
-                    }
-            }.collectAsState(Language(locale.second)).value,
+            selectedItem = remember(selectedLocaleFlow) {
+                selectedLocaleFlow.flatMapLatest { locale ->
+                    languagesRepository.findLanguageFlow(locale).map { it ?: Language(locale) }
+                }
+            }.collectAsState(Language(settings.appLanguage)).value,
             items = remember {
                 combine(
                     languagesFlow,
@@ -169,7 +176,16 @@ class LessonsPresenter @AssistedInject internal constructor(
             }.collectAsState(persistentListOf()).value,
             eventSink = {
                 when (it) {
-                    is FilterMenu.Event.SelectItem -> locale = appLanguage to it.item.code
+                    is FilterMenu.Event.SelectItem -> scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                        withContext(NonCancellable) {
+                            when (mode) {
+                                UiState.Mode.PERSONALIZATION ->
+                                    settings.updateDashboardPersonalizedLessonsFilterLocale(it.item.code)
+
+                                UiState.Mode.ALL_LESSONS -> settings.updateDashboardLessonsFilterLocale(it.item.code)
+                            }
+                        }
+                    }
                 }
             }
         )

--- a/app/src/test/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenterTest.kt
+++ b/app/src/test/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsPresenterTest.kt
@@ -93,9 +93,18 @@ class LessonsPresenterTest {
         every { findLanguageFlow(any()) } answers { flowOf(Language(firstArg())) }
         every { getLanguagesFlow() } returns languagesFlow
     }
+    private val selectedLessonsLocale = MutableStateFlow<Locale?>(null)
+    private val selectedPersonalizedLessonsLocale = MutableStateFlow<Locale?>(null)
     private val settings: Settings = mockk {
+        every { appLanguage } answers { appLangFlow.value }
         every { appLanguageFlow } returns appLangFlow
         every { getCountrySettingFlow() } returns countryFlow
+        every { getDashboardLessonsFilterLocaleFlow() } returns selectedLessonsLocale
+        every { getDashboardPersonalizedLessonsFilterLocaleFlow() } returns selectedPersonalizedLessonsLocale
+        coEvery { updateDashboardLessonsFilterLocale(any()) } answers { selectedLessonsLocale.value = firstArg() }
+        coEvery { updateDashboardPersonalizedLessonsFilterLocale(any()) } answers {
+            selectedPersonalizedLessonsLocale.value = firstArg()
+        }
     }
     private val syncService: GodToolsSyncService = mockk {
         coEvery { syncToolOrder(any(), any(), any()) } coAnswers { toolOrderSync.receive() }
@@ -215,7 +224,17 @@ class LessonsPresenterTest {
     }
 
     @Test
-    fun `State - languageFilter - selectedItem - reset to app locale when app locale changes`() = testScope.runTest {
+    fun `State - languageFilter - selectedItem - follows app language when no selection made`() = testScope.runTest {
+        presenter.test {
+            assertEquals(Locale.ENGLISH, expectMostRecentItem().languageFilter.selectedItem?.code)
+
+            appLangFlow.value = Locale.GERMAN
+            assertEquals(Locale.GERMAN, expectMostRecentItem().languageFilter.selectedItem?.code)
+        }
+    }
+
+    @Test
+    fun `State - languageFilter - selectedItem - keeps user selection when app language changes`() = testScope.runTest {
         presenter.test {
             assertNotNull(expectMostRecentItem().languageFilter) {
                 assertEquals(Locale.ENGLISH, it.selectedItem?.code)
@@ -224,7 +243,7 @@ class LessonsPresenterTest {
             assertEquals(Locale.FRENCH, expectMostRecentItem().languageFilter.selectedItem?.code)
 
             appLangFlow.value = Locale.GERMAN
-            assertEquals(Locale.GERMAN, expectMostRecentItem().languageFilter.selectedItem?.code)
+            expectNoEvents()
         }
     }
 
@@ -235,11 +254,14 @@ class LessonsPresenterTest {
                 assertEquals(Locale.ENGLISH, it.selectedItem?.code)
                 it.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
             }
+            AndroidUiDispatcherUtil.runScheduledDispatches()
             composeTestRule.waitForIdle()
             assertEquals(Locale.FRENCH, expectMostRecentItem().languageFilter.selectedItem?.code)
 
             stateRestorationTester.emulateSavedInstanceStateRestore()
-            assertEquals(Locale.FRENCH, awaitItem().languageFilter.selectedItem?.code)
+            AndroidUiDispatcherUtil.runScheduledDispatches()
+            composeTestRule.waitForIdle()
+            assertEquals(Locale.FRENCH, expectMostRecentItem().languageFilter.selectedItem?.code)
         }
     }
     // endregion State.languageFilter.selectedItem
@@ -366,6 +388,38 @@ class LessonsPresenterTest {
                 .eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
 
             assertEquals(Locale.FRENCH, expectMostRecentItem().languageFilter.selectedItem?.code)
+        }
+    }
+
+    @Test
+    fun `State - languageFilter - Event - SelectItem - independent selection per mode`() = testScope.runTest {
+        presenter.test {
+            assertNotNull(expectMostRecentItem()) {
+                assertEquals(UiState.Mode.PERSONALIZATION, it.mode)
+                it.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale.FRENCH)))
+            }
+            assertNotNull(expectMostRecentItem()) {
+                assertEquals(Locale.FRENCH, it.languageFilter.selectedItem?.code)
+                it.eventSink(UiEvent.ChangeMode(UiState.Mode.ALL_LESSONS))
+            }
+
+            // All Lessons is unaffected by the personalized selection and still defaults to the app language
+            assertNotNull(expectMostRecentItem()) {
+                assertEquals(Locale.ENGLISH, it.languageFilter.selectedItem?.code)
+                it.languageFilter.eventSink(FilterMenu.Event.SelectItem(Language(Locale("es"))))
+            }
+            assertNotNull(expectMostRecentItem()) {
+                assertEquals(Locale("es"), it.languageFilter.selectedItem?.code)
+                it.eventSink(UiEvent.ChangeMode(UiState.Mode.PERSONALIZATION))
+            }
+
+            // the personalized selection was preserved while on All Lessons
+            assertEquals(Locale.FRENCH, expectMostRecentItem().languageFilter.selectedItem?.code)
+
+            coVerify {
+                settings.updateDashboardPersonalizedLessonsFilterLocale(Locale.FRENCH)
+                settings.updateDashboardLessonsFilterLocale(Locale("es"))
+            }
         }
     }
     // endregion State.languageFilter Event.SelectItem

--- a/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayoutTest.kt
+++ b/app/src/testDebug/kotlin/org/cru/godtools/ui/dashboard/lessons/LessonsLayoutTest.kt
@@ -2,6 +2,8 @@ package org.cru.godtools.ui.dashboard.lessons
 
 import android.app.Application
 import android.content.Context
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -9,9 +11,13 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.slack.circuit.test.TestEventSink
+import java.util.Locale
 import kotlin.test.Test
+import kotlinx.collections.immutable.persistentListOf
 import org.cru.godtools.R
+import org.cru.godtools.model.Language
 import org.cru.godtools.model.randomTranslation
+import org.cru.godtools.ui.dashboard.filters.FilterMenu
 import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiEvent
 import org.cru.godtools.ui.dashboard.lessons.LessonsPresenter.UiState
 import org.cru.godtools.ui.tools.ToolCardPresenter
@@ -64,6 +70,45 @@ class LessonsLayoutTest {
         events.assertEvent(UiEvent.ChangeMode(UiState.Mode.ALL_LESSONS))
     }
     // endregion PersonalizationToggle
+
+    // region LessonFilters
+    @Test
+    fun `LessonFilters - language dropdown - hides lesson counts in Personalized mode`() = runComposeUiTest {
+        setContent {
+            LessonsLayout(
+                UiState(
+                    mode = UiState.Mode.PERSONALIZATION,
+                    languageFilter = FilterMenu.UiState(
+                        menuExpanded = remember { mutableStateOf(true) },
+                        items = persistentListOf(FilterMenu.UiState.Item(Language(Locale.FRENCH), 3)),
+                    ),
+                    eventSink = events,
+                )
+            )
+        }
+
+        onNodeWithText("French", substring = true).assertExists()
+        onNodeWithText("Lessons available", substring = true, ignoreCase = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `LessonFilters - language dropdown - shows lesson counts in All Lessons mode`() = runComposeUiTest {
+        setContent {
+            LessonsLayout(
+                UiState(
+                    mode = UiState.Mode.ALL_LESSONS,
+                    languageFilter = FilterMenu.UiState(
+                        menuExpanded = remember { mutableStateOf(true) },
+                        items = persistentListOf(FilterMenu.UiState.Item(Language(Locale.FRENCH), 3)),
+                    ),
+                    eventSink = events,
+                )
+            )
+        }
+
+        onNodeWithText("3 Lessons available", substring = true, ignoreCase = true).assertExists()
+    }
+    // endregion LessonFilters
 
     // region LessonToolCard
     @Test

--- a/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
+++ b/library/base/src/main/kotlin/org/cru/godtools/base/Settings.kt
@@ -67,6 +67,9 @@ class Settings internal constructor(private val context: Context, coroutineScope
         // Dashboard Settings
         private val KEY_DASHBOARD_FILTER_CATEGORY = stringPreferencesKey("dashboardFilterCategory")
         private val KEY_DASHBOARD_FILTER_LOCALE = stringPreferencesKey("dashboardFilterLocale")
+        private val KEY_DASHBOARD_LESSONS_FILTER_LOCALE = stringPreferencesKey("dashboardLessonsFilterLocale")
+        private val KEY_DASHBOARD_PERSONALIZED_LESSONS_FILTER_LOCALE =
+            stringPreferencesKey("dashboardPersonalizedLessonsFilterLocale")
 
         // Personalization Settings
         private val KEY_PERSONALIZATION_COUNTRY = stringPreferencesKey("personalizationCountry")
@@ -162,6 +165,36 @@ class Settings internal constructor(private val context: Context, coroutineScope
                 when (locale) {
                     null -> remove(KEY_DASHBOARD_FILTER_LOCALE)
                     else -> set(KEY_DASHBOARD_FILTER_LOCALE, locale.toLanguageTag())
+                }
+            }
+        }
+    }
+
+    fun getDashboardLessonsFilterLocaleFlow() = dataStorePreferences.data
+        .map { it[KEY_DASHBOARD_LESSONS_FILTER_LOCALE]?.let { Locale.forLanguageTag(it) } }
+        .distinctUntilChanged()
+
+    suspend fun updateDashboardLessonsFilterLocale(locale: Locale?) {
+        dataStorePreferences.updateData {
+            it.toMutablePreferences().apply {
+                when (locale) {
+                    null -> remove(KEY_DASHBOARD_LESSONS_FILTER_LOCALE)
+                    else -> set(KEY_DASHBOARD_LESSONS_FILTER_LOCALE, locale.toLanguageTag())
+                }
+            }
+        }
+    }
+
+    fun getDashboardPersonalizedLessonsFilterLocaleFlow() = dataStorePreferences.data
+        .map { it[KEY_DASHBOARD_PERSONALIZED_LESSONS_FILTER_LOCALE]?.let { Locale.forLanguageTag(it) } }
+        .distinctUntilChanged()
+
+    suspend fun updateDashboardPersonalizedLessonsFilterLocale(locale: Locale?) {
+        dataStorePreferences.updateData {
+            it.toMutablePreferences().apply {
+                when (locale) {
+                    null -> remove(KEY_DASHBOARD_PERSONALIZED_LESSONS_FILTER_LOCALE)
+                    else -> set(KEY_DASHBOARD_PERSONALIZED_LESSONS_FILTER_LOCALE, locale.toLanguageTag())
                 }
             }
         }

--- a/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
+++ b/library/base/src/test/kotlin/org/cru/godtools/base/SettingsTest.kt
@@ -87,6 +87,32 @@ class SettingsTest {
             assertNull(awaitItem())
         }
     }
+
+    @Test
+    fun testDashboardLessonsFilterLocale() = runTest {
+        settings.getDashboardLessonsFilterLocaleFlow().test {
+            assertNull(awaitItem())
+
+            settings.updateDashboardLessonsFilterLocale(Locale.FRENCH)
+            assertEquals(Locale.FRENCH, awaitItem())
+
+            settings.updateDashboardLessonsFilterLocale(null)
+            assertNull(awaitItem())
+        }
+    }
+
+    @Test
+    fun testDashboardPersonalizedLessonsFilterLocale() = runTest {
+        settings.getDashboardPersonalizedLessonsFilterLocaleFlow().test {
+            assertNull(awaitItem())
+
+            settings.updateDashboardPersonalizedLessonsFilterLocale(Locale.FRENCH)
+            assertEquals(Locale.FRENCH, awaitItem())
+
+            settings.updateDashboardPersonalizedLessonsFilterLocale(null)
+            assertNull(awaitItem())
+        }
+    }
     // endregion Dashboard Settings
 
     // region produceAppLocaleState()


### PR DESCRIPTION
## Summary
The Lessons page currently has a single language filter shared by both the Personalized and All Lessons tabs, held only in memory (reset on app restart, and reset whenever the app language changes). This makes the two filters independent and persistent per GT-3097:

- **Independent per tab** — the selection on Personalized and All Lessons no longer affect each other
- **Persisted** — each tab's selection is stored in DataStore (`dashboardLessonsFilterLocale` / `dashboardPersonalizedLessonsFilterLocale`) and survives app restarts. Until the user makes a selection, each tab defaults to the app language
- **Hidden counts** — the "# Lessons available" phrase is hidden in the language dropdown on Personalized (still shown on All Lessons). Counts are still used internally to hide languages with no lessons
- **Layout prep for GT-3096** — `LessonFilters` moved out of the header item into its own LazyColumn item, so the Featured Lessons section can be inserted between the header and the filter without restructuring

## Behavior change to note
Previously, changing the app language reset the filter to the new app language. Now an explicit user selection persists through app-language changes (matching the ticket's persistence requirement and the GT-3102 behavior for tools). A tab with no explicit selection still follows the app language.

## Known minor
On a tab switch, the filter briefly shows the app language until DataStore delivers the stored selection — same class of transient accepted in GT-3102 (#4587).

## Coordination
The `Settings.kt`/`SettingsTest.kt` additions sit adjacent to GT-3102's (#4587); whichever PR merges second will have a trivial keep-both conflict.

## Tests
- `SettingsTest`: save/read/clear round-trips for both new keys
- `LessonsPresenterTest`: independent selection per mode (with per-key write verification), follows app language when unset, keeps user selection on app-language change, persistence through state save & restore
- `LessonsLayoutTest`: counts hidden in Personalized dropdown, shown in All Lessons
- `verifyPaparazzi` passes — the layout split is pixel-identical, no golden changes

🎫 [GT-3097](https://jira.cru.org/browse/GT-3097)

🤖 Generated with [Claude Code](https://claude.com/claude-code)